### PR TITLE
Make a new logger with a fail method that is useful for errbacks

### DIFF
--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -332,7 +332,7 @@ class LogUploader(object):
 
 class Logger(logging.Logger):
     """A logger that has an extra `fail` method useful for handling twisted failures."""
-    def fail(self, callback=None, *args):
+    def fail(self, callback=None, *args, **kwargs):
         """Returns a function to log a failure from an errback.
 
         The returned function appends the error message and extracts
@@ -355,20 +355,20 @@ class Logger(logging.Logger):
             err: twisted.python.failure.Failure
             msg: the message to log, using normal logging string iterpolation.
             msg_args: the values to subtitute into `msg`
-            kwargs: set `level` to change from the default ERROR severity. Other
+            msg_kwargs: set `level` to change from the default ERROR severity. Other
                 keywoards are treated as normal log kwargs.
         """
         fn, lno, func = findCaller()
-        def _fail(err, msg, *msg_args, **kwargs):
-            level = kwargs.pop('level', logging.ERROR)
+        def _fail(err, msg, *msg_args, **msg_kwargs):
+            level = msg_kwargs.pop('level', logging.ERROR)
             msg += ": %s"
             msg_args += (err.getErrorMessage(),)
             exc_info = (err.type, err.value, err.getTracebackObject())
             record = self.makeRecord(
-                self.name, level, fn, lno, msg, msg_args, exc_info, func, kwargs)
+                self.name, level, fn, lno, msg, msg_args, exc_info, func, msg_kwargs)
             self.handle(record)
             if callback:
-                callback(err, *args)
+                callback(err, *args, **kwargs)
         return _fail
 
 

--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 import json
 import logging
 import logging.handlers
@@ -13,6 +14,22 @@ from requests_futures.sessions import FuturesSession
 import lbrynet
 from lbrynet.conf import settings
 from lbrynet.core import utils
+
+####
+# This code is copied from logging/__init__.py in the python source code
+####
+#
+# _srcfile is used when walking the stack to check when we've got the first
+# caller stack frame.
+#
+if hasattr(sys, 'frozen'): #support for py2exe
+    _srcfile = "logging%s__init__%s" % (os.sep, __file__[-4:])
+elif __file__[-4:].lower() in ['.pyc', '.pyo']:
+    _srcfile = __file__[:-4] + '.py'
+else:
+    _srcfile = __file__
+_srcfile = os.path.normcase(_srcfile)
+#####
 
 
 session = FuturesSession()
@@ -147,6 +164,30 @@ class JsonFormatter(logging.Formatter):
         if record.exc_info:
             data['exc_info'] = self.formatException(record.exc_info)
         return json.dumps(data)
+
+####
+# This code is copied from logging/__init__.py in the python source code
+####
+def findCaller(srcfile=None):
+    """Returns the filename, line number and function name of the caller"""
+    srcfile = srcfile or _srcfile
+    f = inspect.currentframe()
+    #On some versions of IronPython, currentframe() returns None if
+    #IronPython isn't run with -X:Frames.
+    if f is not None:
+        f = f.f_back
+    rv = "(unknown file)", 0, "(unknown function)"
+    while hasattr(f, "f_code"):
+        co = f.f_code
+        filename = os.path.normcase(co.co_filename)
+        # ignore any function calls that are in this file
+        if filename == srcfile:
+            f = f.f_back
+            continue
+        rv = (filename, f.f_lineno, co.co_name)
+        break
+    return rv
+###
 
 
 def failure(failure, log, msg, *args):
@@ -287,3 +328,42 @@ class LogUploader(object):
         else:
             log_size = 0
         return cls(log_name, log_file, log_size)
