### PR TITLE
More robustly stop the reactor

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -225,10 +225,12 @@ class Daemon(AuthJSONRPCServer):
         AuthJSONRPCServer.__init__(self, lbrynet_settings.use_auth_http)
         reactor.addSystemEventTrigger('before', 'shutdown', self._shutdown)
 
-        self.allowed_during_startup = ['is_running', 'is_first_run',
-                                       'get_time_behind_blockchain', 'stop',
-                                       'daemon_status', 'get_start_notice',
-                                       'version', 'get_search_servers']
+        self.allowed_during_startup = [
+            'is_running', 'is_first_run',
+            'get_time_behind_blockchain', 'stop',
+            'daemon_status', 'get_start_notice',
+            'version', 'get_search_servers'
+        ]
         last_version = {'last_version': {'lbrynet': lbrynet_version, 'lbryum': lbryum_version}}
         lbrynet_settings.update(last_version)
         self.db_dir = lbrynet_settings.data_dir

--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -121,7 +121,7 @@ def update_settings_from_args(args):
 
 def log_and_kill(failure):
     log_support.failure(failure, log, 'Failed to startup: %s')
-    reactor.stop()
+    reactor.callFromThread(reactor.stop)
 
 
 def start_server_and_listen(launchui, use_auth):
@@ -133,12 +133,12 @@ def start_server_and_listen(launchui, use_auth):
         kwargs: passed along to `DaemonServer().start()`
     """
     lbry = DaemonServer()
-
     d = lbry.start()
     d.addCallback(lambda _: listen(lbry, use_auth))
     if launchui:
         d.addCallback(lambda _: webbrowser.open(settings.UI_ADDRESS))
     d.addErrback(log_and_kill)
+
 
 def listen(lbry, use_auth):
     site_base = get_site_base(use_auth, lbry.root)


### PR DESCRIPTION
Was getting a "cannot stop a reactor that isn't running error"
when playing around with error handling on startup.

Following the suggestion from http://stackoverflow.com/a/36738480
it seems to work better