### PR TITLE
install architecture-independent data files in FHS-specified location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ setup(name='lbrynet',
       install_requires=requires,
       entry_points={'console_scripts': console_scripts},
       data_files=[
-          ('lbrynet/lbrynet_console/plugins',
+          ('share/lbrynet/lbrynet_console/plugins',
            [
                os.path.join(base_dir, 'lbrynet', 'lbrynet_console', 'plugins',
                             'blindrepeater.yapsy-plugin')
            ]
            ),
-          ('lbrynet/lbrynet_gui', gui_data_paths)
+          ('share/lbrynet/lbrynet_gui', gui_data_paths)
       ],
       dependency_links=['https://github.com/lbryio/lbryum/tarball/master/#egg=lbryum'],
       )


### PR DESCRIPTION
The [Filesystem Hierarchy Standard says](http://www.pathname.com/fhs/pub/fhs-2.3.html#USRSHAREARCHITECTUREINDEPENDENTDATA) read-only, architecture-independent data files should go beneath `/usr/share` if installed globally (e.g., by a package manager) or beneath `/usr/local/share` if installed locally (e.g., manually by an administrator). Python's `sys.prefix` defaults to `/usr/local` but is typically overridden to `/usr` when Python is packaged by distros. Thus, the relative installation paths for LBRYnet's read-only, architecture-independent data files should start with `share/`. This has the effect of installing them to the more uniform `/usr/share/lbrynet` rather than to `/usr/lbrynet`.