### PR TITLE
Update right after making claim will fail due to get_my_claim()

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -378,7 +378,7 @@ class Wallet(object):
 
         def _get_my_unspent_claim(claims):
             for claim in claims:
-                if claim['name'] == name and not claim['is spent'] and not claim.get('supported_claimid'):
+                if claim['name'] == name and not claim['is spent'] and not claim.get('supported_claimid',False):
                     return claim
             return False
 

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -370,18 +370,11 @@ class Wallet(object):
         return d
 
     def get_my_claim(self, name):
-        def _convert_units(claim):
-            amount = Decimal(claim['nEffectiveAmount'] / COIN)
-            claim['nEffectiveAmount'] = amount
-            return claim
-
         def _get_claim_for_return(claim):
             if not claim:
                 return False
-            d = self.get_claim(name, claim['claim_id'])
-            d.addCallback(_convert_units)
-            d.addCallback(lambda clm: self._format_claim_for_return(name, clm, claim['txid']))
-            return d
+            claim['value'] = json.loads(claim['value'])
+            return claim 
 
         def _get_my_unspent_claim(claims):
             for claim in claims:


### PR DESCRIPTION
get_my_claim command will not work if you attempt to look for a name immediately after making a claim. Thus attempting to update right after making a claim will not work. 

This is because after obtaining claimed names from lbryum wallet, get_my_claim() attempts to format it using the command get_claim() which triggers a call for lbryum to query lbrycrdd (the blockchain) for claims.  A claim that exists in the wallet, will not necessarily exist in the blockchain yet. 

This will be an interface change for the lbrynet-cli command get_my_claim() , (it seems that no other lbry component is currently using this command).

In the future, we need to further reconsider this function as someone could make multiple claims for a single name, and get_my_claim() only returns the first claim it sees that is not spent. Also it is somewhat redundant with the command get_name_claims() which returns all claims made by the user. ( Could be changed to get_name_claims(name) ) 