### PR TITLE
Allow Access-Control-Allow-Origin to be configurable

### DIFF
--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -104,7 +104,7 @@ def add_env_settings_to_dict(settings_dict):
     return settings_dict
 
 
-class Setting(object):
+class Settings(object):
     """A collection of configuration settings"""
     __fixed = []
     __excluded = ['get_dict', 'update']
@@ -139,7 +139,7 @@ class Setting(object):
                 pass
 
 
-class AdjustableSettings(Setting):
+class AdjustableSettings(Settings):
     """Settings that are allowed to be overriden by the user"""
     def __init__(self):
         self.is_generous_host = True
@@ -186,9 +186,10 @@ class AdjustableSettings(Setting):
         self.use_auth_http = False
         self.sd_download_timeout = 3
         self.max_key_fee = {'USD': {'amount': 25.0, 'address': ''}}
+        Settings.__init__(self)
 
 
-class ApplicationSettings(Setting):
+class ApplicationSettings(Settings):
     """Settings that are constants and shouldn't be overriden"""
     def __init__(self):
         self.MAX_HANDSHAKE_SIZE = 64*KB
@@ -216,6 +217,7 @@ class ApplicationSettings(Setting):
         self.LOGGLY_TOKEN = 'LJEzATH4AzRgAwxjAP00LwZ2YGx3MwVgZTMuBQZ3MQuxLmOv'
         self.ANALYTICS_ENDPOINT = 'https://api.segment.io/v1'
         self.ANALYTICS_TOKEN = 'Ax5LZzR1o3q3Z3WjATASDwR5rKyHH0qOIRIbLmMXn2H='
