### PR TITLE
Cleanup logging

### DIFF
--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -3,9 +3,11 @@ import os
 import sys
 from appdirs import user_data_dir
 
+
 LINUX = 1
 DARWIN = 2
 WINDOWS = 3
+
 
 if sys.platform.startswith("darwin"):
     platform = DARWIN
@@ -226,6 +228,23 @@ class Config(DefaultSettings):
     @property
     def UI_ADDRESS(self):
         return "http://%s:%i" % (DEFAULT_SETTINGS.API_INTERFACE, self.api_port)
+
+
+def get_data_dir():
+    if sys.platform != "darwin":
+        data_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
+    else:
+        data_dir = user_data_dir("LBRY")
+    if not os.path.isdir(data_dir):
+        os.mkdir(data_dir)
+
+
+def get_log_filename():
+    """Return the log file for this platform.
+
+    Also ensure the containing directory exists
+    """
+    return os.path.join(get_data_dir(), settings.LOG_FILE_NAME)
 
 
 # TODO: don't load the configuration automatically. The configuration

--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -7,7 +7,6 @@ import platform
 import sys
 import traceback
 
-import appdirs
 import base58
 import requests
 from requests_futures.sessions import FuturesSession
@@ -206,25 +205,6 @@ def configure_logging(file_name, console, verbose=None):
         handler = configure_console(level=level)
         if verbose:
             handler.addFilter(LoggerNameFilter(verbose))
-
-
-def get_log_file():
-    """Return the log file for this platform.
-
-    Also ensure the containing directory exists
-    """
-    if sys.platform != "darwin":
-        log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-    else:
-        log_dir = appdirs.user_data_dir("LBRY")
-
-    try:
-        os.mkdir(log_dir)
-    except OSError:
-        pass
-
-    lbrynet_log = os.path.join(log_dir, settings.LOG_FILE_NAME)
-    return lbrynet_log
 
 
 class LoggerNameFilter(object):

--- a/lbrynet/core/utils.py
+++ b/lbrynet/core/utils.py
@@ -6,6 +6,7 @@ import json
 import random
 import os
 import socket
+import sys
 import yaml
 
 from lbrynet.conf import settings
@@ -119,3 +120,9 @@ def check_connection(server="www.lbry.io", port=80):
             "Failed to connect to %s:%s. Maybe the internet connection is not working",
             server, port, exc_info=True)
         return False
+
+
+def setup_certs_for_windows():
+    if getattr(sys, 'frozen', False) and os.name == "nt":
+        cert_path = os.path.join(os.path.dirname(sys.executable), "cacert.pem")
+        os.environ["REQUESTS_CA_BUNDLE"] = cert_path

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -56,26 +56,23 @@ from lbrynet.lbrynet_daemon.ExchangeRateManager import ExchangeRateManager
 from lbrynet.lbrynet_daemon.Lighthouse import LighthouseClient
 from lbrynet.lbrynet_daemon.auth.server import AuthJSONRPCServer
 
+from lbrynet.metadata.Metadata import Metadata, verify_name_characters
+from lbrynet.core import log_support
+from lbrynet.core import utils
+from lbrynet.core.utils import generate_id
+from lbrynet.lbrynet_console.Settings import Settings
 
+from lbrynet.core.StreamDescriptor import StreamDescriptorIdentifier, download_sd_blob, BlobStreamDescriptorReader
+from lbrynet.core.Session import Session
+from lbrynet.core.PTCWallet import PTCWallet
+from lbrynet.core.Wallet import LBRYcrdWallet, LBRYumWallet
+from lbrynet.lbryfilemanager.EncryptedFileManager import EncryptedFileManager
+from lbrynet.lbryfile.EncryptedFileMetadataManager import DBEncryptedFileMetadataManager, TempEncryptedFileMetadataManager
+from lbrynet import reflector
 
-# TODO: this code snippet is everywhere. Make it go away
-if sys.platform != "darwin":
-    log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-else:
-    log_dir = user_data_dir("LBRY")
-
-if not os.path.isdir(log_dir):
-    os.mkdir(log_dir)
-
-lbrynet_log = os.path.join(log_dir, lbrynet_settings.LOG_FILE_NAME)
 
 log = logging.getLogger(__name__)
 
