### PR TITLE
Update protobuf library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ https://github.com/lbryio/lbryum/tarball/master/#egg=lbryum
 leveldb==0.193
 miniupnpc==1.9
 pbkdf2==1.3
-protobuf==3.0.0b2
+protobuf==3.0.0b3
 pycrypto==2.6.1
 python-bitcoinrpc==0.1
 qrcode==5.2.2


### PR DESCRIPTION
Updating to protobuf-v3.0.0b3 because it
fixes a bug here https://github.com/google/protobuf/blob/e841bac4fcf47f809e089a70d5f84ac37b3883df/python/google/protobuf/internal/python_message.py#L59
where six.moves is not always available.
In particular, the system python on OSX has an old version of six
which is without six.moves.