### PR TITLE
Start stream event

### DIFF
--- a/lbrynet/analytics/events.py
+++ b/lbrynet/analytics/events.py
@@ -1,4 +1,19 @@
+import logging
+
 from lbrynet.analytics import utils
+
+
+log = logging.getLogger(__name__)
+
+
+def get_sd_hash(stream_info):
+    if not stream_info:
+        return None
+    try:
+        return stream_info['sources']['lbry_sd_hash']
+    except (KeyError, TypeError, ValueError):
+        log.debug('Failed to get sd_hash from %s', stream_info, exc_info=True)
+        return None
 
 
 class Events(object):
@@ -14,6 +29,20 @@ class Events(object):
             'properties': {
                 'lbry_id': self.lbry_id,
                 'session_id': self.session_id
+            },
+            'context': self.context,
+            'timestamp': utils.now()
+        }
+
+    def download_started(self, name, stream_info=None):
+        return {
+            'userId': 'lbry',
+            'event': 'Download Started',
+            'properties': {
+                'lbry_id': self.lbry_id,
+                'session_id': self.session_id,
+                'name': name,
+                'stream_info': get_sd_hash(stream_info)
             },
             'context': self.context,
             'timestamp': utils.now()

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -561,9 +561,12 @@ class LBRYDaemon(jsonrpc.JSONRPC):
         self.send_heartbeat.start(60)
 
     def _send_heartbeat(self):
-        log.debug('Sending heartbeat')
         heartbeat = self._events.heartbeat()
         self.analytics_api.track(heartbeat)
+
+    def _send_download_started(self, name, stream_info=None):
+        event = self._events.download_started(name, stream_info)
+        self.analytics_api.track(event)
 
     def _get_platform(self):
         r =  {
@@ -1129,6 +1132,7 @@ class LBRYDaemon(jsonrpc.JSONRPC):
         Add a lbry file to the file manager, start the download, and return the new lbry file.
         If it already exists in the file manager, return the existing lbry file
         """
+        self._send_download_started(name)
         helper = _DownloadNameHelper(
             self, name, timeout, download_directory, file_name, wait_for_write)
 

--- a/lbrynet/lbrynet_daemon/LBRYDaemon.py
+++ b/lbrynet/lbrynet_daemon/LBRYDaemon.py
@@ -2650,16 +2650,14 @@ class _DownloadNameHelper(object):
     def _setup_stream(self, stream_info):
         stream_hash = get_sd_hash(stream_info)
         d = self.daemon._get_lbry_file_by_sd_hash(stream_hash)
-        d.addCallback(self._add_results_callback(stream_info))
+        d.addCallback(self._prepend_stream_info, stream_info)
         return d
 
-    def _add_results_callback(self, stream_info):
-        def add_results(l):
-            if l:
-                if os.path.isfile(os.path.join(self.download_directory, l.file_name)):
-                    return defer.succeed((stream_info, l))
-            return defer.succeed((stream_info, None))
-        return add_results
+    def _prepend_stream_info(self, lbry_file, stream_info):
+        if lbry_file:
+            if os.path.isfile(os.path.join(self.download_directory, lbry_file.file_name)):
+                return defer.succeed((stream_info, lbry_file))
+        return defer.succeed((stream_info, None))
 
     def wait_or_get_stream(self, args):
         stream_info, lbry_file = args


### PR DESCRIPTION
Adds a new event `Download Started` which is triggered when `_download_name` is called.  This will enable a better "active user" metric.

The resulting event looks like:

```
{
  "context": {
    "is_dev": false,
    "os": {
      "version": "15.6.0",
      "name": "Darwin"
    },
    "app": {
      "ui_version": "fdc6329c2fa35353db1a6c0f9a697216e78e1848",
      "version": "0.5.0",
      "name": "lbrynet",
      "wallet": {
        "version": null,
        "name": "lbrycrd"
      },
      "python_version": "2.7.11"
    },
    "library": {
      "version": "1.0.0",
      "name": "lbrynet-analytics"
    }
  },
  "event": "Download Started",
  "properties": {
    "stream_info": null,
    "lbry_id": "4vox16oB69xoy742F9nTfKVn8KGhLaLiCNPEwX7QfqEyWgDgcJWWJtCEcKAvf7ADZc",
    "name": "francine",
    "session_id": "t92dkf4hs82831JiwNwiEaM7oeUKyUht4mGf7sD3BkPTPLcn9rRRoNarigDvGPfyv"
  },
  "receivedAt": "2016-09-28T16:04:54.423Z",
  "timestamp": "2016-09-28T16:04:53.975Z",
  "userId": "lbry",
  "type": "track",
  "originalTimestamp": "2016-09-28T16:04:53.975327Z",
  "messageId": "api-1cbVo39afr1ybsxQn9TudUUsiPyVEuAc",
  "integrations": {}
}
```