-if os.path.isfile(lbrynet_log):
-    with open(lbrynet_log, 'r') as f:
-        PREVIOUS_NET_LOG = len(f.read())
-else:
-    PREVIOUS_NET_LOG = 0
 
 INITIALIZING_CODE = 'initializing'
 LOADING_DB_CODE = 'loading_db'
@@ -275,12 +272,16 @@ class Daemon(AuthJSONRPCServer):
         self.ui_version = None
         self.ip = None
         self.first_run = None
-        self.log_file = lbrynet_log
+        self.log_file = log_support.get_log_file()
         self.current_db_revision = 1
         self.session = None
         self.first_run_after_update = False
         self.uploaded_temp_files = []
         self._session_id = base58.b58encode(generate_id())
+        # TODO: this should probably be passed into the daemon, or
+        # possibly have the entire log upload functionality taken out
+        # of the daemon, but I don't want to deal with that now
+        self.log_uploader = log_support.LogUploader.load('lbrynet', log_support.get_log_file())
 
         self.analytics_manager = None
         self.lbryid = PENDING_LBRY_ID
@@ -323,7 +324,6 @@ class Daemon(AuthJSONRPCServer):
         self.blob_request_payment_rate_manager = None
         self.lbry_file_metadata_manager = None
         self.lbry_file_manager = None
-
 
     @AuthJSONRPCServer.subhandler
     def _exclude_lbrycrd_only_commands_from_lbryum_session(self, request):
@@ -400,7 +400,6 @@ class Daemon(AuthJSONRPCServer):
         self.exchange_rate_manager.start()
 
         d = defer.Deferred()
-
         if lbrynet_settings.host_ui:
             self.lbry_ui_manager.update_checker.start(1800, now=False)
             d.addCallback(lambda _: self.lbry_ui_manager.setup())
@@ -621,37 +620,20 @@ class Daemon(AuthJSONRPCServer):
 
         ds = []
         for handler in query_handlers:
-            ds.append(self.settings.get_query_handler_status(handler.get_primary_query_identifier()))
+            query_id = handler.get_primary_query_identifier()
+            ds.append(self.settings.get_query_handler_status(query_id))
         dl = defer.DeferredList(ds)
         dl.addCallback(_set_query_handlers)
         return dl
 
     def _upload_log(self, log_type=None, exclude_previous=False, force=False):
         if self.upload_log or force:
-            for lm, lp in [('lbrynet', lbrynet_log)]:
-                if os.path.isfile(lp):
-                    if exclude_previous:
-                        with open( lp, "r") as f:
-                            f.seek(PREVIOUS_NET_LOG)
-                            log_contents = f.read()
-                    else:
-                        with open(lp, "r") as f:
-                            log_contents = f.read()
-                    if self.lbryid is not PENDING_LBRY_ID:
-                        id_hash = base58.b58encode(self.lbryid)[:20]
-                    else:
-                        id_hash = self.lbryid
-                    params = {
-                        'date': datetime.utcnow().strftime('%Y%m%d-%H%M%S'),
-                        'hash': id_hash,
-                        'sys': platform.system(),
-                        'type': "%s-%s" % (lm, log_type) if log_type else lm,
-                        'log': log_contents
-                    }
-                    requests.post(lbrynet_settings.LOG_POST_URL, params)
-            return defer.succeed(None)
-        else:
-            return defer.succeed(None)
+            if self.lbryid is not PENDING_LBRY_ID:
+                id_hash = base58.b58encode(self.lbryid)[:20]
+            else:
+                id_hash = self.lbryid
+            self.log_uploader.upload(exclude_previous, self.lbryid, log_type)
+        return defer.succeed(None)
 
     def _clean_up_temp_files(self):
         for path in self.uploaded_temp_files:
@@ -2187,7 +2169,8 @@ class Daemon(AuthJSONRPCServer):
             check_require = True
 
         if 'path' in p:
-            d = self.lbry_ui_manager.setup(user_specified=p['path'], check_requirements=check_require)
+            d = self.lbry_ui_manager.setup(
+                user_specified=p['path'], check_requirements=check_require)
         elif 'branch' in p:
             d = self.lbry_ui_manager.setup(branch=p['branch'], check_requirements=check_require)
         else:

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -28,6 +28,7 @@ from lbryum.version import LBRYUM_VERSION as lbryum_version
 from lbrynet import __version__ as lbrynet_version
 from lbrynet.conf import settings as lbrynet_settings
 from lbrynet import analytics
