### PR TITLE
Cache pyobjc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/Library/Caches/pip
+    - $TRAVIS_BUILD_DIR/cache/wheel
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./packaging/travis/setup_osx.sh; fi

--- a/packaging/osx/lbry-osx-app/setup_app.sh
+++ b/packaging/osx/lbry-osx-app/setup_app.sh
@@ -53,8 +53,16 @@ MODULES="pyobjc-core pyobjc-framework-Cocoa pyobjc-framework-CFNetwork"
 if [ ${ON_TRAVIS} = true ]; then
     WHEEL_DIR="${TRAVIS_BUILD_DIR}/cache/wheel"
     mkdir -p "${WHEEL_DIR}"
-    pip wheel -w "${WHEEL_DIR}" ${MODULES}
-    pip install "${WHEEL_DIR}"/*
+    # mapping from the package name to the
+    # actual built wheel file is surprisingly
+    # hard so instead of checking for the existance
+    # of each wheel, we mark with a file when they've all been
+    # built and skip when that file exists
+    if [ ! -f "${WHEEL_DIR}"/finished ]; then
+	pip wheel -w "${WHEEL_DIR}" ${MODULES}
+	touch "${WHEEL_DIR}"/finished
+    fi
+    pip install "${WHEEL_DIR}"/*.whl
 else
     pip install $MODULES
 fi

--- a/packaging/osx/lbry-osx-app/setup_app.sh
+++ b/packaging/osx/lbry-osx-app/setup_app.sh
@@ -9,6 +9,7 @@ ON_TRAVIS=false
 
 rm -rf build dist LBRY.app
 
+pip install wheel
 # the default py2app (v0.9) has a bug that is fixed in the head of /metachris/py2app
 pip install git+https://github.com/metachris/py2app
 pip install jsonrpc

--- a/packaging/osx/lbry-osx-app/setup_app.sh
+++ b/packaging/osx/lbry-osx-app/setup_app.sh
@@ -5,6 +5,7 @@ set -o xtrace
 
 DEST=`pwd`
 tmp="${DEST}/build"
+ON_TRAVIS=false
 
 rm -rf build dist LBRY.app
 
@@ -23,6 +24,7 @@ if [ -z ${TRAVIS_BUILD_DIR+x} ]; then
     LBRY="${tmp}/lbry"
 else
     # building on travis
+    ON_TRAVIS=true
     cd ${TRAVIS_BUILD_DIR}
     LBRY=${TRAVIS_BUILD_DIR}
 fi
@@ -45,7 +47,16 @@ codesign -s "${LBRY_DEVELOPER_ID}" -f "${DEST}/dist/LBRYURIHandler.app/Contents/
 codesign --deep -s "${LBRY_DEVELOPER_ID}" -f "${DEST}/dist/LBRYURIHandler.app/Contents/MacOS/LBRYURIHandler"
 codesign -vvvv "${DEST}/dist/LBRYURIHandler.app"
 
-pip install certifi pyobjc-core pyobjc-framework-Cocoa pyobjc-framework-CFNetwork
+pip install certifi
+MODULES="pyobjc-core pyobjc-framework-Cocoa pyobjc-framework-CFNetwork"
+if [ ${ON_TRAVIS} = true ]; then
+    WHEEL_DIR="${TRAVIS_BUILD_DIR}/cache/wheel"
+    mkdir -p "${WHEEL_DIR}"
+    pip wheel -w "${WHEEL_DIR}" ${MODULES}
+fi
+
+pip install $MODULES
+
 
 # add lbrycrdd as a resource. Following
 # http://stackoverflow.com/questions/11370012/can-executables-made-with-py2app-include-other-terminal-scripts-and-run-them

--- a/packaging/osx/lbry-osx-app/setup_app.sh
+++ b/packaging/osx/lbry-osx-app/setup_app.sh
@@ -54,9 +54,10 @@ if [ ${ON_TRAVIS} = true ]; then
     WHEEL_DIR="${TRAVIS_BUILD_DIR}/cache/wheel"
     mkdir -p "${WHEEL_DIR}"
     pip wheel -w "${WHEEL_DIR}" ${MODULES}
+    pip install "${WHEEL_DIR}"/*
+else
+    pip install $MODULES
 fi
-
-pip install $MODULES
 
 
 # add lbrycrdd as a resource. Following


### PR DESCRIPTION
pyobj was taking a long time; this change builds wheels and caches them.  Speeding up the build from 15 minutes to 5 minutes.