### PR TITLE
Refactor jsonrpc get

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -298,7 +298,7 @@ ignored-classes=twisted.internet,RequestMessage
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=lbrynet.lbrynet_daemon.LBRYDaemon.Parameters
 
 
 [IMPORTS]

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -1686,6 +1686,7 @@ class LBRYDaemon(jsonrpc.JSONRPC):
             'file_name': optional, a user specified name for the downloaded file
             'stream_info': optional, specified stream info overrides name
             'timout': optional
+            'wait_for_write': optional, defaults to True
         Returns:
             'stream_hash': hex string
             'path': path of download

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -2249,7 +2249,7 @@ class LBRYDaemon(jsonrpc.JSONRPC):
             d = threads.deferToThread(subprocess.Popen, ['open', '-R', path])
         else:
             # No easy way to reveal specific files on Linux, so just open the containing directory
-            d = threads.deferToThread(subprocess.Popen, ['xdg-open', os.dirname(path)])
+            d = threads.deferToThread(subprocess.Popen, ['xdg-open', os.path.dirname(path)])
 
 
         d.addCallback(lambda _: self._render_response(True, OK_CODE))


### PR DESCRIPTION
Fixes two bugs:
 - `os.dirname` should be `os.path.dirname`
 - the `download_directory` parameter was being ignored in the output

Refactorings:
Move parameter handling into its own function and
better use of the `.get()` function for dictionaries.

Early return on the failed checks is more readable.

The lambda function in the callback was long and
hard to read so moved it out.