### PR TITLE
Fix error when version is None

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -634,7 +634,7 @@ class Daemon(jsonrpc.JSONRPC):
                 )
                 self.git_lbryum_version = version
                 return defer.succeed(None)
-            except:
+            except Exception:
                 log.info("Failed to get lbryum version from git")
                 self.git_lbryum_version = None
                 return defer.fail(None)
@@ -649,7 +649,7 @@ class Daemon(jsonrpc.JSONRPC):
                 )
                 self.git_lbrynet_version = version
                 return defer.succeed(None)
-            except:
+            except Exception:
                 log.info("Failed to get lbrynet version from git")
                 self.git_lbrynet_version = None
                 return defer.fail(None)
@@ -1553,6 +1553,16 @@ class Daemon(jsonrpc.JSONRPC):
         """
 
         platform_info = self._get_platform()
+        try:
+            lbrynet_update_available = utils.version_is_greater_than(
+                self.git_lbrynet_version, lbrynet_version)
+        except AttributeError:
+            lbrynet_update_available = False
+        try:
+            lbryum_update_available = utils.version_is_greater_than(
+                self.git_lbryum_version, lbryum_version)
+        except AttributeError:
+            lbryum_update_available = False
         msg = {
             'platform': platform_info['platform'],
             'os_release': platform_info['os_release'],
@@ -1562,8 +1572,8 @@ class Daemon(jsonrpc.JSONRPC):
             'ui_version': self.ui_version,
             'remote_lbrynet': self.git_lbrynet_version,
             'remote_lbryum': self.git_lbryum_version,
-            'lbrynet_update_available': utils.version_is_greater_than(self.git_lbrynet_version, lbrynet_version),
-            'lbryum_update_available': utils.version_is_greater_than(self.git_lbryum_version, lbryum_version),
+            'lbrynet_update_available': lbrynet_update_available,
+            'lbryum_update_available': lbryum_update_available
         }
 
         log.info("Get version info: " + json.dumps(msg))


### PR DESCRIPTION
Logs were reporting:

```
Failure instance: Traceback: <type 'exceptions.AttributeError'>: StrictVersion instance has no attribute 'version'
/Volumes/LBRY/LBRY.app/Contents/Resources/lib/python2.7/lbrynet/lbrynet_daemon/DaemonServer.py:121:requestReceived
twisted/web/server.pyc:183:process
twisted/web/server.pyc:234:render
/Volumes/LBRY/LBRY.app/Contents/Resources/lib/python2.7/lbrynet/lbrynet_daemon/Daemon.py:450:render
--- <exception caught here> ---
twisted/internet/defer.pyc:150:maybeDeferred
/Volumes/LBRY/LBRY.app/Contents/Resources/lib/python2.7/lbrynet/lbrynet_daemon/Daemon.py:1561:jsonrpc_version
/Volumes/LBRY/LBRY.app/Contents/Resources/lib/python2.7/lbrynet/core/utils.py:39:version_is_greater_than
distutils/version.pyc:140:__cmp__
```