### PR TITLE
set lbryum to log at warning level

### DIFF
--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -90,6 +90,7 @@ def disable_third_party_loggers():
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
     logging.getLogger('BitcoinRPC').setLevel(logging.INFO)
+    logging.getLogger('lbryum').setLevel(logging.WARNING)
 
 
 @_log_decorator


### PR DESCRIPTION
lbryum is very chatty at the info level. As a rough estimate a bit
over half of our logs in loggly are a result of lbryum.

The better, long-term, solution would be to modify lbryum to move more
logs to the debug level.