### PR TITLE
Fix bug in server protocol

### DIFF
--- a/lbrynet/core/server/ServerProtocol.py
+++ b/lbrynet/core/server/ServerProtocol.py
@@ -33,10 +33,9 @@ class ServerProtocol(Protocol):
         peer_info = self.transport.getPeer()
         self.peer = self.factory.peer_manager.get_peer(peer_info.host, peer_info.port)
         self.request_handler = ServerRequestHandler(self)
-        for query_handler_factory, enabled in self.factory.query_handler_factories.iteritems():
-            if enabled is True:
-                query_handler = query_handler_factory.build_query_handler()
-                query_handler.register_with_request_handler(self.request_handler, self.peer)
+        for query_handler_factory in self.factory.query_handler_factories.values():
+            query_handler = query_handler_factory.build_query_handler()
+            query_handler.register_with_request_handler(self.request_handler, self.peer)
         log.debug("Setting the request handler")
         self.factory.rate_limiter.register_protocol(self)
 

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -149,12 +149,12 @@ class LbryUploader(object):
     def start_server(self):
         session = self.session
         query_handler_factories = {
-            BlobAvailabilityHandlerFactory(session.blob_manager): True,
-            BlobRequestHandlerFactory(
+            1: BlobAvailabilityHandlerFactory(session.blob_manager),
+            2: BlobRequestHandlerFactory(
                 session.blob_manager, session.wallet,
                 session.payment_rate_manager,
-                analytics.Track()): True,
-            session.wallet.get_wallet_info_query_handler_factory(): True,
+                analytics.Track()),
+            3: session.wallet.get_wallet_info_query_handler_factory(),
         }
         server_factory = ServerProtocolFactory(session.rate_limiter,
                                                query_handler_factories,
@@ -266,12 +266,12 @@ def start_lbry_reuploader(sd_hash, kill_event, dead_event,
         server_port = None
 
         query_handler_factories = {
-            BlobAvailabilityHandlerFactory(session.blob_manager): True,
-            BlobRequestHandlerFactory(
+            1: BlobAvailabilityHandlerFactory(session.blob_manager),
+            2: BlobRequestHandlerFactory(
                 session.blob_manager, session.wallet,
                 session.payment_rate_manager,
-                analytics.Track()): True,
-            session.wallet.get_wallet_info_query_handler_factory(): True,
+                analytics.Track()),
+            3: session.wallet.get_wallet_info_query_handler_factory(),
         }
 
         server_factory = ServerProtocolFactory(session.rate_limiter,
@@ -342,12 +342,12 @@ def start_live_server(sd_hash_queue, kill_event, dead_event):
     def start_listening():
         logging.debug("Starting the server protocol")
         query_handler_factories = {
-            CryptBlobInfoQueryHandlerFactory(stream_info_manager, session.wallet,
-                                             session.payment_rate_manager): True,
-            BlobRequestHandlerFactory(session.blob_manager, session.wallet,
+            1: CryptBlobInfoQueryHandlerFactory(stream_info_manager, session.wallet,
+                                             session.payment_rate_manager),
+            2: BlobRequestHandlerFactory(session.blob_manager, session.wallet,
                                       session.payment_rate_manager,
-                                      analytics.Track()): True,
-            session.wallet.get_wallet_info_query_handler_factory(): True,
+                                      analytics.Track()),
+            3: session.wallet.get_wallet_info_query_handler_factory()
         }
 
         server_factory = ServerProtocolFactory(session.rate_limiter,
@@ -483,11 +483,11 @@ def start_blob_uploader(blob_hash_queue, kill_event, dead_event, slow, is_genero
         server_port = None
 
         query_handler_factories = {
-            BlobAvailabilityHandlerFactory(session.blob_manager): True,
-            BlobRequestHandlerFactory(session.blob_manager, session.wallet,
+            1: BlobAvailabilityHandlerFactory(session.blob_manager),
+            2: BlobRequestHandlerFactory(session.blob_manager, session.wallet,
                                       session.payment_rate_manager,
-                                      analytics.Track()): True,
-            session.wallet.get_wallet_info_query_handler_factory(): True,
+                                      analytics.Track()),
+            3: session.wallet.get_wallet_info_query_handler_factory(),
         }
 
         server_factory = ServerProtocolFactory(session.rate_limiter,


### PR DESCRIPTION
This patch 
https://github.com/lbryio/lbry/commit/09846413bdf0aa5c647e8ca4e8198d748b4e6ff8 introduced a problem where BlobRequestHandler would never be loaded by ServerProtocol , because self.factory.query_handler_factories loaded by the Daemon ( see _add_query_handler() )was changed to be a dictionary of {query_id: query_handler_factory,} where before it was {query_handler_factory:enabled,}. This will cause the download to fail. 

 This patch changes ServerProtocol but I'm not sure if you want to change ServerProtocol or the Daemon function _add_query_handler() .