+        Settings.__init__(self)
 
 
 APPLICATION_SETTINGS = AdjustableSettings()

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -163,7 +163,11 @@ ENVIRONMENT = Env(
     lbryum_wallet_dir=(str, default_lbryum_dir),
     use_auth_http=(bool, False),
     sd_download_timeout=(int, 3),
-    # TODO: document what the 'address' field is used for
+    # TODO: this field is more complicated than it needs to be because
+    # it goes through a Fee validator when loaded by the exchange rate
+    # manager.  Look into refactoring the exchange rate conversion to
+    # take in a simpler form.
+    #
     # TODO: writing json on the cmd line is a pain, come up with a nicer
     # parser for this data structure. (maybe MAX_KEY_FEE=USD:25
     max_key_fee=(json.loads, {'USD': {'amount': 25.0, 'address': ''}})

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -52,6 +52,8 @@ def convert_setting(env_val, current_val):
 
 
 def _convert_setting(env_val, current_val):
+    if isinstance(env_val, basestring):
+        return json.loads(env_val)
     new_type = env_val.__class__
     current_type = current_val.__class__
     if current_type is bool:

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -163,6 +163,12 @@ ENVIRONMENT = Env(
     lbryum_wallet_dir=(str, default_lbryum_dir),
     use_auth_http=(bool, False),
     sd_download_timeout=(int, 3),
+    # By default, daemon will block all cross origin requests
+    # but if this is set, this value will be used for the
+    # Access-Control-Allow-Origin. For example
+    # set to '*' to allow all requests, or set to 'http://localhost:8080'
+    # if you're running a test UI on that port
+    allowed_origin=(str, ''),
     # TODO: this field is more complicated than it needs to be because
     # it goes through a Fee validator when loaded by the exchange rate
     # manager.  Look into refactoring the exchange rate conversion to
@@ -170,7 +176,7 @@ ENVIRONMENT = Env(
     #
     # TODO: writing json on the cmd line is a pain, come up with a nicer
     # parser for this data structure. (maybe MAX_KEY_FEE=USD:25
-    max_key_fee=(json.loads, {'USD': {'amount': 25.0, 'address': ''}})
+    max_key_fee=(json.loads, {'USD': {'amount': 25.0, 'address': ''}}),
 )
 
 

--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -76,7 +76,7 @@ def start():
 
     lbrynet_log = settings.get_log_filename()
     log_support.configure_logging(lbrynet_log, args.logtoconsole, args.verbose)
-    log.debug('Final Settings: %s', settings.__dict__)
+    log.debug('Final Settings: %s', settings.get_dict())
 
     try:
         log.debug('Checking for an existing lbrynet daemon instance')

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -178,7 +178,8 @@ class AuthJSONRPCServer(AuthorizedBase):
         log.debug(err.getTraceback())
 
     def _set_headers(self, request, data, update_secret=False):
-        request.setHeader("Access-Control-Allow-Origin", settings.API_INTERFACE)
+        if settings.allowed_origin:
+            request.setHeader("Access-Control-Allow-Origin", settings.allowed_origin)
         request.setHeader("Content-Type", "text/json")
         request.setHeader("Content-Length", str(len(data)))
         if update_secret:

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -1,4 +1,5 @@
 import logging
+import urlparse
 
 from decimal import Decimal
 from zope.interface import implements
@@ -189,15 +190,38 @@ class AuthJSONRPCServer(AuthorizedBase):
         request.finish()
 
     def _check_headers(self, request):
+        return self._check_origin(request) and self._check_referer(request)
+
+    def _check_origin(self, request):
         origin = request.getHeader("Origin")
-        referer = request.getHeader("Referer")
-        if origin not in [None, settings.ORIGIN]:
-            log.warning("Attempted api call from %s", origin)
-            return False
-        if referer is not None and not referer.startswith(settings.REFERER):
-            log.warning("Attempted api call from %s", referer)
+        if not self._check_source_of_request(origin):
+            log.warning("Attempted api call from invalid origin: %s", origin)
             return False
         return True
+
+    def _check_source_of_request(self, source):
+        if source is None:
+            return True
+        if settings.API_INTERFACE == '0.0.0.0':
+            return True
+        server, port = self.get_server_port(source)
+        return server == settings.API_INTERFACE
+
+    def _check_referer(self, request):
+        referer = request.getHeader("Referer")
+        if not self._check_source_of_request(referer):
+            log.warning("Attempted api call from invalid referer %s", referer)
+            return False
+        return True
+
+    def get_server_port(self, origin):
+        parsed = urlparse.urlparse(origin)
+        server_port = parsed.netloc.split(':')
+        assert len(server_port) <= 2
+        if len(server_port) == 2:
+            return server_port[0], int(server_port[1])
+        else:
+            return server_port[0], 80
 
     def _check_function_path(self, function_path):
         if function_path not in self.callable_methods:

--- a/packaging/windows/init.ps1
+++ b/packaging/windows/init.ps1
@@ -55,6 +55,7 @@ C:\Python27\Scripts\pip.exe install colorama==0.3.7
 C:\Python27\Scripts\pip.exe install dnspython==1.12.0
 
 C:\Python27\Scripts\pip.exe install ecdsa==0.13
+C:\Python27\Scripts\pip.exe install envparse==0.2.0
 
 C:\Python27\Scripts\pip.exe install jsonrpc==1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ argparse==1.2.1
 colorama==0.3.7
 dnspython==1.12.0
 ecdsa==0.13
+envparse==0.2.0
 gmpy==1.17
 jsonrpc==1.2
 jsonrpclib==0.1.7

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ requires = [
     'base58',
     'googlefinance',
     'requests_futures',
-    'PyYAML'
+    'PyYAML',
+    'envparse'
 ]
 
 console_scripts = [
@@ -251,6 +252,7 @@ elif platform == WINDOWS:
                      'cx_Freeze',
                      'dns',
                      'ecdsa',
+                     'envparse',
                      'gmpy',
                      'googlefinance',
                      'jsonrpc',

--- a/tests/unit/lbrynet_daemon/auth/test_server.py
+++ b/tests/unit/lbrynet_daemon/auth/test_server.py
@@ -1,0 +1,45 @@
+import mock
+import requests
+from twisted.trial import unittest
+
+from lbrynet import conf
+from lbrynet.lbrynet_daemon.auth import server
+
+
+class AuthJSONRPCServerTest(unittest.TestCase):
+    # TODO: move to using a base class for tests
+    # and add useful general utilities like this
+    # onto it.
+    def setUp(self):
+        self.server = server.AuthJSONRPCServer(False)
+
+    def _set_setting(self, attr, value):
+        original = getattr(conf.settings, attr)
+        setattr(conf.settings, attr, value)
+        self.addCleanup(lambda: setattr(conf.settings, attr, original))
+
+    def test_get_server_port(self):
+        self.assertSequenceEqual(
+            ('example.com', 80), self.server.get_server_port('http://example.com'))
+        self.assertSequenceEqual(
+            ('example.com', 1234), self.server.get_server_port('http://example.com:1234'))
+
+    def test_foreign_origin_is_rejected(self):
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://example.com')
+        self.assertFalse(self.server._check_origin(request))
+
+    def test_matching_origin_is_allowed(self):
+        self._set_setting('API_INTERFACE', 'example.com')
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://example.com')
+        self.assertTrue(self.server._check_origin(request))
+
+    def test_any_origin_is_allowed(self):
+        self._set_setting('API_INTERFACE', '0.0.0.0')
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://example.com')
+        self.assertTrue(self.server._check_origin(request))
+        request = mock.Mock(['getHeader'])
+        request.getHeader = mock.Mock(return_value='http://another-example.com')
+        self.assertTrue(self.server._check_origin(request))


### PR DESCRIPTION
Being able to make requests from a different port then 5279 is useful - for example it enables somebody to setup a different server for the UI, say one that supports hot-reloading, and still access the jsonrpc.