### PR TITLE
Add timing to hash announcements

### DIFF
--- a/lbrynet/core/server/DHTHashAnnouncer.py
+++ b/lbrynet/core/server/DHTHashAnnouncer.py
@@ -1,6 +1,7 @@
 import binascii
 import collections
 import logging
+import time
 
 from twisted.internet import defer, reactor
 
@@ -51,7 +52,11 @@ class DHTHashAnnouncer(object):
         return dl
 
     def _announce_hashes(self, hashes):
-
+        if not hashes:
+            return
+        log.debug('Announcing %s hashes', len(hashes))
+        # TODO: add a timeit decorator
+        start = time.time()
         ds = []
 
         for h in hashes:
@@ -72,7 +77,10 @@ class DHTHashAnnouncer(object):
             # TODO: maybe make the 5 configurable
             self._concurrent_announcers += 1
             announce()
-        return defer.DeferredList(ds)
+        d = defer.DeferredList(ds)
+        d.addCallback(lambda _: log.debug('Took %s seconds to announce %s hashes',
+                                          time.time() - start, len(hashes)))
+        return d
 
 
 class DHTHashSupplier(object):


### PR DESCRIPTION
This could potentially be a performance issue
on reflector or any daemon with a large number of blobs.