### PR TITLE
Remove print line

### DIFF
--- a/lbrynet/lbrynet_daemon/LBRYDaemonServer.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemonServer.py
@@ -68,7 +68,6 @@ class LBRYDaemonRequest(server.Request):
         from twisted.web.http import parse_qs
         if self.do_log:
             print '%f Request Received' % time.time()
-        print self.content
 
         self.content.seek(0,0)
         self.args = {}


### PR DESCRIPTION
This line is responsible for flooding the console with messages like
<_io.BytesIO object at 0x7f9e286e52f0>