### PR TITLE
work on jack's add-nout branch

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -307,12 +307,12 @@ class Wallet(object):
         d.addCallback(lambda r: None if 'txid' not in r else r['txid'])
         return d
 
-    def get_stream_info_from_txid(self, name, txid):
+    def get_stream_info_from_txid(self, name, txid, nout):
         d = self.get_claims_from_tx(txid)
 
         def get_claim_for_name(claims):
             for claim in claims:
-                if claim['name'] == name:
+                if claim['name'] == name and claim['nOut'] == nout:
                     claim['txid'] = txid
                     return claim
             return Failure(UnknownNameError(name))

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -378,7 +378,7 @@ class Wallet(object):
             if not claim:
                 return False
 
-            d = self.get_claim(name, claim['claimId'])
+            d = self.get_claim(name, claim['claim_id'])
             d.addCallback(_convert_units)
             d.addCallback(lambda claim_info: self._format_claim_for_return(name, claim_info))
             return d
@@ -452,10 +452,15 @@ class Wallet(object):
         return defer.succeed(Metadata(meta_for_return))
 
     def claim_name(self, name, bid, m):
-        def _save_metadata(txid, nout, metadata):
-            log.info("Saving metadata for claim %s" % txid)
+        def _save_metadata(claim_out, metadata):
+            if not claim_out['success']:
+                msg = 'Claim to name {} failed: {}'.format(name,claim_out['reason'])
+                defer.fail(Exception(msg))
+            txid = claim_out['txid'] 
+            nout = claim_out['nout']
+            log.info("Saving metadata for claim %s %d" % (txid, nout))
             d = self._save_name_metadata(name, txid, nout, metadata['sources']['lbry_sd_hash'])
-            d.addCallback(lambda _: txid)
+            d.addCallback(lambda _: claim_out)
             return d
 
         def _claim_or_update(claim, metadata, _bid):
@@ -477,41 +482,11 @@ class Wallet(object):
 
         d = self.get_claim_info(name)
         d.addCallback(lambda claim: _claim_or_update(claim, meta, bid))
-        d.addCallback(lambda txid, nout: _save_metadata(txid, nout, meta))
+        d.addCallback(lambda claim_out: _save_metadata(claim_out, meta))
         return d
 
-    def abandon_name(self, txid):
-        d1 = self.get_new_address()
-        d2 = self.get_claims_from_tx(txid)
-
-        def get_txout_of_claim(claims):
-            for claim in claims:
-                if 'name' in claim and 'nOut' in claim:
-                    return claim['nOut']
-            return defer.fail(ValueError("No claims in tx"))
-
-        def get_value_of_txout(nOut):
-            d = self._get_raw_tx(txid)
-            d.addCallback(self._get_decoded_tx)
-            d.addCallback(lambda tx: tx['vout'][nOut]['value'])
-            return d
-
-        d2.addCallback(get_txout_of_claim)
-        d2.addCallback(get_value_of_txout)
-        dl = defer.DeferredList([d1, d2], consumeErrors=True)
-
-        def abandon(results):
-            if results[0][0] and results[1][0]:
-                address = results[0][1]
-                amount = float(results[1][1])
-                return self._send_abandon(txid, address, amount)
-            elif results[0][0] is False:
-                return defer.fail(Failure(ValueError("Couldn't get a new address")))
-            else:
-                return results[1][1]
-
-        dl.addCallback(abandon)
-        return dl
+    def abandon_claim(self, txid, nout):
+        return self._abandon_claim(txid,nout)
 
     def support_claim(self, name, claim_id, amount):
         return self._support_claim(name, claim_id, amount)
@@ -726,7 +701,7 @@ class Wallet(object):
     def _get_decoded_tx(self, raw_tx):
         return defer.fail(NotImplementedError())
 
-    def _send_abandon(self, txid, address, amount):
+    def _abandon_claim(self, txid, nout):
         return defer.fail(NotImplementedError())
 
     def _send_name_claim_update(self, name, claim_id, txid, nout, value, amount):
@@ -1313,14 +1288,9 @@ class LBRYumWallet(Wallet):
         return d
 
     def _send_name_claim(self, name, val, amount):
-        def send_claim(address):
-            cmd = known_commands['claimname']
-            func = getattr(self.cmd_runner, cmd.name)
-            return threads.deferToThread(func, address, amount, name, json.dumps(val))
-        d = self.get_new_address()
-        d.addCallback(send_claim)
-        d.addCallback(self._broadcast_transaction)
-        return d
+        cmd = known_commands['claim']
+        func = getattr(self.cmd_runner, cmd.name)
+        return threads.deferToThread(func, name, json.dumps(val), amount)
 
     def _get_claims_for_name(self, name):
         cmd = known_commands['getclaimsforname']
