### PR TITLE
Fix bug to exclude support in get_my_claim

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -405,12 +405,12 @@ class Wallet(object):
             if not claim:
                 return False
             claim['value'] = json.loads(claim['value'])
-            return claim 
+            return claim
 
 
         def _get_my_unspent_claim(claims):
             for claim in claims:
-                if claim['name'] == name and not claim['is spent'] and not claim.get('supported_claimid', False):
+                if claim['name'] == name and not claim['is spent'] and claim['category'] != 'support':
                     return claim
             return False
 


### PR DESCRIPTION
Code to not include supports in get_my_claim is deprecated, entries for supports look like below, use key 'category' to identify supports. 

        "address": "bGKZv95UCGA6Wuw9rjwU1ueFLEw4i9pbpv", 
        "amount": 0.0001, 
        "blocks to expiration": 261288, 
        "category": "support", 
        "claim_id": "467513d3a6eed0114964d751cd85ed49c8e3af4e", 
        "confirmations": 1686, 
        "expiration height": 350378, 
        "expired": false, 
        "height": 87404, 
        "is spent": false, 
        "nOut": 0, 
        "name": "warandpeace", 
        "txid": "9b647d61326752abd2efba31b6cf9413ef961eb43673ae8e9f331804aa196c64"