### PR TITLE
Updates the deployment process and the version check associated with it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ deploy:
   - provider: releases
     file: "${TRAVIS_BUILD_DIR}/`python setup.py --name`_`python setup.py -V`_amd64.deb"
     skip_cleanup: true
+    prerelease: true
     on:
       tags: true
       condition: "$TRAVIS_OS_NAME = linux"
@@ -54,6 +55,7 @@ deploy:
   - provider: releases
     file: "${TRAVIS_BUILD_DIR}/packaging/osx/lbry-osx-app/`python setup.py --name`.`python setup.py -V`.dmg"
     skip_cleanup: true
+    prerelease: true
     on:
       tags: true
       condition: "$TRAVIS_OS_NAME = osx"

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -2,6 +2,7 @@ import string
 import locale
 import mimetypes
 import os
+import re
 import subprocess
 import sys
 import random
@@ -585,13 +586,12 @@ class LBRYDaemon(jsonrpc.JSONRPC):
 
         def _get_lbrynet_version():
             try:
-                r = urlopen("https://raw.githubusercontent.com/lbryio/lbry/master/lbrynet/__init__.py").read().split('\n')
-                vs = next(i for i in r if '__version__ =' in i).split("=")[1].replace(" ", "")
-                vt = tuple(int(x) for x in vs[1:-1].split('.'))
-                vr = ".".join([str(x) for x in vt])
-                log.info("remote lbrynet " + str(vr) + " > local lbrynet " + str(lbrynet_version) + " = " + str(
-                    vr > lbrynet_version))
-                self.git_lbrynet_version = vr
+                version = get_lbrynet_version_from_github()
+                log.info(
+                    "remote lbrynet %s > local lbrynet %s = %s",
+                    version, lbrynet_version, compare_versions(version, lbrynet_version)
+                )
+                self.git_lbrynet_version = version
                 return defer.succeed(None)
             except:
                 log.info("Failed to get lbrynet version from git")
@@ -2284,7 +2284,6 @@ class LBRYDaemon(jsonrpc.JSONRPC):
         Returns:
             True, opens file browser
         """
-        
         path = p['path']
         if sys.platform == "darwin":
             d = threads.deferToThread(subprocess.Popen, ['open', '-R', path])
@@ -2295,3 +2294,27 @@ class LBRYDaemon(jsonrpc.JSONRPC):
 
         d.addCallback(lambda _: self._render_response(True, OK_CODE))
         return d
+
+
+def get_lbrynet_version_from_github():
+    """Return the latest released version from github."""
+    response = requests.get('https://api.github.com/repos/lbryio/lbry/releases/latest')
+    release = response.json()
+    tag = release['tag_name']
+    # githubs documentation claims this should never happen, but we'll check just in case
+    if release['prerelease']:
+        raise Exception('Release {} is a pre-release'.format(tag))
+    return get_version_from_tag(tag)
+
+
+def get_version_from_tag(tag):
+    match = re.match('v([\d.]+)', tag)
+    if match:
+        return match.group(1)
+    else:
+        raise Exception('Failed to parse version from tag {}'.format(tag))
+
+
+def compare_versions(a, b):
+    """Returns True if version a is more recent than version b"""
+    return a > b

--- a/tests/lbrynet/lbrynet_daemon/test_LBRYDaemon.py
+++ b/tests/lbrynet/lbrynet_daemon/test_LBRYDaemon.py
@@ -1,0 +1,38 @@
+import mock
+import requests
+from twisted.trial import unittest
+
+from lbrynet.lbrynet_daemon import LBRYDaemon
+
+
+class MiscTests(unittest.TestCase):
+    def test_get_lbrynet_version_from_github(self):
+        response = mock.create_autospec(requests.Response)
+        # don't need to mock out the entire response from the api
+        # but at least need 'tag_name'
+        response.json.return_value = {
+            "url": "https://api.github.com/repos/lbryio/lbry/releases/3685199",
+            "assets_url": "https://api.github.com/repos/lbryio/lbry/releases/3685199/assets",
+            "html_url": "https://github.com/lbryio/lbry/releases/tag/v0.3.8",
+            "id": 3685199,
+            "tag_name": "v0.3.8",
+            "prerelease": False
+        }
+        with mock.patch('lbrynet.lbrynet_daemon.LBRYDaemon.requests') as req:
+            req.get.return_value = response
+            self.assertEqual('0.3.8', LBRYDaemon.get_lbrynet_version_from_github())
+
+    def test_error_is_thrown_if_prerelease(self):
+        response = mock.create_autospec(requests.Response)
+        response.json.return_value = {
+            "tag_name": "v0.3.8",
+            "prerelease": True
+        }
+        with mock.patch('lbrynet.lbrynet_daemon.LBRYDaemon.requests') as req:
+            req.get.return_value = response
+            with self.assertRaises(Exception):
+                LBRYDaemon.get_lbrynet_version_from_github()
+
+    def test_error_is_thrown_when_version_cant_be_parsed(self):
+        with self.assertRaises(Exception):
+            LBRYDaemon.get_version_from_tag('garbage')


### PR DESCRIPTION
This commit supports steps 1 and 2 in the new workflow:
1. Change the logic in the daemon to check the github api for the latest release that is not a pre release
2. Change travis to mark all releases as pre release
3. When we are ready to stage a release we push a tag to master. Travis builds the packages and releases them
4. We manually check them
5. Remove the pre release mark when we are happy