### PR TITLE
web-ui files are on S3 now

### DIFF
--- a/lbrynet/lbrynet_daemon/LBRYUIManager.py
+++ b/lbrynet/lbrynet_daemon/LBRYUIManager.py
@@ -98,8 +98,8 @@ class LBRYUIManager(object):
             return d
         else:
             log.info("Checking for updates for UI branch: " + branch)
-            self._git_url = "https://api.github.com/repos/lbryio/lbry-web-ui/git/refs/heads/%s" % branch
-            self._dist_url = "https://raw.githubusercontent.com/lbryio/lbry-web-ui/%s/dist.zip" % branch
+            self._git_url = "https://s3.amazonaws.com/lbry-ui/{}/data.json".format(branch)
+            self._dist_url = "https://s3.amazonaws.com/lbry-ui/{}/dist.zip".format(branch)
 
         d = self._up_to_date()
         d.addCallback(lambda r: self._download_ui() if not r else self._load_ui())
@@ -109,7 +109,7 @@ class LBRYUIManager(object):
         def _get_git_info():
             response = urlopen(self._git_url)
             data = json.loads(response.read())
-            return defer.succeed(data['object']['sha'])
+            return defer.succeed(data['sha'])
 
         def _set_git(version):
             self.git_version = version.replace('\n', '')


### PR DESCRIPTION
Don't merge this until https://github.com/lbryio/lbry-web-ui/pull/20 is merged and the files are properly on S3.

Tested with the current add-travis branch:

```
INFO:lbrynet.lbrynet_daemon.LBRYUIManager:Checking for updates for UI branch: add-travis
INFO:lbrynet.lbrynet_daemon.LBRYUIManager:UI updates available, checking if installation meets requirements
INFO:lbrynet.lbrynet_daemon.LBRYUIManager:Downloaded files for UI commit af553c6ac0e211c1988c8a3dc646c8f924df9c52
INFO:lbrynet.lbrynet_daemon.LBRYUIManager:Local version of lbrynet meets ui requirement
INFO:lbrynet.lbrynet_daemon.LBRYUIManager:Loaded UI update
INFO:lbrynet.lbrynet_daemon.LBRYDaemon:Platform: {"ip": "174.73.19.15", "python_version: ": "2.7.11", "os_system": "Darwin", "lbrynet_version: ": "0.3.6", "os_release": "15.5.0", "platform": "Darwin-15.5.0-x86_64-i386-64bit", "lbryum_version: ": "2.7.0.2", "ui_version": "af553c6ac0e211c1988c8a3dc646c8f924df9c52", "processor": "i386"}
```