### PR TITLE
Better error detection in Wallet for invalid streams

### DIFF
--- a/lbrynet/core/Error.py
+++ b/lbrynet/core/Error.py
@@ -53,11 +53,12 @@ class InvalidStreamDescriptorError(Exception):
 
 
 class InvalidStreamInfoError(Exception):
-    def __init__(self, name):
+    def __init__(self, name, stream_info):
         self.name = name
+        self.stream_info = stream_info
 
     def __str__(self):
-        return repr(self.name)
+        return '{} has claim with invalid stream info: {}'.format(self.name,self.stream_info)
 
 
 class MisbehavingPeerError(Exception):

--- a/lbrynet/core/Error.py
+++ b/lbrynet/core/Error.py
@@ -54,11 +54,10 @@ class InvalidStreamDescriptorError(Exception):
 
 class InvalidStreamInfoError(Exception):
     def __init__(self, name, stream_info):
+        msg = '{} has claim with invalid stream info: {}'.format(name,  stream_info)
+        Exception.__init__(self, msg)
         self.name = name
         self.stream_info = stream_info
-
-    def __str__(self):
-        return '{} has claim with invalid stream info: {}'.format(self.name,self.stream_info)
 
 
 class MisbehavingPeerError(Exception):

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -344,7 +344,7 @@ class Wallet(object):
  
         try:
             metadata = Metadata(json.loads(result['value'])) 
-        except (TypeError,ValueError,ValidationError):
+        except (TypeError, ValueError, ValidationError):
             return Failure(InvalidStreamInfoError(name,result['value']))          
   
         txid = result['txid']
@@ -427,7 +427,7 @@ class Wallet(object):
                 meta_ver = metadata.version
                 sd_hash = metadata['sources']['lbry_sd_hash']
                 d = self._save_name_metadata(name, txid, sd_hash)
-            except (TypeError,ValueError,ValidationError):
+            except (TypeError, ValueError, ValidationError):
                 metadata = claim['value']
                 meta_ver = "Non-compliant"
                 d = defer.succeed(None)

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -331,22 +331,22 @@ class Wallet(object):
         def _check_result_fields(r):
             for k in ['value', 'txid', 'n', 'height', 'amount']:
                 assert k in r, "getvalueforname response missing field %s" % k
-
+ 
         def _log_success(claim_id):
             log.info("lbry://%s complies with %s, claimid: %s", name, metadata.version, claim_id)
             return defer.succeed(None)
-
+ 
         if 'error' in result:
             log.warning("Got an error looking up a name: %s", result['error'])
             return Failure(UnknownNameError(name))
 
         _check_result_fields(result)
-
+ 
         try:
-            metadata = Metadata(json.loads(result['value']))
-        except ValidationError:
-            return Failure(InvalidStreamInfoError(name))
-
+            metadata = Metadata(json.loads(result['value'])) 
+        except (TypeError,ValueError,ValidationError):
+            return Failure(InvalidStreamInfoError(name,result['value']))          
+  
         txid = result['txid']
         sd_hash = metadata['sources']['lbry_sd_hash']
         d = self._save_name_metadata(name, txid, sd_hash)
@@ -427,7 +427,7 @@ class Wallet(object):
                 meta_ver = metadata.version
                 sd_hash = metadata['sources']['lbry_sd_hash']
                 d = self._save_name_metadata(name, txid, sd_hash)
-            except ValidationError:
+            except (TypeError,ValueError,ValidationError):
                 metadata = claim['value']
                 meta_ver = "Non-compliant"
                 d = defer.succeed(None)

--- a/lbrynet/lbrynet_console/ControlHandlers.py
+++ b/lbrynet/lbrynet_console/ControlHandlers.py
@@ -900,7 +900,7 @@ class AddStreamFromLBRYcrdName(AddStreamFromHash):
     def _resolve_name(self, name):
         def get_name_from_info(stream_info):
             if 'stream_hash' not in stream_info:
-                raise InvalidStreamInfoError(name,stream_info)
+                raise InvalidStreamInfoError(name, stream_info)
             self.resolved_name = stream_info.get('name', None)
             self.description = stream_info.get('description', None)
             try:

--- a/lbrynet/lbrynet_console/ControlHandlers.py
+++ b/lbrynet/lbrynet_console/ControlHandlers.py
@@ -900,7 +900,7 @@ class AddStreamFromLBRYcrdName(AddStreamFromHash):
     def _resolve_name(self, name):
         def get_name_from_info(stream_info):
             if 'stream_hash' not in stream_info:
-                raise InvalidStreamInfoError(name)
+                raise InvalidStreamInfoError(name,stream_info)
             self.resolved_name = stream_info.get('name', None)
             self.description = stream_info.get('description', None)
             try:

--- a/lbrynet/metadata/Metadata.py
+++ b/lbrynet/metadata/Metadata.py
@@ -33,6 +33,8 @@ class Metadata(StructuredDict):
     ]
 
     def __init__(self, metadata, migrate=True, target_version=None):
+        if not isinstance(metadata,dict):
+            raise TypeError("metadata is not a dictionary") 
         starting_version = metadata.get('ver', '0.0.1')
 
         StructuredDict.__init__(self, metadata, starting_version, migrate, target_version)


### PR DESCRIPTION
_get_stream_info_from_value and _get_claim_info function in Wallet could fail with uninformative exceptions in the case where the value of a claim is not a json dictionary, or is not a json string. 

Have Metadata class detect when it is fed an non dictionary item as metadata and throw a TyepError exception.  

Catch  TypeError exceptions from Metadata and ValueError exceptions from failed json.loads('...') calls. 

Change InvalidStreamInfoError to contain the stream info. 
