### PR TITLE
Use patched version of make-deb

### DIFF
--- a/packaging/ubuntu/ubuntu_package_setup.sh
+++ b/packaging/ubuntu/ubuntu_package_setup.sh
@@ -101,7 +101,7 @@ $SUDO apt-get ${QUIET} install -y --no-install-recommends \
 
 # need a modern version of pip (more modern than ubuntu default)
 $SUDO pip install --upgrade pip
-$SUDO pip install make-deb
+$SUDO pip install git+https://github.com/jobevers/make-deb
 
 # build packages
 #


### PR DESCRIPTION
Ran into a bug in make-deb that fails when there is utf-8 characters
in the git commit message. https://github.com/nylas/make-deb/issues/13.

I wrote a patch to fix the bug and am installing that version until the
make-deb maintainers incorporate it