### PR TITLE
Attempt to fix analytics badstatusline error

### DIFF
--- a/lbrynet/analytics/api.py
+++ b/lbrynet/analytics/api.py
@@ -37,6 +37,21 @@ class Api(object):
         self.url = url
         self.write_key = write_key
 
+    def post(self, endpoint, data):
+        # there is an issue with a timing condition with keep-alive
+        # that is best explained here: https://github.com/mikem23/keepalive-race
+        #
+        #   If you make a request, wait just the right amount of time,
+        #   then make another request, the requests module may opt to
+        #   reuse the connection, but by the time the server gets it the
+        #   timeout will have expired.
+        #
+        # by forcing the connection to close, we will disable the keep-alive.
+        assert endpoint[0] == '/'
+        headers = {"Connection": "close"}
+        return self.session.post(
+            self.url + endpoint, json=data, auth=self.auth, headers=headers)
+
     @property
     def auth(self):
         return auth.HTTPBasicAuth(self.write_key, '')
@@ -53,13 +68,13 @@ class Api(object):
         })
         log.debug('sending %s events', len(events))
         log.debug('Data: %s', data)
-        return self.session.post(self.url + '/batch', json=data, auth=self.auth)
+        return self.post('/batch', data)
 
     @log_response
     def track(self, event):
         """Send a single tracking event"""
         log.debug('Sending track event: %s', event)
-        return self.session.post(self.url + '/track', json=event, auth=self.auth)
+        return self.post('/track', event)
 
     @classmethod
     def new_instance(cls, session=None):


### PR DESCRIPTION
We've started seeing a lot of:
ConnectionError: ('Connection aborted.', BadStatusLine("''",))

Hopefully this fixes the problem. Its hard to test, so I'll
have to check the logs after releasing.