### PR TITLE
Remove 'success' and 'reason' as outputs in claim commands + Wallet unit test

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -463,11 +463,13 @@ class Wallet(object):
             meta_for_return[k] = new_metadata[k]
         return defer.succeed(Metadata(meta_for_return))
 
+
     def claim_name(self, name, bid, m):
         def _save_metadata(claim_out, metadata):
             if not claim_out['success']:
                 msg = 'Claim to name {} failed: {}'.format(name, claim_out['reason'])
                 raise Exception(msg)
+            claim_out.pop('success')
             claim_outpoint = ClaimOutpoint(claim_out['txid'], claim_out['nout'])
             log.debug("Saving metadata for claim %s %d" % (claim_outpoint['txid'], claim_outpoint['nout']))
             d = self._save_name_metadata(name, claim_outpoint, metadata['sources']['lbry_sd_hash'])
@@ -494,11 +496,29 @@ class Wallet(object):
         return d
 
     def abandon_claim(self, txid, nout):
+        def _parse_abandon_claim_out(claim_out):
+            if not claim_out['success']:
+                msg = 'Abandon of {}:{} failed: {}'.format(txid, nout, claim_out['resason'])
+                raise Exception(msg)
+            claim_out.pop('success')
+            return defer.succeed(claim_out)
+
         claim_outpoint = ClaimOutpoint(txid, nout)
-        return self._abandon_claim(claim_outpoint)
+        d = self._abandon_claim(claim_outpoint)
+        d.addCallback(lambda claim_out: _parse_abandon_claim_out(claim_out))
+        return d
 
     def support_claim(self, name, claim_id, amount):
-        return self._support_claim(name, claim_id, amount)
+        def _parse_support_claim_out(claim_out):
+            if not claim_out['success']:
+                msg = 'Support of {}:{} failed: {}'.format(name, claim_id, claim_out['reason'])
+                raise Exception(msg)
+            claim_out.pop('success')
+            return defer.succeed(claim_out)
+
+        d = self._support_claim(name, claim_id, amount)
+        d.addCallback(lambda claim_out: _parse_support_claim_out(claim_out))
+        return d
 
     def get_tx(self, txid):
         d = self._get_raw_tx(txid)

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1697,8 +1697,6 @@ class Daemon(AuthJSONRPCServer):
             'metadata': metadata dictionary
             optional 'fee'
         Returns:
-            'success' : True if claim was succesful , False otherwise
-            'reason' : if not succesful, give reason
             'txid' : txid of resulting transaction if succesful
             'nout' : nout of the resulting support claim if succesful
             'fee' : fee paid for the claim transaction if succesful
@@ -1773,8 +1771,6 @@ class Daemon(AuthJSONRPCServer):
             'txid': txid of claim, string
             'nout': nout of claim, integer
         Return:
-            success : True if succesful , False otherwise
-            reason : if not succesful, give reason
             txid : txid of resulting transaction if succesful
             fee : fee paid for the transaction if succesful
         """
@@ -1818,8 +1814,6 @@ class Daemon(AuthJSONRPCServer):
             'claim_id': claim id of claim to support
             'amount': amount to support by
         Return:
-            success : True if succesful , False otherwise
-            reason : if not succesful, give reason
             txid : txid of resulting transaction if succesful
             nout : nout of the resulting support claim if succesful
             fee : fee paid for the transaction if succesful

--- a/tests/unit/core/test_Wallet.py
+++ b/tests/unit/core/test_Wallet.py
@@ -31,12 +31,6 @@ class MocLbryumWallet(Wallet):
 
 class WalletTest(unittest.TestCase):
 
-    def _check_exception(self, d):
-        def check(err):
-            with self.assertRaises(Exception):
-                err.raiseException()
-        d.addCallbacks(lambda _: self.assertTrue(False), lambda err: check(err))
-
     def test_failed_send_name_claim(self):
         def not_enough_funds_send_name_claim(self, name, val, amount):
             claim_out = {'success':False, 'reason':'Not enough funds'}
@@ -44,11 +38,11 @@ class WalletTest(unittest.TestCase):
         MocLbryumWallet._send_name_claim = not_enough_funds_send_name_claim
         wallet = MocLbryumWallet()
         d = wallet.claim_name('test', 1, test_metadata)
-        self._check_exception(d)
+        self.assertFailure(d,Exception)
         return d
 
     def test_successful_send_name_claim(self):
-        test_claim_out = {
+        expected_claim_out = {
             "claimid": "f43dc06256a69988bdbea09a58c80493ba15dcfa",
             "fee": "0.00012",
             "nout": 0,
@@ -58,13 +52,13 @@ class WalletTest(unittest.TestCase):
 
         def check_out(claim_out):
             self.assertTrue('success' not in claim_out)
-            self.assertEqual(claim_out['claimid'], test_claim_out['claimid'])
-            self.assertEqual(claim_out['fee'], test_claim_out['fee'])
-            self.assertEqual(claim_out['nout'], test_claim_out['nout'])
-            self.assertEqual(claim_out['txid'], test_claim_out['txid'])
+            self.assertEqual(expected_claim_out['claimid'], claim_out['claimid'])
+            self.assertEqual(expected_claim_out['fee'], claim_out['fee'])
+            self.assertEqual(expected_claim_out['nout'], claim_out['nout'])
+            self.assertEqual(expected_claim_out['txid'], claim_out['txid'])
 
         def success_send_name_claim(self, name, val, amount):
-            return test_claim_out
+            return expected_claim_out
 
         MocLbryumWallet._send_name_claim = success_send_name_claim
         wallet = MocLbryumWallet()
@@ -79,11 +73,11 @@ class WalletTest(unittest.TestCase):
         MocLbryumWallet._support_claim = failed_support_claim
         wallet = MocLbryumWallet()
         d = wallet.support_claim('test', "f43dc06256a69988bdbea09a58c80493ba15dcfa", 1)
-        self._check_exception(d)
+        self.assertFailure(d,Exception)
         return d
 
     def test_succesful_support(self):
-        test_support_out = {
+        expected_support_out = {
             "fee": "0.000129",
             "nout": 0,
             "success": True,
@@ -92,12 +86,12 @@ class WalletTest(unittest.TestCase):
 
         def check_out(claim_out):
             self.assertTrue('success' not in claim_out)
-            self.assertEqual(claim_out['fee'], test_support_out['fee'])
-            self.assertEqual(claim_out['nout'], test_support_out['nout'])
-            self.assertEqual(claim_out['txid'], test_support_out['txid'])
+            self.assertEqual(expected_support_out['fee'], claim_out['fee'])
+            self.assertEqual(expected_support_out['nout'], claim_out['nout'])
+            self.assertEqual(expected_support_out['txid'], claim_out['txid'])
 
         def success_support_claim(self, name, val, amount):
-            return threads.deferToThread(lambda: test_support_out)
+            return threads.deferToThread(lambda: expected_support_out)
         MocLbryumWallet._support_claim = success_support_claim
         wallet = MocLbryumWallet()
         d = wallet.support_claim('test', "f43dc06256a69988bdbea09a58c80493ba15dcfa", 1)
@@ -111,11 +105,11 @@ class WalletTest(unittest.TestCase):
         MocLbryumWallet._abandon_claim = failed_abandon_claim
         wallet = MocLbryumWallet()
         d = wallet.abandon_claim("11030a76521e5f552ca87ad70765d0cc52e6ea4c0dc0063335e6cf2a9a85085f", 1)
-        self._check_exception(d)
+        self.assertFailure(d,Exception)
         return d
 
     def test_successful_abandon(self):
-        test_abandon_out = {
+        expected_abandon_out = {
             "fee": "0.000096",
             "success": True,
             "txid": "0578c161ad8d36a7580c557d7444f967ea7f988e194c20d0e3c42c3cabf110dd"
@@ -123,11 +117,11 @@ class WalletTest(unittest.TestCase):
 
         def check_out(claim_out):
             self.assertTrue('success' not in claim_out)
-            self.assertEqual(claim_out['fee'], test_abandon_out['fee'])
-            self.assertEqual(claim_out['txid'], test_abandon_out['txid'])
+            self.assertEqual(expected_abandon_out['fee'], claim_out['fee'])
+            self.assertEqual(expected_abandon_out['txid'], claim_out['txid'])
 
         def success_abandon_claim(self, claim_outpoint):
-            return threads.deferToThread(lambda: test_abandon_out)
+            return threads.deferToThread(lambda: expected_abandon_out)
 
         MocLbryumWallet._abandon_claim = success_abandon_claim
         wallet = MocLbryumWallet()

--- a/tests/unit/core/test_Wallet.py
+++ b/tests/unit/core/test_Wallet.py
@@ -1,0 +1,136 @@
+from twisted.trial import unittest
+
+from twisted.internet import threads, defer
+from lbrynet.core.Wallet import Wallet
+
+test_metadata = {
+'license': 'NASA',
+'fee': {'USD': {'amount': 0.01, 'address': 'baBYSK7CqGSn5KrEmNmmQwAhBSFgo6v47z'}},
+'ver': '0.0.3',
+'description': 'test',
+'language': 'en',
+'author': 'test',
+'title': 'test',
+'sources': {
+    'lbry_sd_hash': '8655f713819344980a9a0d67b198344e2c462c90f813e86f0c63789ab0868031f25c54d0bb31af6658e997e2041806eb'},
+'nsfw': False,
+'content_type': 'video/mp4',
+'thumbnail': 'test'
+}
+
+
+class MocLbryumWallet(Wallet):
+    def __init__(self):
+        pass
+    def get_name_claims(self):
+        return threads.deferToThread(lambda: [])
+
+    def _save_name_metadata(self, name, claim_outpoint, sd_hash):
+        return defer.succeed(True)
+
+
+class WalletTest(unittest.TestCase):
+
+    def _check_exception(self, d):
+        def check(err):
+            with self.assertRaises(Exception):
+                err.raiseException()
+        d.addCallbacks(lambda _: self.assertTrue(False), lambda err: check(err))
+
+    def test_failed_send_name_claim(self):
+        def not_enough_funds_send_name_claim(self, name, val, amount):
+            claim_out = {'success':False, 'reason':'Not enough funds'}
+            return claim_out
+        MocLbryumWallet._send_name_claim = not_enough_funds_send_name_claim
+        wallet = MocLbryumWallet()
+        d = wallet.claim_name('test', 1, test_metadata)
+        self._check_exception(d)
+        return d
+
+    def test_successful_send_name_claim(self):
+        test_claim_out = {
+            "claimid": "f43dc06256a69988bdbea09a58c80493ba15dcfa",
+            "fee": "0.00012",
+            "nout": 0,
+            "success": True,
+            "txid": "6f8180002ef4d21f5b09ca7d9648a54d213c666daf8639dc283e2fd47450269e"
+         }
+
+        def check_out(claim_out):
+            self.assertTrue('success' not in claim_out)
+            self.assertEqual(claim_out['claimid'], test_claim_out['claimid'])
+            self.assertEqual(claim_out['fee'], test_claim_out['fee'])
+            self.assertEqual(claim_out['nout'], test_claim_out['nout'])
+            self.assertEqual(claim_out['txid'], test_claim_out['txid'])
+
+        def success_send_name_claim(self, name, val, amount):
+            return test_claim_out
+
+        MocLbryumWallet._send_name_claim = success_send_name_claim
+        wallet = MocLbryumWallet()
+        d = wallet.claim_name('test', 1, test_metadata)
+        d.addCallback(lambda claim_out: check_out(claim_out))
+        return d
+
+    def test_failed_support(self):
+        def failed_support_claim(self, name, claim_id, amount):
+            claim_out = {'success':False, 'reason':'Not enough funds'}
+            return threads.deferToThread(lambda: claim_out)
+        MocLbryumWallet._support_claim = failed_support_claim
+        wallet = MocLbryumWallet()
+        d = wallet.support_claim('test', "f43dc06256a69988bdbea09a58c80493ba15dcfa", 1)
+        self._check_exception(d)
+        return d
+
+    def test_succesful_support(self):
+        test_support_out = {
+            "fee": "0.000129",
+            "nout": 0,
+            "success": True,
+            "txid": "11030a76521e5f552ca87ad70765d0cc52e6ea4c0dc0063335e6cf2a9a85085f"
+        }
+
+        def check_out(claim_out):
+            self.assertTrue('success' not in claim_out)
+            self.assertEqual(claim_out['fee'], test_support_out['fee'])
+            self.assertEqual(claim_out['nout'], test_support_out['nout'])
+            self.assertEqual(claim_out['txid'], test_support_out['txid'])
+
+        def success_support_claim(self, name, val, amount):
+            return threads.deferToThread(lambda: test_support_out)
+        MocLbryumWallet._support_claim = success_support_claim
+        wallet = MocLbryumWallet()
+        d = wallet.support_claim('test', "f43dc06256a69988bdbea09a58c80493ba15dcfa", 1)
+        d.addCallback(lambda claim_out: check_out(claim_out))
+        return d
+
+    def test_failed_abandon(self):
+        def failed_abandon_claim(self, claim_outpoint):
+            claim_out = {'success':False, 'reason':'Not enough funds'}
+            return threads.deferToThread(lambda: claim_out)
+        MocLbryumWallet._abandon_claim = failed_abandon_claim
+        wallet = MocLbryumWallet()
+        d = wallet.abandon_claim("11030a76521e5f552ca87ad70765d0cc52e6ea4c0dc0063335e6cf2a9a85085f", 1)
+        self._check_exception(d)
+        return d
+
+    def test_successful_abandon(self):
+        test_abandon_out = {
+            "fee": "0.000096",
+            "success": True,
+            "txid": "0578c161ad8d36a7580c557d7444f967ea7f988e194c20d0e3c42c3cabf110dd"
+        }
+
+        def check_out(claim_out):
+            self.assertTrue('success' not in claim_out)
+            self.assertEqual(claim_out['fee'], test_abandon_out['fee'])
+            self.assertEqual(claim_out['txid'], test_abandon_out['txid'])
+
+        def success_abandon_claim(self, claim_outpoint):
+            return threads.deferToThread(lambda: test_abandon_out)
+
+        MocLbryumWallet._abandon_claim = success_abandon_claim
+        wallet = MocLbryumWallet()
+        d = wallet.abandon_claim("0578c161ad8d36a7580c557d7444f967ea7f988e194c20d0e3c42c3cabf110dd", 1)
+        d.addCallback(lambda claim_out: check_out(claim_out))
+        return d


### PR DESCRIPTION
Replacement for https://github.com/lbryio/lbry/pull/306 (branch from lbryio/lbry instead of kaykurokawa/lbry)

Remove 'success' and 'reason' as outputs in Daemon claim commands, as we throw an exception instead for failed claims instead.

Have support and abandon claim commands do the same.

Added test_Wallet.py under tests to test these features, and to implement more tests for Wallet.py in the future. 