+from lbrynet import conf
 from lbrynet import reflector
 from lbrynet.metadata.Metadata import Metadata, verify_name_characters
 from lbrynet.metadata.Fee import FeeValidator

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -272,7 +272,7 @@ class Daemon(AuthJSONRPCServer):
         self.ui_version = None
         self.ip = None
         self.first_run = None
-        self.log_file = log_support.get_log_file()
+        self.log_file = conf.get_log_file()
         self.current_db_revision = 1
         self.session = None
         self.first_run_after_update = False
@@ -281,7 +281,7 @@ class Daemon(AuthJSONRPCServer):
         # TODO: this should probably be passed into the daemon, or
         # possibly have the entire log upload functionality taken out
         # of the daemon, but I don't want to deal with that now
-        self.log_uploader = log_support.LogUploader.load('lbrynet', log_support.get_log_file())
+        self.log_uploader = log_support.LogUploader.load('lbrynet', conf.get_log_file())
 
         self.analytics_manager = None
         self.lbryid = PENDING_LBRY_ID

--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -1,5 +1,6 @@
 import argparse
 import logging.handlers
+import os
 import webbrowser
 
 from twisted.web import server, guard

--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -11,6 +11,7 @@ from jsonrpc.proxy import JSONRPCProxy
 
 from lbrynet.lbrynet_daemon.auth.auth import PasswordChecker, HttpPasswordRealm
 from lbrynet.lbrynet_daemon.auth.util import initialize_api_key_file
+from lbrynet import conf
 from lbrynet.core import log_support
 from lbrynet.core import utils
 from lbrynet.lbrynet_daemon.DaemonServer import DaemonServer
@@ -68,7 +69,7 @@ def start():
     args = parser.parse_args()
 
     utils.setup_certs_for_windows()
-    lbrynet_log = log_support.get_log_file()
+    lbrynet_log = conf.get_log_file()
     log_support.configure_logging(lbrynet_log, args.logtoconsole, args.verbose)
 
     to_pass = {}

--- a/lbrynet/lbrynet_daemon/DaemonServer.py
+++ b/lbrynet/lbrynet_daemon/DaemonServer.py
@@ -1,29 +1,20 @@
 import logging
 import os
-import sys
 
-from appdirs import user_data_dir
 from twisted.internet import defer
+
 from lbrynet.lbrynet_daemon.Daemon import Daemon
 from lbrynet.lbrynet_daemon.Resources import LBRYindex, HostedEncryptedFile, EncryptedFileUpload
 from lbrynet.conf import settings
 
 
-# TODO: omg, this code is essentially duplicated in Daemon
-if sys.platform != "darwin":
-    data_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-else:
-    data_dir = user_data_dir("LBRY")
-if not os.path.isdir(data_dir):
-    os.mkdir(data_dir)
-
-lbrynet_log = os.path.join(data_dir, settings.LOG_FILE_NAME)
 log = logging.getLogger(__name__)
 
 
 class DaemonServer(object):
     def _setup_server(self):
-        self.root = LBRYindex(os.path.join(os.path.join(data_dir, "lbry-ui"), "active"))
+        ui_path = os.path.join(get_data_dir(), "lbry-ui", "active")
+        self.root = LBRYindex(ui_path)
         self._api = Daemon(self.root)
         self.root.putChild("view", HostedEncryptedFile(self._api))
         self.root.putChild("upload", EncryptedFileUpload(self._api))

--- a/lbrynet/lbrynet_daemon/DaemonServer.py
+++ b/lbrynet/lbrynet_daemon/DaemonServer.py
@@ -3,6 +3,7 @@ import os
 
 from twisted.internet import defer
 
+from lbrynet import conf
 from lbrynet.lbrynet_daemon.Daemon import Daemon
 from lbrynet.lbrynet_daemon.Resources import LBRYindex, HostedEncryptedFile, EncryptedFileUpload
 from lbrynet.conf import settings
@@ -13,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class DaemonServer(object):
     def _setup_server(self):
