### PR TITLE
Allow 0.0.0.0 for api interface

### DIFF
--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -170,7 +170,12 @@ ENVIRONMENT = Env(
     #
     # TODO: writing json on the cmd line is a pain, come up with a nicer
     # parser for this data structure. (maybe MAX_KEY_FEE=USD:25
-    max_key_fee=(json.loads, {'USD': {'amount': 25.0, 'address': ''}})
+    max_key_fee=(json.loads, {'USD': {'amount': 25.0, 'address': ''}}),
+    # Changing this value is not-advised as it could potentially
+    # expose the lbrynet daemon to the outside world which would
+    # give an attacker access to your wallet and you could lose
+    # all of your credits.
+    API_INTERFACE=(str, "localhost"),
 )
 
 
@@ -205,7 +210,6 @@ class ApplicationSettings(Settings):
         self.LOG_FILE_NAME = "lbrynet.log"
         self.LOG_POST_URL = "https://lbry.io/log-upload"        
         self.CRYPTSD_FILE_EXTENSION = ".cryptsd"
-        self.API_INTERFACE = "localhost"
         self.API_ADDRESS = "lbryapi"
         self.ICON_PATH = "icons" if platform is WINDOWS else "app.icns"
         self.APP_NAME = "LBRY"

--- a/tests/unit/lbrynet_daemon/auth/test_server.py
+++ b/tests/unit/lbrynet_daemon/auth/test_server.py
@@ -1,0 +1,61 @@
+import mock
+import requests
+from twisted.trial import unittest
+
+from lbrynet import conf
+from lbrynet.lbrynet_daemon.auth import server
+
+
+class AuthJSONRPCServerTest(unittest.TestCase):
+    # TODO: move to using a base class for tests
+    # and add useful general utilities like this
+    # onto it.
+    def setUp(self):
+        self.server = server.AuthJSONRPCServer(False)
+
+    def _set_setting(self, attr, value):
+        original = getattr(conf.settings, attr)
+        setattr(conf.settings, attr, value)
+        self.addCleanup(lambda: setattr(conf.settings, attr, original))
+
+    def test_get_server_port(self):
+        self.assertSequenceEqual(
+            ('example.com', 80), self.server.get_server_port('http://example.com'))
+        self.assertSequenceEqual(
+            ('example.com', 1234), self.server.get_server_port('http://example.com:1234'))
+
+    def test_foreign_origin_is_rejected(self):
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://example.com')
+        self.assertFalse(self.server._check_header_source(request, 'Origin'))
+
+    def test_wrong_port_is_rejected(self):
+        self._set_setting('api_port', 1234)
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://localhost:9999')
+        self.assertFalse(self.server._check_header_source(request, 'Origin'))
+
+    def test_matching_origin_is_allowed(self):
+        self._set_setting('API_INTERFACE', 'example.com')
+        self._set_setting('api_port', 1234)
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://example.com:1234')
+        self.assertTrue(self.server._check_header_source(request, 'Origin'))
+
+    def test_any_origin_is_allowed(self):
+        self._set_setting('API_INTERFACE', '0.0.0.0')
+        self._set_setting('api_port', 80)
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://example.com')
+        self.assertTrue(self.server._check_header_source(request, 'Origin'))
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://another-example.com')
+        self.assertTrue(self.server._check_header_source(request, 'Origin'))
+
+    def test_matching_referer_is_allowed(self):
+        self._set_setting('API_INTERFACE', 'the_api')
+        self._set_setting('api_port', 1111)
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://the_api:1111?settings')
+        self.assertTrue(self.server._check_header_source(request, 'Referer'))
+        request.getHeader.assert_called_with('Referer')


### PR DESCRIPTION
For a host to be able to access the daemon running inside a docker
container the damon needs to be listening to 0.0.0.0