+
+
+class Logger(logging.Logger):
+    """A logger that has an extra `fail` method useful for handling twisted failures."""
+    def fail(self):
+        """Returns a function to log a failure from an errback.
+
+        The returned function appends the error message and extracts
+        the traceback from `err`.
+
+        Example usage:
+            d.addErrback(log.fail(), 'This is an error message')
+
+        Although odd, making the method call is necessary to extract
+        out useful filename and line number information; otherwise the
+        reported values are from inside twisted's deferred handling
+        code.
+
+        Args (for the returned function):
+            err: twisted.python.failure.Failure
+            msg: the message to log, using normal logging string iterpolation.
+            args: the values to subtitute into `msg`
+            kwargs: set `level` to change from the default ERROR severity. Other
+                keywoards are treated as normal log kwargs.
+
+        """
+        fn, lno, func = findCaller()
+        def _fail(err, msg, *args, **kwargs):
+            level = kwargs.pop('level', logging.ERROR)
+            msg += ": %s"
+            args += (err.getErrorMessage(),)
+            exc_info = (err.type, err.value, err.getTracebackObject())
+            record = self.makeRecord(
+                self.name, level, fn, lno, msg, args, exc_info, func, kwargs)
+            self.handle(record)
+        return _fail
+
+
+logging.setLoggerClass(Logger)

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -602,14 +602,14 @@ class Daemon(AuthJSONRPCServer):
             d = defer.succeed(None)
 
         d.addCallback(lambda _: self._stop_server())
-        d.addErrback(log_support.failure, log, 'Failure while shutting down: %s')
+        d.addErrback(log.fail(), 'Failure while shutting down')
         d.addCallback(lambda _: self._stop_reflector())
-        d.addErrback(log_support.failure, log, 'Failure while shutting down: %s')
+        d.addErrback(log.fail(), 'Failure while shutting down')
         d.addCallback(lambda _: self._stop_file_manager())
-        d.addErrback(log_support.failure, log, 'Failure while shutting down: %s')
+        d.addErrback(log.fail(), 'Failure while shutting down')
         if self.session is not None:
             d.addCallback(lambda _: self.session.shut_down())
-            d.addErrback(log_support.failure, log, 'Failure while shutting down: %s')
+            d.addErrback(log.fail(), 'Failure while shutting down')
         return d
 
     def _update_settings(self, settings):
@@ -1468,9 +1468,20 @@ class Daemon(AuthJSONRPCServer):
             return self._render_response(None, BAD_REQUEST)
 
         d = self._resolve_name(name, force_refresh=force)
+        # TODO: this is the rpc call that returns a server.failure.
+        #       what is up with that?
         d.addCallbacks(
             lambda info: self._render_response(info, OK_CODE),
-            errback=handle_failure, errbackArgs=('Failed to resolve name: %s',)
+            # TODO: Is server.failure a module? It looks like it:
+            #
+            # In [1]: import twisted.web.server
+            # In [2]: twisted.web.server.failure
+            # Out[2]: <module 'twisted.python.failure' from
+            #         '.../site-packages/twisted/python/failure.pyc'>
+            #
+            # If so, maybe we should return something else.
+            errback=log.fail(lambda: server.failure),
+            errbackArgs=('Failed to resolve name: %s',)
         )
         return d
 
@@ -2696,18 +2707,6 @@ def get_lbry_file_search_value(p):
         if value:
             return searchtype, value
     raise NoValidSearch()
-
-
-def handle_failure(err, msg):
-    log_support.failure(err, log, msg)
-    # TODO: Is this a module? It looks like it:
-    #
-    # In [1]: import twisted.web.server
-    # In [2]: twisted.web.server.failure
-    # Out[2]: <module 'twisted.python.failure' from '.../site-packages/twisted/python/failure.pyc'>
-    #
-    # If so, maybe we should return something else.
-    return server.failure
 
 
 def run_reflector_factory(factory):

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -10,7 +10,6 @@ from twisted.python.failure import Failure
 from txjsonrpc import jsonrpclib
 from lbrynet.core.Error import InvalidAuthenticationToken, InvalidHeaderError, SubhandlerError
 from lbrynet.conf import settings
-from lbrynet.core import log_support
 from lbrynet.lbrynet_daemon.auth.util import APIKey, get_auth_message
 from lbrynet.lbrynet_daemon.auth.client import LBRY_SECRET
 
@@ -117,11 +116,6 @@ class AuthJSONRPCServer(AuthorizedBase):
         request.write(fault)
         request.finish()
 
-    def _log_and_render_error(self, failure, request, message=None, **kwargs):
-        msg = message or "API Failure: %s"
-        log_support.failure(Failure(failure), log, msg)
-        self._render_error(failure, request, **kwargs)
-
     def render(self, request):
         notify_finish = request.notifyFinish()
         assert self._check_headers(request), InvalidHeaderError
