### PR TITLE
more stream and file fixes

### DIFF
--- a/lbrynet/__init__.py
+++ b/lbrynet/__init__.py
@@ -4,5 +4,5 @@ import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
-version = (0, 2, 3)
+version = (0, 2, 4)
 __version__ = ".".join([str(x) for x in version])

--- a/lbrynet/core/LBRYcrdWallet.py
+++ b/lbrynet/core/LBRYcrdWallet.py
@@ -530,8 +530,10 @@ class LBRYWallet(object):
                                 "    sd_hash text)")
 
     def _save_name_metadata(self, name, sd_hash, txid):
-        d = self.db.runQuery("insert into name_metadata values (?, ?, ?)",
-                             (name, txid, sd_hash))
+        d = self.db.runQuery("select * from name_metadata where txid=?", (txid,))
+        d.addCallback(lambda r: self.db.runQuery("insert into name_metadata values (?, ?, ?)", (name, txid, sd_hash))
+                                if not len(r) else None)
+
         return d
 
     def _get_claim_metadata_for_sd_hash(self, sd_hash):

--- a/lbrynet/lbryfilemanager/LBRYFileDownloader.py
+++ b/lbrynet/lbryfilemanager/LBRYFileDownloader.py
@@ -111,11 +111,21 @@ class ManagedLBRYFileDownloader(LBRYFileSaver):
         d.addCallback(lambda _: self.stream_info_manager._get_sd_blob_hashes_for_stream(self.stream_hash))
 
         def _save_sd_hash(sd_hash):
-            self.sd_hash = sd_hash[0]
+            if len(sd_hash):
+                self.sd_hash = sd_hash[0]
+                d = self.wallet._get_claim_metadata_for_sd_hash(self.sd_hash)
+            else:
+                d = defer.succeed(None)
+
+            return d
+
+        def _save_claim(name, txid):
+            self.uri = name
+            self.txid = txid
             return defer.succeed(None)
 
         d.addCallback(_save_sd_hash)
-
+        d.addCallback(lambda r: _save_claim(r[0], r[1]) if r else None)
         d.addCallback(lambda _: self._save_status())
 
         return d

--- a/lbrynet/lbryfilemanager/LBRYFileDownloader.py
+++ b/lbrynet/lbryfilemanager/LBRYFileDownloader.py
@@ -25,6 +25,8 @@ class ManagedLBRYFileDownloader(LBRYFileSaver):
                                stream_info_manager, payment_rate_manager, wallet, download_directory,
                                upload_allowed, file_name)
         self.sd_hash = None
+        self.txid = None
+        self.uri = None
         self.rowid = rowid
         self.lbry_file_manager = lbry_file_manager
         self.saving_status = False
@@ -35,10 +37,19 @@ class ManagedLBRYFileDownloader(LBRYFileSaver):
         def _save_sd_hash(sd_hash):
             if len(sd_hash):
                 self.sd_hash = sd_hash[0]
+                d = self.wallet._get_claim_metadata_for_sd_hash(self.sd_hash)
+            else:
+                d = defer.succeed(None)
+
+            return d
+
+        def _save_claim(name, txid):
+            self.uri = name
+            self.txid = txid
             return defer.succeed(None)
 
         d.addCallback(_save_sd_hash)
-
+        d.addCallback(lambda r: _save_claim(r[0], r[1]) if r else None)
         d.addCallback(lambda _: self.lbry_file_manager.get_lbry_file_status(self))
 
         def restore_status(status):

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -1119,9 +1119,22 @@ class LBRYDaemon(jsonrpc.JSONRPC):
 
                 return d
 
+            def _add_metadata(message):
+                def _add_to_dict(metadata):
+                    message['metadata'] = metadata
+                    return defer.succeed(message)
+
+                if f.txid:
+                    d = self._resolve_name(f.uri)
+                    d.addCallback(_add_to_dict)
+                else:
+                    d = defer.succeed(None)
+                return d
+
             if f:
                 d = f.get_total_bytes()
                 d.addCallback(_generate_reply)
+                d.addCallback(_add_metadata)
                 return d
             else:
                 return False

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -1101,6 +1101,7 @@ class LBRYDaemon(jsonrpc.JSONRPC):
                                                    'stream_name': f.stream_name,
                                                    'suggested_file_name': f.suggested_file_name,
                                                    'upload_allowed': f.upload_allowed, 'sd_hash': f.sd_hash,
+                                                   'lbry_uri': f.uri, 'txid': f.txid,
                                                    'total_bytes': size,
                                                    'written_bytes': written_bytes, 'code': status[0],
                                                    'message': message})
@@ -1109,7 +1110,8 @@ class LBRYDaemon(jsonrpc.JSONRPC):
                                        'points_paid': f.points_paid, 'stopped': f.stopped, 'stream_hash': f.stream_hash,
                                        'stream_name': f.stream_name, 'suggested_file_name': f.suggested_file_name,
                                        'upload_allowed': f.upload_allowed, 'sd_hash': f.sd_hash, 'total_bytes': size,
-                                       'written_bytes': written_bytes, 'code': status[0], 'message': status[1]})
+                                       'written_bytes': written_bytes, 'lbry_uri': f.uri, 'txid': f.txid,
+                                       'code': status[0], 'message': status[1]})
 
                 return d
 

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -1137,7 +1137,7 @@ class LBRYDaemon(jsonrpc.JSONRPC):
                     d = self._resolve_name(f.uri)
                     d.addCallback(_add_to_dict)
                 else:
-                    d = defer.succeed(None)
+                    d = defer.succeed(message)
                 return d
 
             if f:

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -913,7 +913,10 @@ class LBRYDaemon(jsonrpc.JSONRPC):
 
             d = self._get_lbry_file_by_sd_hash(stream_hash)
             def _add_results(l):
-                return defer.succeed((stream_info, l))
+                if l:
+                    if os.path.isfile(os.path.join(self.download_directory, l.file_name)):
+                        return defer.succeed((stream_info, l))
+                return defer.succeed((stream_info, None))
             d.addCallback(_add_results)
             return d
 

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -593,6 +593,7 @@ class LBRYDaemon(jsonrpc.JSONRPC):
 
         d = self._upload_log(name_prefix="close", exclude_previous=False if self.first_run else True)
         d.addCallback(lambda _: self._stop_server())
+        d.addCallback(lambda _: self.lbry_file_manager.stop())
         d.addErrback(lambda err: log.info("Bad server shutdown: " + err.getTraceback()))
         if self.session is not None:
             d.addCallback(lambda _: self.session.shut_down())

--- a/lbrynet/lbrynet_daemon/LBRYDaemonControl.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemonControl.py
@@ -104,7 +104,7 @@ def start():
     if test_internet_connection():
         lbry = LBRYDaemonServer()
 
-        d = lbry.start(branch=args.branch, user_specified=args.ui)
+        d = lbry.start(branch=args.branch, user_specified=args.ui, wallet=args.wallet)
         if args.launchui:
             d.addCallback(lambda _: webbrowser.open(UI_ADDRESS))
 


### PR DESCRIPTION
-include lbry uri, claim txid, and claim value in lbry_file

-lbryum 2.6.0.4 returns what’s needed to write claim data to sqlite, fix lbrynet to make sure it doesnt store duplicates

-add waiting_for_credits to loading screen to force user to not try to download something before credits show up, a common source of timeout errors

-fix --wallet=lbrycrd , lbrycrdd should be run separately. added set_miner and get_miner_status commands