@@ -1328,18 +1298,12 @@ class LBRYumWallet(Wallet):
         return threads.deferToThread(func, name)
 
     def _send_name_claim_update(self, name, claim_id, txid, nout, value, amount):
-        def send_claim_update(address):
-            decoded_claim_id = claim_id.decode('hex')[::-1]
-            metadata = json.dumps(value)
-            log.info("updateclaim %s %s %f %s %s '%s'", txid, address, amount, name, decoded_claim_id.encode('hex'), metadata)
-            cmd = known_commands['updateclaim']
-            func = getattr(self.cmd_runner, cmd.name)
-            return threads.deferToThread(func, txid, address, amount, name, decoded_claim_id, metadata)
+        metadata = json.dumps(value)
+        log.info("updateclaim %s %d %s %f %s %s '%s'", txid, nout, address, amount, name, claim_id, metadata)
+        cmd = known_commands['update']
+        func = getattr(self.cmd_runner, cmd.name)
+        return threads.deferToThread(func, txid, nout, name, claim_id, metadata, amount)
 
-        d = self.get_new_address()
-        d.addCallback(send_claim_update)
-        d.addCallback(self._broadcast_transaction)
-        return d
 
     def _get_decoded_tx(self, raw_tx):
         tx = Transaction(raw_tx)
@@ -1351,23 +1315,18 @@ class LBRYumWallet(Wallet):
             decoded_tx['vout'].append(out)
         return decoded_tx
 
-    def _send_abandon(self, txid, address, amount):
-        log.info("Abandon %s %s %f" % (txid, address, amount))
-        cmd = known_commands['abandonclaim']
+    def _abandon_claim(self, txid, nout):
+        log.info("Abandon %s %s" % (txid, nout))
+        cmd = known_commands['abandon']
         func = getattr(self.cmd_runner, cmd.name)
-        d = threads.deferToThread(func, txid, address, amount)
-        d.addCallback(self._broadcast_transaction)
+        d = threads.deferToThread(func, txid, nout)
         return d
 
     def _support_claim(self, name, claim_id, amount):
-        def _send_support(d, a, n, c):
-            cmd = known_commands['supportclaim']
-            func = getattr(self.cmd_runner, cmd.name)
-            d = threads.deferToThread(func, d, a, n, c)
-            return d
-        d = self.get_new_address()
-        d.addCallback(lambda address: _send_support(address, amount, name, claim_id))
-        d.addCallback(self._broadcast_transaction)
+        log.info("Support %s %s %f" % (name, claim_id, amount))
+        cmd = known_commands['support']
+        func = getattr(self.cmd_runner, cmd.name)
+        d = threads.deferToThread(func, name, claim_id, amount)
         return d
 
     def _broadcast_transaction(self, raw_tx):

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -360,7 +360,7 @@ class Wallet(object):
                 return defer.succeed(claim_id)
             else:
                 d = self.get_claims_from_tx(txid)
-                d.addCallback(lambda claims: next(c for c in claims if c['name'] == name))
+                d.addCallback(lambda claims: next(c for c in claims if c['name'] == name and c['nOut'] == nout))
                 d.addCallback(lambda claim: self._update_claimid(claim['claimId'], name, txid, claim['nOut']))
                 return d
 

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -542,7 +542,7 @@ class Wallet(object):
 
     def get_name_and_validity_for_sd_hash(self, sd_hash):
         d = self._get_claim_metadata_for_sd_hash(sd_hash)
-        d.addCallback(lambda name_txid: self._get_status_of_claim(name_txid[1], name_txid[0], sd_hash) if name_txid is not None else None)
+        d.addCallback(lambda name_txid: self._get_status_of_claim(name_txid[1], name_txid[2], name_txid[0], sd_hash) if name_txid is not None else None)
         return d
 
     def get_available_balance(self):
@@ -562,7 +562,7 @@ class Wallet(object):
         d.addCallback(lambda _: self._first_run == self._FIRST_RUN_YES)
         return d
 
-    def _get_status_of_claim(self, txid, name, sd_hash):
+    def _get_status_of_claim(self, txid, nout, name, sd_hash):
         d = self.get_claims_from_tx(txid)
 
         def get_status(claims):
@@ -570,7 +570,9 @@ class Wallet(object):
                 claims = []
             for claim in claims:
                 if 'in claim trie' in claim:
-                    if 'name' in claim and str(claim['name']) == name and 'value' in claim:
+                    name_is_equal = 'name' in claim and str(claim['name']) == name
+                    nout_is_equal = 'nOut' in claim and claim['nOut'] == nout 
+                    if name_is_equal and nout_is_equal and 'value' in claim:
                         try:
                             value_dict = json.loads(claim['value'])
                         except (ValueError, TypeError):

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -663,8 +663,8 @@ class Wallet(object):
 
     def _save_name_metadata(self, name, txid, nout, sd_hash):
         assert len(txid) == 64, "That's not a txid: %s" % str(txid)
