### PR TITLE
fix windows cli

### DIFF
--- a/lbrynet/lbrynet_daemon/LBRYDaemonCLI.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemonCLI.py
@@ -25,6 +25,16 @@ def guess_type(x):
     except ValueError:
         return x
 
+
+def get_params_from_kwargs(params):
+    params_for_return = {}
+    for i in params:
+        eq_pos = i.index('=')
+        k, v = i[:eq_pos], i[eq_pos+1:]
+        params_for_return[k] = guess_type(v)
+    return params_for_return
+
+
 def main():
     api = JSONRPCProxy.from_url(API_CONNECTION_STRING)
 
@@ -35,27 +45,21 @@ def main():
         sys.exit(1)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('method', nargs=1, type=str)
+    parser.add_argument('method', nargs=1)
     parser.add_argument('params', nargs=argparse.REMAINDER, default=None)
     args = parser.parse_args()
+
     meth = args.method[0]
     params = {}
+
     if args.params:
         if len(args.params) > 1:
-            for i in args.params:
-                k, v = i.split('=')[0], i.split('=')[1:]
-                if isinstance(v, list):
-                    v = ''.join(v)
-                params[k] = guess_type(v)
+            params = get_params_from_kwargs(args.params)
         elif len(args.params) == 1:
             try:
                 params = json.loads(args.params[0])
             except ValueError:
-                for i in args.params:
-                    k, v = i.split('=')[0], i.split('=')[1:]
-                    if isinstance(v, list):
-                        v = ''.join(v)
-                    params[k] = guess_type(v)
+                params = get_params_from_kwargs(args.params)
 
     msg = help_msg
     for f in api.help():

--- a/lbrynet/lbrynet_daemon/LBRYDaemonCLI.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemonCLI.py
@@ -36,18 +36,18 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('method', nargs=1, type=str)
-    parser.add_argument('params', nargs="+")
+    parser.add_argument('params', nargs=argparse.REMAINDER, default=None)
     args = parser.parse_args()
     meth = args.method[0]
     params = {}
     if args.params:
-        if len(args.params) != 1:
+        if len(args.params) > 1:
             for i in args.params:
                 k, v = i.split('=')[0], i.split('=')[1:]
                 if isinstance(v, list):
                     v = ''.join(v)
                 params[k] = guess_type(v)
-        else:
+        elif len(args.params) == 1:
             try:
                 params = json.loads(args.params[0])
             except ValueError:

--- a/tests/unit/lbrynet_daemon/test_LBRYDaemonCLI.py
+++ b/tests/unit/lbrynet_daemon/test_LBRYDaemonCLI.py
@@ -1,0 +1,28 @@
+from twisted.trial import unittest
+from lbrynet.lbrynet_daemon import LBRYDaemonCLI
+
+
+class LBRYDaemonCLITests(unittest.TestCase):
+    def test_guess_type(self):
+        self.assertEqual('0.3.8', LBRYDaemonCLI.guess_type('0.3.8'))
+        self.assertEqual(0.3, LBRYDaemonCLI.guess_type('0.3'))
+        self.assertEqual(3, LBRYDaemonCLI.guess_type('3'))
+        self.assertEqual('VdNmakxFORPSyfCprAD/eDDPk5TY9QYtSA==', LBRYDaemonCLI.guess_type('VdNmakxFORPSyfCprAD/eDDPk5TY9QYtSA=='))
+        self.assertEqual(0.3, LBRYDaemonCLI.guess_type('0.3'))
+
+    def test_get_params(self):
+        test_params = [
+            'b64address=VdNmakxFORPSyfCprAD/eDDPk5TY9QYtSA==',
+            'name=test',
+            'amount=5.3',
+            'n=5',
+            'address=bY13xeAjLrsjP4KGETwStK2a9UgKgXVTXu'
+        ]
+        test_r = {
+            'b64address': 'VdNmakxFORPSyfCprAD/eDDPk5TY9QYtSA==',
+            'name': 'test',
+            'amount': 5.3,
+            'n': 5,
+            'address': 'bY13xeAjLrsjP4KGETwStK2a9UgKgXVTXu'
+        }
+        self.assertDictEqual(test_r, LBRYDaemonCLI.get_params_from_kwargs(test_params))


### PR DESCRIPTION
Make lbrynet-cli easier to use on windows by converting keyword args to json. Windows doesn't want to decode arguments given as json from powershell, this provides an alternative.

cli now accepts commands like:

`lbrynet-cli resolve_name name=one`

as well as json:

`lbrynet-cli resolve_name '{"name": "one"}'`