### PR TITLE
Appveyor build needs to fail when tests fail

### DIFF
--- a/packaging/windows/test.ps1
+++ b/packaging/windows/test.ps1
@@ -1,4 +1,4 @@
 C:\Python27\Scripts\pip.exe install mock
 C:\Python27\Scripts\pip.exe install pylint
 C:\Python27\python.exe C:\Python27\Scripts\trial.py C:\projects\lbry\tests\unit
-
+if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }


### PR DESCRIPTION
According to
https://www.appveyor.com/docs/build-configuration/#script-blocks-in-build-configuration
a build only fails if an exception is thrown. This is causing builds to pass even if
the tests fail. That same link suggests adding the code that is in this commit.

I tested that this works by intentionally failing a test: https://ci.appveyor.com/project/LBRY/lbry/build/1.0.170