### PR TITLE
upgrade unqlite to 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ simplejson==3.8.2
 six==1.9.0
 slowaes==0.1a1
 txJSON-RPC==0.3.1
-unqlite==0.2.0
+unqlite==0.4.0
 wsgiref==0.1.2
 zope.interface==4.1.3
 base58==0.2.2

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requires = [
     'python-bitcoinrpc==0.1',
     'txJSON-RPC',
     'requests>=2.4.2',
-    'unqlite==0.2.0',
+    'unqlite==0.4.0',
     'lbryum',
     'jsonrpc',
     'simplejson',


### PR DESCRIPTION
unqlite 0.2.0 was causing problems on arch linux.  Upgrading to
the current version (0.6.0) causing difficulties in building
the package so 0.4.0 it is.

Eventually it would be nice to get rid of unqlite.