-        d = self.db.runQuery("delete from name_metadata where name=? and txid=? and sd_hash=?",
-                             (name, txid, sd_hash))
+        d = self.db.runQuery("delete from name_metadata where name=? and txid=? and n=? and sd_hash=?",
+                             (name, txid, nout, sd_hash))
         d.addCallback(lambda _: self.db.runQuery("insert into name_metadata values (?, ?, ?, ?)",
                                                  (name, txid, nout, sd_hash)))
         return d
@@ -676,8 +676,8 @@ class Wallet(object):
 
     def _update_claimid(self, claim_id, name, txid, nout):
         assert len(txid) == 64, "That's not a txid: %s" % str(txid)
-        d = self.db.runQuery("delete from claim_ids where claimId=? and name=? and txid=?",
-                             (claim_id, name, txid))
+        d = self.db.runQuery("delete from claim_ids where claimId=? and name=? and txid=? and n=?",
+                             (claim_id, name, txid, nout))
         d.addCallback(lambda r: self.db.runQuery("insert into claim_ids values (?, ?, ?, ?)",
                                                  (claim_id, name, txid, nout)))
         d.addCallback(lambda _: claim_id)

--- a/lbrynet/lbryfilemanager/EncryptedFileDownloader.py
+++ b/lbrynet/lbryfilemanager/EncryptedFileDownloader.py
@@ -136,13 +136,14 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
 
             return d
 
-        def _save_claim(name, txid):
+        def _save_claim(name, txid, nout):
             self.uri = name
             self.txid = txid
+            self.nout = nout 
             return defer.succeed(None)
 
         d.addCallback(_save_sd_hash)
-        d.addCallback(lambda r: _save_claim(r[0], r[1]) if r else None)
+        d.addCallback(lambda r: _save_claim(r[0], r[1], r[2]) if r else None)
         d.addCallback(lambda _: self._save_status())
 
         return d

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -667,10 +667,13 @@ class Daemon(jsonrpc.JSONRPC):
         if not self.connected_to_internet:
             self.connection_problem = CONNECTION_PROBLEM_CODES[1]
 
-    def _add_to_pending_claims(self, name, txid, nout):
-        log.info("Adding lbry://%s to pending claims, txid %s nOut %d" % (name, txid, nout))
+    # claim_out is dictionary containing 'txid' and 'nout' 
+    def _add_to_pending_claims(self, name, claim_out):
+        txid = claim_out['txid']
+        nout = claim_out['nout'] 
+        log.info("Adding lbry://%s to pending claims, txid %s nout %d" % (name, txid, nout))
         self.pending_claims[name] = (txid,nout)
-        return txid, nout
+        return claim_out
 
     def _check_pending_claims(self):
         # TODO: this was blatantly copied from jsonrpc_start_lbry_file. Be DRY.
@@ -686,7 +689,8 @@ class Daemon(jsonrpc.JSONRPC):
         def re_add_to_pending_claims(name):
             log.warning("Re-add %s to pending claims", name)
             txid, nout = self.pending_claims.pop(name)
-            self._add_to_pending_claims(name, txid, nout)
+            claim_out = {'txid':txid,'nout':nout} 
+            self._add_to_pending_claims(name, claim_out)
 
         def _process_lbry_file(name, lbry_file):
             # lbry_file is an instance of ManagedEncryptedFileDownloader or None
@@ -1770,6 +1774,9 @@ class Daemon(jsonrpc.JSONRPC):
 
             Args:
                 'name': name to look up, string, do not include lbry:// prefix
+                'txid': optional, if specified, look for claim with this txid
+                'nout': optional, if specified, look for claim with this nout
+ 
             Returns:
                 txid, amount, value, n, height
         """
@@ -1981,7 +1988,12 @@ class Daemon(jsonrpc.JSONRPC):
             'metadata': metadata dictionary
             optional 'fee'
         Returns:
-            Claim txid
+            'success' : True if claim was succesful , False otherwise                            
+            'reason' : if not succesful, give reason
+            'txid' : txid of resulting transaction if succesful
+            'nout' : nout of the resulting support claim if succesful
+            'fee' : fee paid for the claim transaction if succesful
+            'claimid' : claimid of the resulting transaction
         """
 
         def _set_address(address, currency, m):
@@ -1989,10 +2001,10 @@ class Daemon(jsonrpc.JSONRPC):
             m['fee'][currency]['address'] = address
             return m
 
-        def _reflect_if_possible(sd_hash, txid):
+        def _reflect_if_possible(sd_hash, claim_out):
             d = self._get_lbry_file('sd_hash', sd_hash, return_json=False)
             d.addCallback(self._reflect)
