### PR TITLE
script to migrate private keys to lbrycrd

### DIFF
--- a/scripts/migrate_lbryum_to_lbrycrd.py
+++ b/scripts/migrate_lbryum_to_lbrycrd.py
@@ -1,5 +1,6 @@
 import argparse
 import hashlib
+import json
 import subprocess
 import sys
 
@@ -21,10 +22,22 @@ def main():
     for addr in addresses[:-1]:
         printBalance(wallet, addr)
         saveAddr(wallet, addr)
+        validateAddress(addr)
     # on the last one, rescan.  Don't rescan early for sake of efficiency
     addr = addresses[-1]
     printBalance(wallet, addr)
     saveAddr(wallet, addr, "true")
+    validateAddress(addr)
+
+
+def validateAddress(addr):
+    raw_output = subprocess.check_output(
+        ['lbrycrd-cli', 'validateaddress', addr])
+    output = json.loads(raw_output)
+    if not output['isvalid']:
+        raise Exception('Address {} is not valid'.format(addr))
+    if not output['ismine']:
+        raise Exception('Address {} is not yours'.format(addr))
 
 
 def printBalance(wallet, addr):

--- a/scripts/migrate_lbryum_to_lbrycrd.py
+++ b/scripts/migrate_lbryum_to_lbrycrd.py
@@ -71,8 +71,8 @@ def getWallet(path=None):
         path = config.get_wallet_path()
     storage = WalletStorage(path)
     if not storage.file_exists:
-        print "No wallet to migrate"
-        return
+        print "Failed to run: No wallet to migrate"
+        exit(1)
     return Wallet(storage)
 
 

--- a/scripts/migrate_lbryum_to_lbrycrd.py
+++ b/scripts/migrate_lbryum_to_lbrycrd.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument('--wallet', help='path to lbryum wallet')
     args = parser.parse_args()
 
+    ensureCliIsOnPathAndServerIsRunning()
+
     wallet = getWallet(args.wallet)
     addresses = wallet.addresses(True)
     for addr in addresses[:-1]:
@@ -28,6 +30,20 @@ def main():
     printBalance(wallet, addr)
     saveAddr(wallet, addr, "true")
     validateAddress(addr)
+
+
+def ensureCliIsOnPathAndServerIsRunning():
+    try:
+        output = subprocess.check_output(['lbrycrd-cli', 'getinfo'])
+    except OSError:
+        print 'Failed to run: lbrycrd-cli needs to be on the PATH'
+        exit(1)
+    except subprocess.CalledProcessError:
+        print 'Failed to run: could not connect to the lbrycrd server.'
+        print 'Make sure it is running and able to be connected to.'
+        print 'One way to do this is to run:'
+        print '      lbrycrdd -server -printtoconsole'
+        exit(1)
 
 
 def validateAddress(addr):

--- a/scripts/migrate_lbryum_to_lbrycrd.py
+++ b/scripts/migrate_lbryum_to_lbrycrd.py
@@ -1,0 +1,73 @@
+import argparse
+import hashlib
+import subprocess
+import sys
+
+import base58
+
+from lbryum import SimpleConfig, Network
+from lbryum.wallet import WalletStorage, Wallet
+from lbryum.commands import known_commands, Commands
+from lbryum import lbrycrd
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--wallet', help='path to lbryum wallet')
+    args = parser.parse_args()
+
+    wallet = getWallet(args.wallet)
+    addresses = wallet.addresses(True)
+    for addr in addresses[:-1]:
+        balance = getBalance(wallet, addr)
+        print 'Importing private key for %s with balance %s' % (addr, balance)
+        saveAddr(wallet, addr)
+    # on the last one, rescan.  Don't rescan early for sake of efficiency
+    saveAddr(wallet, addresses[-1], "true")
+
+
+def getBalance(wallet, addr):
+    return sum(wallet.get_addr_balance(addr))
+
+def getWallet(path=None):
+    if not path:
+        config = SimpleConfig()
+        path = config.get_wallet_path()
+    storage = WalletStorage(path)
+    if not storage.file_exists:
+        print "No wallet to migrate"
+        return
+    return Wallet(storage)
+
+    
+def saveAddr(wallet, addr, rescan="false"):
+    keys = wallet.get_private_key(addr, None)
+    
+    for key in keys:
+        # copied from lbrycrd.regenerate_key
+        b = lbrycrd.ASecretToSecret(key)
+        pkey = b[0:32]
+        wif = pkeyToWif(pkey)
+        print subprocess.check_output(
+            ['lbrycrd-cli', 'importprivkey', wif, "lbryum import", rescan])
+    print subprocess.check_output(['lbrycrd-cli', 'importaddress', addr])
+
+
+def pkeyToWif(pkey):
+    # Follow https://en.bitcoin.it/wiki/Wallet_import_format
+    # to convert from a private key to the wallet import format
+    prefix = '\x1c'
+    wif = prefix + pkey
+    intermediate_checksum = hashlib.sha256(wif).digest()
+    checksum = hashlib.sha256(intermediate_checksum).digest()
+    wif = wif + checksum[:4]
+    return base58.b58encode(wif)
+
+
+def wifToPkey(wif):
+    pkey = base58.b58decode(wif)
+    return pkey[1:-4]
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Exports the private keys out of the lbryum wallet, reformats them and imports them into lbrycrd.

Requires the lbrycrdd is already running and that lbrycrd-cli is on the path.