### PR TITLE
Normalize python version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 0.7.6-rc0
+current_version = 0.7.6rc0
 commit = True
 tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-?(?P<release>[a-z]+)(?P<candidate>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<candidate>\d+))?
 serialize = 
-	{major}.{minor}.{patch}-{release}{candidate}
+	{major}.{minor}.{patch}{release}{candidate}
 	{major}.{minor}.{patch}
 
 [bumpversion:file:lbrynet/__init__.py]

--- a/lbrynet/__init__.py
+++ b/lbrynet/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.7.6-rc0"
+__version__ = "0.7.6rc0"
 version = tuple(__version__.split('.'))
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/packaging/ubuntu/lbry.desktop
+++ b/packaging/ubuntu/lbry.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.7.6-rc0
+Version=0.7.6rc0
 Name=LBRY
 Comment=The world's first user-owned content marketplace
 Icon=lbry


### PR DESCRIPTION
setuptools will force a version to be 'normalized'
which means that it removes the dash.

This will probably cause some weirdness on the version
numbers in the windows build; might have to re-work
my patches on cx_freeze: https://bitbucket.org/jobevers/cx_freeze/commits/all