### PR TITLE
Restore reactor.iterate in dht shutdown

### DIFF
--- a/lbrynet/dht/protocol.py
+++ b/lbrynet/dht/protocol.py
@@ -321,3 +321,7 @@ class KademliaProtocol(protocol.DatagramProtocol):
             except Exception, e:
                 log.exception('Failed to cancel %s', self._callLaterList[key])
             del self._callLaterList[key]
+            # not sure why this is needed, but taking this out sometimes causes
+            # exceptions.AttributeError: 'Port' object has no attribute 'socket'
+            # to happen on shutdown
+            reactor.iterate()


### PR DESCRIPTION
This reverts the change made in 693fef1964e281eaf7b39f9bd9f5728406942a14

Not sure why this is needed, but taking this out sometimes causes
`exceptions.AttributeError: 'Port' object has no attribute 'socket'`
to happen on shutdown.