### PR TITLE
Use new exclude_claimtrietx option in lbryum getbalance command, fix maturity use

### DIFF
--- a/lbrynet/core/LBRYWallet.py
+++ b/lbrynet/core/LBRYWallet.py
@@ -1200,8 +1200,10 @@ class LBRYumWallet(LBRYWallet):
     def get_balance(self):
         cmd = known_commands['getbalance']
         func = getattr(self.cmd_runner, cmd.name)
-        d = threads.deferToThread(func)
-        d.addCallback(lambda result: result['unmatured'] if 'unmatured' in result else result['confirmed'])
+        accounts = None
+        exclude_claimtrietx = True
+        d = threads.deferToThread(func, accounts, exclude_claimtrietx)
+        d.addCallback(lambda result: result['confirmed'])
         d.addCallback(Decimal)
         return d
 


### PR DESCRIPTION
This uses the exclude_claimtrietx option in lbryum pull request https://github.com/lbryio/lbryum/pull/30

Thus the balance should now be displayed as the available amount of credits, not used for any claim trie transactions (claim,support,update). 

This also fixes an incorrect use of the field 'unmatured' which would have resulted in some strange behaviors if you held some new coins (probably someone had to patch this in during the early stage of testing where they were testing with unmatured coins ).  

This patches to show the fully confirmed balance only, but if we want to show the unconfirmed and insecure balance (with the confirmed balance) it should be result['confirmed'] + result['unconfirmed'] + result['unmatured'] , we could potentially  add another function to show the unconfirmed and insecure balance. 

I've not yet actually tested this patch myself. 