### PR TITLE
upgrade txJson-RCP to 0.5

### DIFF
--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -94,6 +94,7 @@ class AuthJSONRPCServer(AuthorizedBase):
     isLeaf = True
     OK = 200
     UNAUTHORIZED = 401
+    # TODO: codes should follow jsonrpc spec: http://www.jsonrpc.org/specification#error_object
     NOT_FOUND = 8001
     FAILURE = 8002
 

--- a/packaging/windows/init.ps1
+++ b/packaging/windows/init.ps1
@@ -83,7 +83,7 @@ C:\Python27\Scripts\pip.exe install simplejson==3.8.2
 
 C:\Python27\Scripts\pip.exe install slowaes==0.1a1
 
-C:\Python27\Scripts\pip.exe install txJSON-RPC==0.3.1
+C:\Python27\Scripts\pip.exe install txJSON-RPC==0.5
 
 C:\Python27\Scripts\pip.exe install unqlite==0.5.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ seccure==0.3.1.3
 simplejson==3.8.2
 six>=1.9.0
 slowaes==0.1a1
-txJSON-RPC==0.3.1
+txJSON-RPC==0.5
 wsgiref==0.1.2
 zope.interface==4.1.3
 base58==0.2.2

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ requires = [
     'simplejson==3.8.2',
     'six>=1.9.0',
     'slowaes==0.1a1',
-    'txJSON-RPC==0.3.1',
+    'txJSON-RPC==0.5',
     'wsgiref==0.1.2',
     'zope.interface==4.1.3',
     'base58==0.2.2',


### PR DESCRIPTION
The older version we were running didn't support jsonrpc v2 for
error codes, which both the command line client and ui client
were expecting.

Notably, this fixes this error:

```
  File "/home/jobevers/.virtualenvs/lbry/lib/python2.7/site-packages/jsonrpc/common.py", line 185, in get_result
    code = self.error['code']
KeyError: 'code'
```