### PR TITLE
Improve BlobAvailabilityTracker performance

### DIFF
--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -167,7 +167,7 @@ class BlobAvailabilityTracker(BlobAvailability.BlobAvailabilityTracker):
         self._dht_node = None
         self._check_popular = None
         self._check_mine = None
-        self._get_mean_peers()
+        self._set_mean_peers()
 
     def start(self):
         pass


### PR DESCRIPTION
For daemons with a lot of blobs, getting mean availabity
will be slow. Samples the blobs in an attempt at getting
better performance.