### PR TITLE
Give priority to arguments over settings in UIManager.setup()

### DIFF
--- a/lbrynet/lbrynet_daemon/UIManager.py
+++ b/lbrynet/lbrynet_daemon/UIManager.py
@@ -61,10 +61,9 @@ class UIManager(object):
                 self.loaded_requirements = None
 
     def setup(self, branch=None, check_requirements=None, user_specified=None):
-        local_ui_path = (user_specified if user_specified is not None
-                         else settings.local_ui_path)
-        self.branch = branch if branch is not None else settings.ui_branch
+        local_ui_path = user_specified or settings.local_ui_path
 
+        self.branch = branch or settings.ui_branch
         self.check_requirements = (check_requirements if check_requirements is not None
                                    else settings.check_ui_requirements)
 

--- a/lbrynet/lbrynet_daemon/UIManager.py
+++ b/lbrynet/lbrynet_daemon/UIManager.py
@@ -61,9 +61,12 @@ class UIManager(object):
                 self.loaded_requirements = None
 
     def setup(self, branch=None, check_requirements=None, user_specified=None):
-        local_ui_path = settings.local_ui_path or user_specified
-        self.branch = settings.ui_branch or branch
-        self.check_requirements = settings.check_ui_requirements or check_requirements
+        local_ui_path = (user_specified if user_specified is not None
+                         else settings.local_ui_path)
+        self.branch = branch if branch is not None else settings.ui_branch
+
+        self.check_requirements = (check_requirements if check_requirements is not None
+                                   else settings.check_ui_requirements)
 
         if self._check_for_bundled_ui():
             return defer.succeed(True)


### PR DESCRIPTION
Currently, certain options passed in through the API, like `check_requirements: true`, will sometimes be overridden by settings. This PR fixes that.