-            d.addCallback(lambda _: txid)
+            d.addCallback(lambda _: claim_out)
             return d
 
         name = p['name']
@@ -2039,9 +2051,9 @@ class Daemon(jsonrpc.JSONRPC):
         else:
             d.addCallback(lambda meta: self.session.wallet.claim_name(name, bid, meta))
             if sd_hash:
-                d.addCallback(lambda txid: _reflect_if_possible(sd_hash, txid))
+                d.addCallback(lambda claim_out: _reflect_if_possible(sd_hash, claim_out))
 
-        d.addCallback(lambda txid: self._add_to_pending_claims(name, txid))
+        d.addCallback(lambda claim_out: self._add_to_pending_claims(name, claim_out))
         d.addCallback(lambda r: self._render_response(r, OK_CODE))
 
         return d
@@ -2049,15 +2061,18 @@ class Daemon(jsonrpc.JSONRPC):
     def jsonrpc_abandon_claim(self, p):
         """
         Abandon a name and reclaim credits from the claim
-
         Args:
             'txid': txid of claim, string
+            'nout': nout of claim, integer
         Return:
-            txid
+            success : True if succesful , False otherwise
+            reason : if not succesful, give reason
+            txid : txid of resulting transaction if succesful
+            fee : fee paid for the transaction if succesful 
         """
-
-        if 'txid' in p.keys():
+        if 'txid' in p.keys() and 'nout' in p.keys():
             txid = p['txid']
+            nout = p['nout']
         else:
             return server.failure
 
@@ -2066,7 +2081,7 @@ class Daemon(jsonrpc.JSONRPC):
             return self._render_response(x, OK_CODE)
 
         d = defer.Deferred()
-        d.addCallback(lambda _: self.session.wallet.abandon_name(txid))
+        d.addCallback(lambda _: self.session.wallet.abandon_claim(txid,nout))
         d.addCallback(_disp)
         d.callback(None)
 
@@ -2094,7 +2109,12 @@ class Daemon(jsonrpc.JSONRPC):
             'claim_id': claim id of claim to support
             'amount': amount to support by
         Return:
-            txid
+            success : True if succesful , False otherwise
+            reason : if not succesful, give reason
+            txid : txid of resulting transaction if succesful
+            nout : nout of the resulting support claim if succesful
+            fee : fee paid for the transaction if succesful 
+
         """
 
         name = p['name']

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -40,6 +40,7 @@ class Publisher(object):
         self.verified = False
         self.lbry_file = None
         self.txid = None
+        self.nout = None
         self.stream_hash = None
         reflector_server = random.choice(REFLECTOR_SERVERS)
         self.reflector_server, self.reflector_port = reflector_server[0], reflector_server[1]
@@ -48,8 +49,11 @@ class Publisher(object):
     def start(self, name, file_path, bid, metadata):
         log.info('Starting publish for %s', name)
         def _show_result():
-            log.info("Success! Published %s --> lbry://%s txid: %s", self.file_name, self.publish_name, self.txid)
-            return defer.succeed(self.txid)
+            log.info("Success! Published %s --> lbry://%s txid: %s nout: %d", self.file_name, self.publish_name, self.txid, self.nout)
+            out = {}
+            out['nout'] = self.nout
+            out['txid'] = self.txid 
+            return defer.succeed(out)
 
         self.publish_name = name
         self.file_path = file_path
@@ -132,12 +136,18 @@ class Publisher(object):
         self._update_metadata()
         m = Metadata(self.metadata)
 
-        def set_tx_hash(txid):
-            log.debug('Name claimed using txid: %s', txid)
+        def set_txid_nout(claim_out):
+            if not claim_out['success']:
+                msg = 'Failed to claim name:{}'.format(claim_out['reason'])
+                defer.fail(Exception(msg))
+            txid = claim_out['txid']
+            nout = claim_out['nout'] 
+            log.debug('Name claimed using txid: %s, nout: %d', txid, nout)
             self.txid = txid
+            self.nout = nout 
 
         d = self.wallet.claim_name(self.publish_name, self.bid_amount, m)
-        d.addCallback(set_tx_hash)
+        d.addCallback(set_txid_nout)
         return d
 
     def _update_metadata(self):


### PR DESCRIPTION
Further work on jack's branch add-nout to integrate nout : https://github.com/lbryio/lbry/pull/186 . 

This pull request also integrates unmerged new lbryum claim transaction commands https://github.com/lbryio/lbryum/pull/34 

This patch changes the daemon json rpc commands support_claim, abandon_claim, and publish . As such some changes to lbry-web-ui is probably required. 

This patch will also break lbrycrd support if merged, as it does not have txid + nout support for claim transactions. 

I was able to test the publishing successfully through the web ui and the abandon_claim / support_claim through the cli. But further testing is needed as this is a major change. 