-        ui_path = os.path.join(get_data_dir(), "lbry-ui", "active")
+        ui_path = os.path.join(conf.get_data_dir(), "lbry-ui", "active")
         self.root = LBRYindex(ui_path)
         self._api = Daemon(self.root)
         self.root.putChild("view", HostedEncryptedFile(self._api))

--- a/lbrynet/lbrynet_daemon/Downloader.py
+++ b/lbrynet/lbrynet_daemon/Downloader.py
@@ -1,10 +1,8 @@
 import json
 import logging
 import os
-import sys
 
 from copy import deepcopy
-from appdirs import user_data_dir
 from twisted.internet import defer
 from twisted.internet.task import LoopingCall
 
@@ -20,28 +18,24 @@ DOWNLOAD_TIMEOUT_CODE = 'timeout'
 DOWNLOAD_RUNNING_CODE = 'running'
 DOWNLOAD_STOPPED_CODE = 'stopped'
 STREAM_STAGES = [
-                    (INITIALIZING_CODE, 'Initializing...'),
-                    (DOWNLOAD_METADATA_CODE, 'Downloading metadata'),
-                    (DOWNLOAD_RUNNING_CODE, 'Started stream'),
-                    (DOWNLOAD_STOPPED_CODE, 'Paused stream'),
-                    (DOWNLOAD_TIMEOUT_CODE, 'Stream timed out')
-                ]
+    (INITIALIZING_CODE, 'Initializing...'),
+    (DOWNLOAD_METADATA_CODE, 'Downloading metadata'),
+    (DOWNLOAD_RUNNING_CODE, 'Started stream'),
+    (DOWNLOAD_STOPPED_CODE, 'Paused stream'),
+    (DOWNLOAD_TIMEOUT_CODE, 'Stream timed out')
+]
 
-if sys.platform != "darwin":
-    log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-else:
-    log_dir = user_data_dir("LBRY")
 
-if not os.path.isdir(log_dir):
-    os.mkdir(log_dir)
-
-lbrynet_log = os.path.join(log_dir, settings.LOG_FILE_NAME)
 log = logging.getLogger(__name__)
 
 
 class GetStream(object):
-    def __init__(self, sd_identifier, session, wallet, lbry_file_manager, exchange_rate_manager,
-                 max_key_fee, data_rate=0.5, timeout=settings.download_timeout, download_directory=None, file_name=None):
+    def __init__(self, sd_identifier, session, wallet,
+                 lbry_file_manager, exchange_rate_manager,
+                 max_key_fee, data_rate=0.5, timeout=None,
+                 download_directory=None, file_name=None):
+        if timeout is None:
+            timeout = settings.download_timeout
         self.wallet = wallet
         self.resolved_name = None
         self.description = None

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -1,10 +1,9 @@
 import logging
 import mimetypes
 import os
-import sys
 import random
 
-from appdirs import user_data_dir
+from twisted.internet import threads, defer, reactor
 
 from lbrynet.core.Error import InsufficientFundsError
 from lbrynet.lbryfilemanager.EncryptedFileCreator import create_lbry_file
@@ -13,17 +12,8 @@ from lbrynet.metadata.Metadata import Metadata
 from lbrynet.lbryfilemanager.EncryptedFileDownloader import ManagedEncryptedFileDownloader
 from lbrynet import reflector
 from lbrynet.conf import settings
-from twisted.internet import threads, defer, reactor
 
-if sys.platform != "darwin":
-    log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-else:
-    log_dir = user_data_dir("LBRY")
 
-if not os.path.isdir(log_dir):
-    os.mkdir(log_dir)
-
-lbrynet_log = os.path.join(log_dir, settings.LOG_FILE_NAME)
 log = logging.getLogger(__name__)
 
 

--- a/lbrynet/lbrynet_daemon/UIManager.py
+++ b/lbrynet/lbrynet_daemon/UIManager.py
@@ -15,15 +15,7 @@ from lbryum.version import LBRYUM_VERSION as lbryum_version
 from zipfile import ZipFile
 from appdirs import user_data_dir
 
-if sys.platform != "darwin":
-    log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-else:
-    log_dir = user_data_dir("LBRY")
 
-if not os.path.isdir(log_dir):
-    os.mkdir(log_dir)
-
-lbrynet_log = os.path.join(log_dir, settings.LOG_FILE_NAME)
 log = logging.getLogger(__name__)
 
 

