### PR TITLE
raise Exception on GetStream timeout

### DIFF
--- a/lbrynet/lbrynet_daemon/LBRYDownloader.py
+++ b/lbrynet/lbrynet_daemon/LBRYDownloader.py
@@ -76,14 +76,14 @@ class GetStream(object):
         # TODO: Why is this the stopping condition for the finished callback?
         if self.download_path:
             self.checker.stop()
-            self.finished.callback((self.stream_hash, self.download_path))
+            self.finished.callback((True, self.stream_hash, self.download_path))
 
         elif self.timeout_counter >= self.timeout:
             log.info("Timeout downloading lbry://%s" % self.resolved_name)
             self.checker.stop()
             self.d.cancel()
             self.code = STREAM_STAGES[4]
-            self.finished.callback(False)
+            self.finished.callback((False, None, None))
 
     def _convert_max_fee(self):
         if isinstance(self.max_key_fee, dict):


### PR DESCRIPTION
when GetStream timesout, it causes an error later on.  This instead raises an error.

Should actually do something when a timeout happens, but I'm not sure what.  This is at least better then it was.