### PR TITLE
Fix deferred for loading user-specified UIs

### DIFF
--- a/lbrynet/lbrynet_daemon/UIManager.py
+++ b/lbrynet/lbrynet_daemon/UIManager.py
@@ -80,7 +80,7 @@ class UIManager(object):
                 log.info("User specified UI directory doesn't exist, using " + self.branch)
         elif self.loaded_branch == "user-specified":
             log.info("Loading user provided UI")
-            d = defer.maybeDeferred(self._load_ui())
+            d = defer.maybeDeferred(self._load_ui)
             return d
         else:
             log.info("Checking for updates for UI branch: " + self.branch)


### PR DESCRIPTION
In UIManager, pass self._load_ui into deferred as function object instead of calling immediately
