### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
     include:
         - os: linux
           sudo: required
-          dist: trust
+          dist: trusty
           # dh-virtualenv requires that we use the same python interpreter
           # that comes with the system, so we don't want to use anything that
           # travis would try to set-up for us in python

--- a/packaging/ubuntu/ubuntu_package_setup.sh
+++ b/packaging/ubuntu/ubuntu_package_setup.sh
@@ -107,7 +107,7 @@ $SUDO pip install make-deb
 #
 # dpkg-buildpackage outputs its results into '..' so
 # we need to move/clone lbry into the build directory
-if [ "$CLONE" == true]; then
+if [ "$CLONE" == true ]; then
     cp -a $SOURCE_DIR lbry
 else
     git clone https://github.com/lbryio/lbry.git
@@ -165,6 +165,10 @@ ar r "$PACKAGE" debian-binary control.tar.gz data.tar.xz
 
 # TODO: we can append to data.tar instead of extracting it all and recompressing
 
-if [[ -n "${TRAVIS_BUILD_DIR}" ]]; then
+if [[ ! -z "${TRAVIS_BUILD_DIR+x}" ]]; then
+    # move it to a consistent place so that later it can be uploaded
+    # to the github releases page
     mv "${PACKAGE}" "${TRAVIS_BUILD_DIR}/${PACKAGE}"
+    # want to be able to check the size of the result in the log
+    ls -l "${TRAVIS_BUILD_DIR}/${PACKAGE}"
 fi


### PR DESCRIPTION
The build on travis was the wrong size because it wasn't being built on 14.04!  I had a typo when specifying the distribution to use and so travis was falling back to 12.04

The file size looks more reasonable now:

```ls -l /home/travis/build/lbryio/lbry/lbrynet_0.2.5_amd64.deb
-rw-r--r-- 1 travis travis 10490736 Jun 10 06:43 /home/travis/build/lbryio/lbry/lbrynet_0.2.5_amd64.deb```