--- a/packaging/osx/lbry-osx-app/lbrygui/main.py
+++ b/packaging/osx/lbry-osx-app/lbrygui/main.py
@@ -4,32 +4,22 @@ install(runner=AppHelper.runEventLoop)
 from twisted.internet import reactor
 
 import logging
-import sys
-import os
-from appdirs import user_data_dir
 
+from lbrynet import conf
+from lbrynet.core import log_support
 from LBRYApp import LBRYDaemonApp
 
-if sys.platform != "darwin":
-    log_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-else:
-    log_dir = user_data_dir("LBRY")
 
-if not os.path.isdir(log_dir):
-    os.mkdir(log_dir)
-
-LOG_FILENAME = os.path.join(log_dir, 'lbrynet-daemon.log')
-
-log = logging.getLogger(__name__)
-handler = logging.handlers.RotatingFileHandler(LOG_FILENAME, maxBytes=2097152, backupCount=5)
-log.addHandler(handler)
-logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()
 
 
 def main():
+    log_file = conf.get_log_filename()
+    log_support.configure_logging(log_file, console=False)
     app = LBRYDaemonApp.sharedApplication()
     reactor.addSystemEventTrigger("after", "shutdown", AppHelper.stopEventLoop)
     reactor.run()
+
 
 if __name__ == "__main__":
     main()

--- a/packaging/windows/lbry-win32-app/LBRYWin32App.py
+++ b/packaging/windows/lbry-win32-app/LBRYWin32App.py
@@ -25,16 +25,7 @@ from lbrynet.conf import settings
 from packaging.uri_handler.LBRYURIHandler import LBRYURIHandler
 
 
-# TODO: omg, this code is essentially duplicated in LBRYDaemon
-data_dir = os.path.join(os.path.expanduser("~"), ".lbrynet")
-if not os.path.isdir(data_dir):
-    os.mkdir(data_dir)
-
-lbrynet_log = os.path.join(data_dir, settings.LOG_FILE_NAME)
 log = logging.getLogger(__name__)
-
-if getattr(sys, 'frozen', False) and os.name == "nt":
-    os.environ["REQUESTS_CA_BUNDLE"] = os.path.join(os.path.dirname(sys.executable), "cacert.pem")
 
 
 def test_internet_connection():
@@ -290,7 +281,9 @@ def main(lbry_name=None):
         sys.exit(1)
     reactor.run()
 
+
 if __name__ == '__main__':
+    utils.setup_certs_for_windows()
     lbry_daemon = JSONRPCProxy.from_url(settings.API_CONNECTION_STRING)
 
     try:

--- a/packaging/windows/lbry-win32-app/LBRYWin32App.py
+++ b/packaging/windows/lbry-win32-app/LBRYWin32App.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import socket
 import sys
 import threading
 import webbrowser
@@ -11,13 +10,14 @@ import win32gui_struct
 from jsonrpc.proxy import JSONRPCProxy
 from twisted.internet import reactor, error
 from twisted.web import server
-import twisted
 
 try:
     import winxpgui as win32gui
 except ImportError:
     import win32gui
 
+from lbrynet import conf
+from lbrynet.core import log_support
 from lbrynet.core import utils
 from lbrynet.lbrynet_daemon.DaemonServer import DaemonServer
 from lbrynet.lbrynet_daemon.DaemonRequest import DaemonRequest
@@ -284,6 +284,8 @@ def main(lbry_name=None):
 
 if __name__ == '__main__':
     utils.setup_certs_for_windows()
+    log_file = conf.get_log_filename()
+    log_support.configure_logging(log_file, console=False)
     lbry_daemon = JSONRPCProxy.from_url(settings.API_CONNECTION_STRING)
 
     try:


### PR DESCRIPTION
 - Make the logging across the OSX app, the windows app and the CLI consistent.
 - Remove the repeated code for setting up the log file
    - Moved logic for log file upload into its own class
 - change the logic for the `--verbose` flag:
   - if no arguments are specified after `--verbose`, set all `lbrynet` loggers to debug
   - if arguments are specified after `--verbose` only set those loggers to debug

The idea with the --verbose flag is that we will be able set the modules that we're working on to be at the debug level.