### PR TITLE
Add release candidates to bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,8 +2,16 @@
 current_version = 0.7.5
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-?(?P<release>[a-z]+)(?P<candidate>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}{candidate}
+	{major}.{minor}.{patch}
 
 [bumpversion:file:lbrynet/__init__.py]
-
 [bumpversion:file:packaging/ubuntu/lbry.desktop]
 
+[bumpversion:part:release]
+optional_value = production
+values = 
+	rc
+	production


### PR DESCRIPTION
The release process now looks like:
starting version: 0.7.5
bumpversion patch -> 0.7.6-rc0
bumpversion candidate -> 0.7.6-rc1
bumpversion release -> 0.7.6