### PR TITLE
Fix OSX build issue with openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ matrix:
           osx_image: xcode7.3
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade && brew install python --framework; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gmp; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./packaging/travis/setup_osx.sh; fi
   
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./packaging/travis/install_dependencies_and_run_tests.sh; fi

--- a/packaging/osx/lbry-osx-app/setup_app.sh
+++ b/packaging/osx/lbry-osx-app/setup_app.sh
@@ -29,6 +29,8 @@ fi
 NAME=`python setup.py --name`
 VERSION=`python setup.py -V`
 pip install -r requirements.txt
+# not totally sure if pyOpenSSl is needed (JIE)
+pip install pyOpenSSL
 python setup.py install
 
 echo "Building URI Handler"

--- a/packaging/travis/setup_osx.sh
+++ b/packaging/travis/setup_osx.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo pipefail
+set -o xtrace
+
+wget https://www.python.org/ftp/python/2.7.11/python-2.7.11-macosx10.6.pkg
+sudo installer -pkg python-2.7.11-macosx10.6.pkg -target /
+pip install -U pip
+brew install gmp
+


### PR DESCRIPTION
Use python from python.org.

- py2app won't  included the system default in the app bundle
- brew's version of python links against brew's version of openssl - which doesn't get included in the bundle so it fails on a machine that doesn't have that version of openssl