### PR TITLE
Force auto connect to be on for lbryum

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -1125,6 +1125,7 @@ class LBRYumWallet(Wallet):
 
         def setup_network():
             self.config = make_config(self._config)
+            self.config.set_key('auto_connect',True)
             self.network = Network(self.config)
             alert.info("Loading the wallet...")
             return defer.succeed(self.network.start())


### PR DESCRIPTION
This will force auto connect to be on for lbryum when using lbry. 

Auto connect allows lbryum wallet to connect to a functioning server if the default is down, and reconnect if a connection dies. 

This should fix lbryum wallet startup being slow in some instances. 

Goes with merged lbryum patch https://github.com/lbryio/lbryum/pull/52 