### PR TITLE
fix lagging indicator and improve diagnostics

### DIFF
--- a/lbrynet/__init__.py
+++ b/lbrynet/__init__.py
@@ -4,5 +4,5 @@ import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
-version = (0, 2, 1)
+version = (0, 2, 2)
 __version__ = ".".join([str(x) for x in version])

--- a/lbrynet/core/LBRYcrdWallet.py
+++ b/lbrynet/core/LBRYcrdWallet.py
@@ -904,6 +904,7 @@ class LBRYumWallet(LBRYWallet):
         self._start_check = None
         self._catch_up_check = None
         self._caught_up_counter = 0
+        self._lag_counter = 0
         self.blocks_behind_alert = 0
         self.catchup_progress = 0
         self.max_behind = 0
@@ -997,8 +998,18 @@ class LBRYumWallet(LBRYWallet):
                 self._catch_up_check.stop()
                 self._catch_up_check = None
                 blockchain_caught_d.callback(True)
+
             elif remote_height != 0:
+                past_blocks_behind = self.blocks_behind_alert
                 self.blocks_behind_alert = remote_height - local_height
+                if self.blocks_behind_alert < past_blocks_behind:
+                    self._lag_counter = 0
+                    self.is_lagging = False
+                else:
+                    self._lag_counter += 1
+                    if self._lag_counter >= 900:
+                        self.is_lagging = True
+
                 if self.blocks_behind_alert > self.max_behind:
                     self.max_behind = self.blocks_behind_alert
                 self.catchup_progress = int(100 * (self.blocks_behind_alert / (5 + self.max_behind)))
@@ -1006,9 +1017,6 @@ class LBRYumWallet(LBRYWallet):
                     alert.info('Catching up to the blockchain...showing blocks left...')
                 if self._caught_up_counter % 30 == 0:
                     alert.info('%d...', (remote_height - local_height))
-                    alert.info("Catching up: " + str(self.catchup_progress) + "%")
-                if self._caught_up_counter >= 600:
-                    self.is_lagging = True
 
                 self._caught_up_counter += 1
 

--- a/lbrynet/lbrynet_daemon/LBRYDaemonControl.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemonControl.py
@@ -74,9 +74,13 @@ def start():
     parser.add_argument('--no-launch', dest='launchui', action="store_false")
     parser.set_defaults(launchui=True)
 
+    args = parser.parse_args()
+
     try:
         JSONRPCProxy.from_url(API_CONNECTION_STRING).is_running()
         log.info("lbrynet-daemon is already running")
+        if args.launchui:
+            webbrowser.open(UI_ADDRESS)
         return
     except:
         pass
@@ -87,8 +91,6 @@ def start():
     print "Web UI is available at http://%s:%i" %(API_INTERFACE, API_PORT)
     print "JSONRPC API is available at " + API_CONNECTION_STRING
     print "To quit press ctrl-c or call 'stop' via the API"
-
-    args = parser.parse_args()
 
     if args.branch == "HEAD":
         GIT_CMD_STRING = "git ls-remote https://github.com/lbryio/lbry-web-ui.git | grep %s | cut -f 1" % args.branch

--- a/packaging/ubuntu/lbry
+++ b/packaging/ubuntu/lbry
@@ -17,7 +17,7 @@ urlencode() {
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ -z "$(pgrep lbrynet-daemon)" ]; then
   echo "running lbrynet-daemon..."
-  $DIR/lbrynet-daemon --branch=settings-page &
+  $DIR/lbrynet-daemon &
   sleep 3 # let the daemon load before connecting
 fi
 

--- a/packaging/ubuntu/lbry.desktop
+++ b/packaging/ubuntu/lbry.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.2.1
+Version=0.2.2
 Name=LBRY
 # Only KDE 4 seems to use GenericName, so we reuse the KDE strings.
 # From Ubuntu's language-pack-kde-XX-base packages, version 9.04-20090413.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ console_scripts = ['lbrynet-console = lbrynet.lbrynet_console.LBRYConsole:launch
 
 requires = ['pycrypto', 'twisted', 'miniupnpc', 'yapsy', 'seccure',
             'python-bitcoinrpc==0.1', 'txJSON-RPC', 'requests>=2.4.2', 'unqlite==0.2.0',
-            'leveldb', 'lbryum>=2.6.0.1', 'jsonrpc', 'simplejson', 'appdirs', 'six==1.9.0', 'base58']
+            'leveldb', 'lbryum', 'jsonrpc', 'simplejson', 'appdirs', 'six==1.9.0', 'base58']
 
 gui_data_files = ['close2.gif', 'lbry-dark-242x80.gif', 'lbry-dark-icon.xbm', 'lbry-dark-icon.ico',
                   'drop_down.gif', 'show_options.gif', 'hide_options.gif', 'lbry.conf', 'lbry.png']


### PR DESCRIPTION
-make is_lagging more meaningful - it is set to true after 90 seconds
with no progress, this is to stop slow but steady catchups from
triggering it

-prevent situation where repeated shutdowns before wallet catchup
results in never receiving first run credits

-fix settings to write new defaults that aren’t already in the
configuration file

-report log of startup sequence if upload_log set to true

-redirect /view?name=lbry to the main UI page. This is to make the ui
accessible from a lbry:// link on linux