### PR TITLE
WIP: Fix wallet initialization 

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -1172,7 +1172,6 @@ class LBRYumWallet(Wallet):
         d.addCallback(lambda _: self._start_check.start(.1))
         d.addCallback(lambda _: network_start_d)
         d.addCallback(lambda _: self._load_wallet())
-        d.addCallback(lambda _: self._get_cmd_runner())
         return d
 
     def _stop(self):
@@ -1268,12 +1267,12 @@ class LBRYumWallet(Wallet):
         d.addCallback(lambda _: blockchain_caught_d)
         return d
 
-    def _get_cmd_runner(self):
-        self.cmd_runner = Commands(self.config, self.wallet, self.network)
+    def _get_cmd_runner(self, password = None):
+        return Commands(self.config, self.wallet, self.network, password = password)
 
     def get_balance(self):
         cmd = known_commands['getbalance']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         accounts = None
         exclude_claimtrietx = True
         d = threads.deferToThread(func, accounts, exclude_claimtrietx)
@@ -1287,7 +1286,7 @@ class LBRYumWallet(Wallet):
 
     def get_block(self, blockhash):
         cmd = known_commands['getblock']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, blockhash)
 
     def get_most_recent_blocktime(self):
@@ -1307,7 +1306,7 @@ class LBRYumWallet(Wallet):
 
     def get_name_claims(self):
         cmd = known_commands['getnameclaims']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func)
 
     def _check_first_run(self):
@@ -1315,7 +1314,7 @@ class LBRYumWallet(Wallet):
 
     def _get_raw_tx(self, txid):
         cmd = known_commands['gettransaction']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, txid)
 
     def _get_transaction(self, txid):
@@ -1330,22 +1329,21 @@ class LBRYumWallet(Wallet):
 
     def _send_name_claim(self, name, val, amount):
         cmd = known_commands['claim']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, name, json.dumps(val), amount)
 
     def _get_claims_for_name(self, name):
         cmd = known_commands['getclaimsforname']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, name)
 
     def _send_name_claim_update(self, name, claim_id, claim_outpoint, value, amount):
         metadata = json.dumps(value)
-        log.debug("Update %s %d %f %s %s '%s'", claim_outpoint['txid'], claim_outpoint['nout'], 
+        log.debug("Update %s %d %f %s %s '%s'", claim_outpoint['txid'], claim_outpoint['nout'],
                                                      amount, name, claim_id, metadata)
         cmd = known_commands['update']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, claim_outpoint['txid'], claim_outpoint['nout'], name, claim_id, metadata, amount)
-
 
     def _get_decoded_tx(self, raw_tx):
         tx = Transaction(raw_tx)
@@ -1360,14 +1358,14 @@ class LBRYumWallet(Wallet):
     def _abandon_claim(self, claim_outpoint):
         log.debug("Abandon %s %s" % (claim_outpoint['txid'], claim_outpoint['nout']))
         cmd = known_commands['abandon']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         d = threads.deferToThread(func, claim_outpoint['txid'], claim_outpoint['nout'])
         return d
 
     def _support_claim(self, name, claim_id, amount):
         log.debug("Support %s %s %f" % (name, claim_id, amount))
         cmd = known_commands['support']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         d = threads.deferToThread(func, name, claim_id, amount)
         return d
 
@@ -1376,7 +1374,7 @@ class LBRYumWallet(Wallet):
             log.debug("Broadcast tx: %s", r)
             return r
         cmd = known_commands['broadcast']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         d = threads.deferToThread(func, raw_tx)
         d.addCallback(_log_tx)
         d.addCallback(
@@ -1387,17 +1385,17 @@ class LBRYumWallet(Wallet):
     def _do_send_many(self, payments_to_send):
         log.warning("Doing send many. payments to send: %s", str(payments_to_send))
         cmd = known_commands['paytomanyandsend']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, payments_to_send.iteritems())
 
     def _get_value_for_name(self, name):
         cmd = known_commands['getvalueforname']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, name)
 
     def get_claims_from_tx(self, txid):
         cmd = known_commands['getclaimsfromtx']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, txid)
 
     def _get_balance_for_address(self, address):
@@ -1405,22 +1403,22 @@ class LBRYumWallet(Wallet):
 
     def get_nametrie(self):
         cmd = known_commands['getclaimtrie']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func)
 
     def _get_history(self):
         cmd = known_commands['history']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func)
 
     def _address_is_mine(self, address):
         cmd = known_commands['ismine']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, address)
 
     def get_pub_keys(self, wallet):
         cmd = known_commands['getpubkeys']
-        func = getattr(self.cmd_runner, cmd.name)
+        func = getattr(self._get_cmd_runner(), cmd.name)
         return threads.deferToThread(func, wallet)
 
     def _save_wallet(self, val):


### PR DESCRIPTION
7fb42e1 changes the order of how the wallet is loaded. Before it would load the network, load the disk wallet, and then catch up on the blockchain (if any steps failed, the subsequent steps would not be performed) . If loading the network failed, the wallet would never be loaded (we can still query the wallet for balance, and transactions even if not connected to the network). 

Now we load the disk wallet first, load the network, and than catch up on the blockchain so that the wallet is always loaded regardless of if the network loaded. 

dafb8f1 fixes cmd_runner so that it would always get loaded upon call. This patch is also needed for lbryum password entry for encryption.  

