### PR TITLE
add get_my_claim, remove is_mine from get_claim_info response

### DIFF
--- a/lbrynet/core/LBRYWallet.py
+++ b/lbrynet/core/LBRYWallet.py
@@ -376,8 +376,14 @@ class LBRYWallet(object):
             d.addCallback(lambda c: self._format_claim_for_return(name, c, claim['txid']))
             return d
 
+        def _get_my_unspent_claim(claims):
+            for claim in claims:
+                if claim['name'] == name and not claim['is spent']:
+                    return claim
+            return False
+
         d = self.get_name_claims()
-        d.addCallback(lambda claims: next((c for c in claims if c['name'] == name and not c['is spent']), False))
+        d.addCallback(_get_my_unspent_claim)
         d.addCallback(_get_claim_for_return)
         return d
 

--- a/lbrynet/core/LBRYWallet.py
+++ b/lbrynet/core/LBRYWallet.py
@@ -369,11 +369,17 @@ class LBRYWallet(object):
         return d
 
     def get_my_claim(self, name):
+        def _convert_units(claim):
+            amount = Decimal(claim['nEffectiveAmount'] / COIN)
+            claim['nEffectiveAmount'] = amount
+            return claim
+
         def _get_claim_for_return(claim):
             if not claim:
                 return False
             d = self.get_claim(name, claim['claim_id'])
-            d.addCallback(lambda c: self._format_claim_for_return(name, c, claim['txid']))
+            d.addCallback(_convert_units)
+            d.addCallback(lambda clm: self._format_claim_for_return(name, clm, claim['txid']))
             return d
 
         def _get_my_unspent_claim(claims):
@@ -399,7 +405,7 @@ class LBRYWallet(object):
     def _format_claim_for_return(self, name, claim, txid, metadata=None, meta_version=None):
         result = {}
         result['claim_id'] = claim['claimId']
-        result['amount'] = Decimal(claim['nEffectiveAmount'] / COIN)
+        result['amount'] = claim['nEffectiveAmount']
         result['height'] = claim['nHeight']
         result['name'] = name
         result['txid'] = txid

--- a/lbrynet/core/LBRYWallet.py
+++ b/lbrynet/core/LBRYWallet.py
@@ -399,7 +399,7 @@ class LBRYWallet(object):
     def _format_claim_for_return(self, name, claim, txid, metadata=None, meta_version=None):
         result = {}
         result['claim_id'] = claim['claimId']
-        result['amount'] = claim['nEffectiveAmount']
+        result['amount'] = Decimal(claim['nEffectiveAmount'] / COIN)
         result['height'] = claim['nHeight']
         result['name'] = name
         result['txid'] = txid

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -1739,6 +1739,21 @@ class LBRYDaemon(jsonrpc.JSONRPC):
         d.addCallbacks(lambda info: self._render_response(info, OK_CODE), lambda _: server.failure)
         return d
 
+    def jsonrpc_get_my_claim(self, p):
+        """
+        Return existing claim for a given name
+
+        Args:
+            'name': name to look up
+        Returns:
+            claim info, False if no such claim exists
+        """
+
+        name = p['name']
+        d = self.session.wallet.get_my_claim(name)
+        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        return d
+
     def jsonrpc_get_claim_info(self, p):
         """
             Resolve claim info from a LBRY uri


### PR DESCRIPTION
This changes the return for `get_claim_info` to not include `is_mine` as a field, and instead adds a `get_my_claim` function to look for a users claims.