### PR TITLE
Use a more up-to-date OSX version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,11 @@ matrix:
           # python 2.7 is broken on osx on travis, so follow we have to specify the installation ourselves
           # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855
           language: generic
+          osx_image: xcode7.3
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install python; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo pip install --upgrade pip virtualenv; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv $HOME/venv && source $HOME/venv/bin/activate; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated gmp || brew upgrade gmp; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated openssl || brew upgrade openssl; fi
-  # the default py2app (v0.9) has a bug that is fixed in the head of /metachris/py2app
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install git+https://github.com/metachris/py2app; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install jsonrpc; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install -r requirements.txt; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade && brew install python --framework; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gmp; fi
   
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./packaging/travis/install_dependencies_and_run_tests.sh; fi

--- a/packaging/osx/certs/.gitignore
+++ b/packaging/osx/certs/.gitignore
@@ -1,0 +1,2 @@
+dist.cer
+dist.p12

--- a/packaging/osx/lbry-osx-app/setup_app.py
+++ b/packaging/osx/lbry-osx-app/setup_app.py
@@ -10,7 +10,6 @@ DATA_FILES = []
 DATA_FILES.append('app.icns')
 
 OPTIONS = {
-    # 'argv_emulation': True,
     'iconfile': ICON_PATH,
     'plist': {
         'CFBundleIdentifier': 'io.lbry.LBRY',

--- a/packaging/osx/lbry-osx-app/setup_app.sh
+++ b/packaging/osx/lbry-osx-app/setup_app.sh
@@ -8,6 +8,10 @@ tmp="${DEST}/build"
 
 rm -rf build dist LBRY.app
 
+# the default py2app (v0.9) has a bug that is fixed in the head of /metachris/py2app
+pip install git+https://github.com/metachris/py2app
+pip install jsonrpc
+
 mkdir -p $tmp
 cd $tmp
 
@@ -24,6 +28,7 @@ else
 fi
 NAME=`python setup.py --name`
 VERSION=`python setup.py -V`
+pip install -r requirements.txt
 python setup.py install
 
 echo "Building URI Handler"


### PR DESCRIPTION
By default, Travis uses an old xcode and osx 10.9.

Also related:
 - install framework version of python
 - ensure unencrypted keys are never accidently added to repo