### PR TITLE
Wallet storage

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -290,12 +290,9 @@ class Daemon(AuthJSONRPCServer):
         self.lbry_file_metadata_manager = None
         self.lbry_file_manager = None
 
+    @defer.inlineCallbacks
     def setup(self):
         self._modify_loggly_formatter()
-
-        def _log_starting_vals():
-            log.info("Starting balance: " + str(self.session.wallet.wallet_balance))
-            return defer.succeed(None)
 
         def _announce_startup():
             def _wait_for_credits():
@@ -330,26 +327,23 @@ class Daemon(AuthJSONRPCServer):
         self.looping_call_manager.start(Checker.CONNECTION_PROBLEM, 1)
         self.exchange_rate_manager.start()
 
-        d = defer.Deferred()
         if conf.settings.host_ui:
             self.lbry_ui_manager.update_checker.start(1800, now=False)
-            d.addCallback(lambda _: self.lbry_ui_manager.setup())
-        d.addCallback(lambda _: self._initial_setup())
-        d.addCallback(lambda _: threads.deferToThread(self._setup_data_directory))
-        d.addCallback(lambda _: self._check_db_migration())
-        d.addCallback(lambda _: self._load_caches())
-        d.addCallback(lambda _: self._set_events())
-        d.addCallback(lambda _: self._get_session())
-        d.addCallback(lambda _: self._get_analytics())
-        d.addCallback(lambda _: add_lbry_file_to_sd_identifier(self.sd_identifier))
-        d.addCallback(lambda _: self._setup_stream_identifier())
-        d.addCallback(lambda _: self._setup_lbry_file_manager())
-        d.addCallback(lambda _: self._setup_query_handlers())
-        d.addCallback(lambda _: self._setup_server())
-        d.addCallback(lambda _: _log_starting_vals())
-        d.addCallback(lambda _: _announce_startup())
-        d.callback(None)
-        return d
+            yield self.lbry_ui_manager.setup()
+        yield self._initial_setup()
+        yield threads.deferToThread(self._setup_data_directory)
+        yield self._check_db_migration()
+        yield self._load_caches()
+        yield self._set_events()
+        yield self._get_session()
+        yield self._get_analytics()
+        yield add_lbry_file_to_sd_identifier(self.sd_identifier)
+        yield self._setup_stream_identifier()
+        yield self._setup_lbry_file_manager()
+        yield self._setup_query_handlers()
+        yield self._setup_server()
+        log.info("Starting balance: " + str(self.session.wallet.wallet_balance))
+        yield _announce_startup()
 
     def _get_platform(self):
         if self.platform is None:
@@ -756,7 +750,6 @@ class Daemon(AuthJSONRPCServer):
 
         d.addCallback(create_session)
         d.addCallback(lambda _: self.session.setup())
-
         return d
 
     def _setup_stream_identifier(self):

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -43,7 +43,7 @@ from lbrynet.core import system_info
 from lbrynet.core.StreamDescriptor import StreamDescriptorIdentifier, download_sd_blob
 from lbrynet.core.StreamDescriptor import BlobStreamDescriptorReader
 from lbrynet.core.Session import Session
-from lbrynet.core.Wallet import LBRYumWallet
+from lbrynet.core.Wallet import LBRYumWallet, SqliteStorage
 from lbrynet.core.looping_call_manager import LoopingCallManager
 from lbrynet.core.server.BlobRequestHandler import BlobRequestHandlerFactory
 from lbrynet.core.server.ServerProtocol import ServerProtocolFactory
@@ -727,7 +727,9 @@ class Daemon(AuthJSONRPCServer):
                 config = {'auto_connect': True}
                 if conf.settings.lbryum_wallet_dir:
                     config['lbryum_path'] = conf.settings.lbryum_wallet_dir
-                return defer.succeed(LBRYumWallet(self.db_dir, config))
+                storage = SqliteStorage(self.db_dir)
+                wallet = LBRYumWallet(storage, config)
+                return defer.succeed(wallet)
             elif self.wallet_type == PTC_WALLET:
                 log.info("Using PTC wallet")
                 from lbrynet.core.PTCWallet import PTCWallet

--- a/lbrynet/lbrynet_daemon/DaemonServer.py
+++ b/lbrynet/lbrynet_daemon/DaemonServer.py
@@ -41,10 +41,10 @@ class DaemonServer(object):
 
         return defer.succeed(True)
 
+    @defer.inlineCallbacks
     def start(self, use_auth):
-        d = self._setup_server(use_auth)
-        d.addCallback(lambda _: self._api.setup())
-        return d
+        yield self._setup_server(use_auth)
+        yield self._api.setup()
 
 
 def get_site_base(use_auth, root):


### PR DESCRIPTION
In some of my scripts to test reflector it was useful to have a different storage backend to cache metadata for the wallet.

This separates the metadata caching logic from the wallet and creates an new in-memory storage backend.