@@ -192,7 +186,10 @@ class AuthJSONRPCServer(AuthorizedBase):
         # cancel the response if the connection is broken
         notify_finish.addErrback(self._response_failed, d)
         d.addCallback(self._callback_render, request, version, reply_with_next_secret)
-        d.addErrback(self._log_and_render_error, request, version=version)
+        d.addErrback(
+            log.fail(self._render_error, request, version=version),
+            'Failed to process %s', function_name
+        )
         return server.NOT_DONE_YET
 
     def _register_user_session(self, session_id):

--- a/tests/unit/core/test_log_support.py
+++ b/tests/unit/core/test_log_support.py
@@ -1,0 +1,40 @@
+import StringIO
+import logging
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from lbrynet.core import log_support
+
+
+class TestLogger(unittest.TestCase):
+    def raiseError(self):
+        raise Exception('terrible things happened')
+
+    def triggerErrback(self, log):
+        d = defer.Deferred()
+        d.addCallback(lambda _: self.raiseError())
+        d.addErrback(log.fail(), 'My message')
+        d.callback(None)
+        return d
+
+    def test_can_log_failure(self):
+        def output_lines():
+            return stream.getvalue().split('\n')
+
+        log = log_support.Logger('test')
+        stream = StringIO.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(filename)s:%(lineno)d - %(message)s"))
+        log.addHandler(handler)
+
+        # the line number could change if this file gets refactored
+        expected_first_line = 'test_log_support.py:17 - My message: terrible things happened'
+
+        # testing the entirety of the message is futile as the
+        # traceback will depend on the system the test is being run on
+        # but hopefully these two tests are good enough
+        d = self.triggerErrback(log)
+        d.addCallback(lambda _: self.assertEquals(expected_first_line, output_lines()[0]))
+        d.addCallback(lambda _: self.assertEqual(10, len(output_lines())))
+        return d

--- a/tests/unit/core/test_log_support.py
+++ b/tests/unit/core/test_log_support.py
@@ -1,6 +1,7 @@
 import StringIO
 import logging
 
+import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -11,30 +12,37 @@ class TestLogger(unittest.TestCase):
     def raiseError(self):
         raise Exception('terrible things happened')
 
-    def triggerErrback(self, log):
+    def triggerErrback(self, callback=None):
         d = defer.Deferred()
         d.addCallback(lambda _: self.raiseError())
-        d.addErrback(log.fail(), 'My message')
+        d.addErrback(self.log.fail(callback), 'My message')
         d.callback(None)
         return d
 
+    def setUp(self):
+        self.log = log_support.Logger('test')
+        self.stream = StringIO.StringIO()
+        handler = logging.StreamHandler(self.stream)
+        handler.setFormatter(logging.Formatter("%(filename)s:%(lineno)d - %(message)s"))
+        self.log.addHandler(handler)
+
     def test_can_log_failure(self):
         def output_lines():
-            return stream.getvalue().split('\n')
-
-        log = log_support.Logger('test')
-        stream = StringIO.StringIO()
-        handler = logging.StreamHandler(stream)
-        handler.setFormatter(logging.Formatter("%(filename)s:%(lineno)d - %(message)s"))
-        log.addHandler(handler)
+            return self.stream.getvalue().split('\n')
 
         # the line number could change if this file gets refactored
-        expected_first_line = 'test_log_support.py:17 - My message: terrible things happened'
+        expected_first_line = 'test_log_support.py:18 - My message: terrible things happened'
 
         # testing the entirety of the message is futile as the
         # traceback will depend on the system the test is being run on
         # but hopefully these two tests are good enough
-        d = self.triggerErrback(log)
+        d = self.triggerErrback()
         d.addCallback(lambda _: self.assertEquals(expected_first_line, output_lines()[0]))
         d.addCallback(lambda _: self.assertEqual(10, len(output_lines())))
+        return d
+
+    def test_can_log_failure_with_callback(self):
+        callback = mock.Mock()
+        d = self.triggerErrback(callback)
+        d.addCallback(lambda _: callback.assert_called_once_with(mock.ANY))
         return d


### PR DESCRIPTION
Extracting useful tracebacks and line numbers from failures
within twisted's deferred can be a pain. Hopefully this is a step
in the right direction.