### PR TITLE
Have TimeoutError hexlify blobs

### DIFF
--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -241,7 +241,7 @@ class Node(object):
 
         def log_error(err, n):
             log.error("error storing blob_hash %s at %s", binascii.hexlify(blob_hash), str(n))
-            log.error(binascii.hexlify(err.getErrorMessage()))
+            log.error(err.getErrorMessage())
             log.error(err.getTraceback())
 
         def log_success(res):

--- a/lbrynet/dht/protocol.py
+++ b/lbrynet/dht/protocol.py
@@ -7,6 +7,7 @@
 # The docstrings in this module contain epytext markup; API documentation
 # may be created by processing this file with epydoc: http://epydoc.sf.net
 
+import binascii
 import time
 
 from twisted.internet import protocol, defer
@@ -23,6 +24,13 @@ reactor = twisted.internet.reactor
 
 class TimeoutError(Exception):
     """ Raised when a RPC times out """
+    def __init__(self, remote_contact_id):
+        # remote_contact_id is a binary blob so we need to convert it
+        # into something more readable
+        msg = 'Timeout connecting to {}'.format(binascii.hexlify(remote_contact_id))
+        Exception.__init__(self, msg)
+        self.remote_contact_id = remote_contact_id
+
 
 class KademliaProtocol(protocol.DatagramProtocol):
     """ Implements all low-level network-related functions of a Kademlia node """


### PR DESCRIPTION
TimeoutError was outputting useless binary blobs.

I'm not sure if these log messages are even useful, but this change at least makes them readable.