### PR TITLE
Use better json formatting

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1034,7 +1034,6 @@ class Daemon(jsonrpc.JSONRPC):
             session_id=self._session_id
         )
 
-
     def _setup_lbry_file_manager(self):
         self.startup_status = STARTUP_STAGES[3]
         self.lbry_file_metadata_manager = DBEncryptedFileMetadataManager(self.db_dir)


### PR DESCRIPTION
Apply json.dumps at the end of the formatting process instead of the
middle.  This allows for proper escaping of quotes and allows for
actual json to be emitted.

Tracebacks in loggly aren't being parsed because of this mistake.  This should allow for more robust filtering.