### PR TITLE
Fix: Log configuration should not happen when a module is imported

### DIFF
--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -1,0 +1,24 @@
+import logging
+import logging.handlers
+import sys
+
+
+DEFAULT_FORMAT = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)d: %(message)s"
+DEFAULT_FORMATTER = logging.Formatter(DEFAULT_FORMAT)
+
+
+def configureConsole(log=None, level=logging.INFO):
+    """Convenience function to configure a logger that outputs to stdout"""
+    log = log or logging.getLogger()
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(DEFAULT_FORMATTER)
+    log.addHandler(handler)
+    log.setLevel(level=level)
+
+
+def configureFileHandler(file_name, log=None, level=logging.INFO):
+    log = log or logging.getLogger()
+    handler = logging.handlers.RotatingFileHandler(file_name, maxBytes=2097152, backupCount=5)
+    handler.setFormatter(DEFAULT_FORMATTER)
+    log.addHandler(handler)
+    log.setLevel(level=level)

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -56,6 +56,7 @@ from lbrynet.lbryfile.LBRYFileMetadataManager import DBLBRYFileMetadataManager, 
 log = logging.getLogger(__name__)
 
 
+# TODO: this code snippet is everywhere. Make it go away
 if sys.platform != "darwin":
     log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
 else:
@@ -68,25 +69,10 @@ lbrynet_log = os.path.join(log_dir, LOG_FILE_NAME)
 
 log = logging.getLogger(__name__)
 
-# TODO: configuring a logger on module import drastically reduces the
-# amount of control the caller of this code has over logging
-#
-# Better would be to configure all logging at runtime.
-handler = logging.handlers.RotatingFileHandler(lbrynet_log, maxBytes=2097152, backupCount=5)
-log.addHandler(handler)
-log.setLevel(logging.INFO)
-
-# if os.path.isfile(lbryum_log):
-#     f = open(lbryum_log, 'r')
-#     PREVIOUS_LBRYUM_LOG = len(f.read())
-#     f.close()
-# else:
-#     PREVIOUS_LBRYUM_LOG = 0
 
 if os.path.isfile(lbrynet_log):
-    f = open(lbrynet_log, 'r')
-    PREVIOUS_LBRYNET_LOG = len(f.read())
-    f.close()
+    with open(lbrynet_log, 'r') as f:
+        PREVIOUS_LBRYNET_LOG = len(f.read())
 else:
     PREVIOUS_LBRYNET_LOG = 0
 

--- a/lbrynet/lbrynet_daemon/LBRYDaemonServer.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemonServer.py
@@ -20,6 +20,7 @@ from lbrynet.lbrynet_daemon.LBRYDaemon import LBRYDaemon
 from lbrynet.conf import API_CONNECTION_STRING, API_ADDRESS, DEFAULT_WALLET, UI_ADDRESS, DEFAULT_UI_BRANCH, LOG_FILE_NAME
 
 
+# TODO: omg, this code is essentially duplicated in LBRYDaemon
 if sys.platform != "darwin":
     data_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
 else:
@@ -29,9 +30,7 @@ if not os.path.isdir(data_dir):
 
 lbrynet_log = os.path.join(data_dir, LOG_FILE_NAME)
 log = logging.getLogger(__name__)
-handler = logging.handlers.RotatingFileHandler(lbrynet_log, maxBytes=2097152, backupCount=5)
-log.addHandler(handler)
-log.setLevel(logging.INFO)
+
 
 class LBRYDaemonRequest(server.Request):
     """

--- a/lbrynet/lbrynet_daemon/LBRYDownloader.py
+++ b/lbrynet/lbrynet_daemon/LBRYDownloader.py
@@ -37,9 +37,7 @@ if not os.path.isdir(log_dir):
 
 lbrynet_log = os.path.join(log_dir, LOG_FILE_NAME)
 log = logging.getLogger(__name__)
-handler = logging.handlers.RotatingFileHandler(lbrynet_log, maxBytes=2097152, backupCount=5)
-log.addHandler(handler)
-log.setLevel(logging.INFO)
+
 
 class GetStream(object):
     def __init__(self, sd_identifier, session, wallet, lbry_file_manager, max_key_fee, data_rate=0.5,

--- a/lbrynet/lbrynet_daemon/LBRYPublisher.py
+++ b/lbrynet/lbrynet_daemon/LBRYPublisher.py
@@ -24,9 +24,6 @@ if not os.path.isdir(log_dir):
 
 lbrynet_log = os.path.join(log_dir, LOG_FILE_NAME)
 log = logging.getLogger(__name__)
-handler = logging.handlers.RotatingFileHandler(lbrynet_log, maxBytes=2097152, backupCount=5)
-log.addHandler(handler)
-log.setLevel(logging.INFO)
 
 
 class Publisher(object):

--- a/lbrynet/lbrynet_daemon/LBRYUIManager.py
+++ b/lbrynet/lbrynet_daemon/LBRYUIManager.py
@@ -25,9 +25,6 @@ if not os.path.isdir(log_dir):
 
 lbrynet_log = os.path.join(log_dir, LOG_FILE_NAME)
 log = logging.getLogger(__name__)
-handler = logging.handlers.RotatingFileHandler(lbrynet_log, maxBytes=2097152, backupCount=5)
-log.addHandler(handler)
-log.setLevel(logging.INFO)
 
 
 class LBRYUIManager(object):


### PR DESCRIPTION
Instead, move the responsibility to the main program. Also,
each module had the same, redundant setup.