### PR TITLE
Fix Daemon RPC command publish output

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -609,7 +609,21 @@ class Wallet(object):
             meta_for_return[k] = new_metadata[k]
         return defer.succeed(Metadata(meta_for_return))
 
+    """
+    Claim a name, update if name already claimed by user
+    @param name: name to claim
 
+    @param bid: bid amount
+
+    @param m: metadata
+
+    @return: Deferred which returns a dict containing below items
+        txid - txid of the resulting transaction
+        nout - nout of the resulting claim
+        fee - transaction fee paid to make claim
+        claim_id -  claim id of the claim
+
+    """
     def claim_name(self, name, bid, m):
         def _save_metadata(claim_out, metadata):
             if not claim_out['success']:
@@ -635,6 +649,7 @@ class Wallet(object):
                     lambda new_metadata: self._send_name_claim_update(name, claim['claim_id'],
                                                                       claim_outpoint,
                                                                       new_metadata, _bid))
+                d.addCallback(lambda claim_out: claim_out.update({'claim_id':claim['claim_id']}))
                 return d
 
         meta = Metadata(m)

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -649,7 +649,7 @@ class Wallet(object):
                     lambda new_metadata: self._send_name_claim_update(name, claim['claim_id'],
                                                                       claim_outpoint,
                                                                       new_metadata, _bid))
-                d.addCallback(lambda claim_out: claim_out.update({'claim_id':claim['claim_id']}))
+                d.addCallback(lambda claim_out: claim_out.update({'claim_id': claim['claim_id']}))
                 return d
 
         meta = Metadata(m)

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1686,7 +1686,7 @@ class Daemon(AuthJSONRPCServer):
             'txid' : txid of resulting transaction if succesful
             'nout' : nout of the resulting support claim if succesful
             'fee' : fee paid for the claim transaction if succesful
-            'claimid' : claimid of the resulting transaction
+            'claim_id' : claimid of the resulting transaction
         """
 
         def _set_address(address, currency, m):

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1686,7 +1686,7 @@ class Daemon(AuthJSONRPCServer):
             'txid' : txid of resulting transaction if succesful
             'nout' : nout of the resulting support claim if succesful
             'fee' : fee paid for the claim transaction if succesful
-            'claim_id' : claimid of the resulting transaction
+            'claim_id' : claim id of the resulting transaction
         """
 
         def _set_address(address, currency, m):

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -30,6 +30,8 @@ class Publisher(object):
         self.lbry_file = None
         self.txid = None
         self.nout = None
+        self.claim_id = None
+        self.fee = None
         self.stream_hash = None
         # TODO: this needs to be passed into the constructor
         reflector_server = random.choice(conf.settings.reflector_servers)
@@ -44,6 +46,8 @@ class Publisher(object):
             out = {}
             out['nout'] = self.nout
             out['txid'] = self.txid
+            out['claim_id'] = self.claim_id
+            out['fee'] = self.fee
             return defer.succeed(out)
 
         self.publish_name = name
@@ -136,15 +140,17 @@ class Publisher(object):
         self._update_metadata()
         m = Metadata(self.metadata)
 
-        def set_txid_nout(claim_out):
-            txid = claim_out['txid']
-            nout = claim_out['nout']
-            log.debug('Name claimed using txid: %s, nout: %d', txid, nout)
-            self.txid = txid
-            self.nout = nout
+        def set_claim_out(claim_out):
+            log.debug('Name claimed using txid: %s, nout: %d, claim_id: %s, fee :%f',
+                        claim_out['txid'], claim_out['nout'],
+                        claim_out['claim_id'], claim_out['fee'])
+            self.txid = claim_out['txid']
+            self.nout = claim_out['nout']
+            self.claim_id = claim_out['claim_id']
+            self.fee = claim_out['fee']
 
         d = self.wallet.claim_name(self.publish_name, self.bid_amount, m)
-        d.addCallback(set_txid_nout)
+        d.addCallback(set_claim_out)
         return d
 
     def _update_metadata(self):

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -40,15 +40,18 @@ class Publisher(object):
 
     def start(self, name, file_path, bid, metadata):
         log.info('Starting publish for %s', name)
+
         def _show_result():
-            log.info("Success! Published %s --> lbry://%s txid: %s nout: %d",
-                      self.file_name, self.publish_name, self.txid, self.nout)
-            out = {}
-            out['nout'] = self.nout
-            out['txid'] = self.txid
-            out['claim_id'] = self.claim_id
-            out['fee'] = self.fee
-            return defer.succeed(out)
+            log.info(
+                "Success! Published %s --> lbry://%s txid: %s nout: %d",
+                self.file_name, self.publish_name, self.txid, self.nout
+            )
+            return defer.succeed({
+                'nout': self.nout,
+                'txid': self.txid,
+                'claim_id': self.claim_id,
+                'fee': self.fee,
+            })
 
         self.publish_name = name
         self.file_path = file_path


### PR DESCRIPTION
The Daemon RPC command "publish" did not return the claim ID of the claim and fee when going through Publisher class (Publisher class only returned txid and nout).  

It was also returning the claim Id in a dictionary with the key "claimid" which was inconsistent with other claim functions which were using the key "claim_id". This requires lbryum patch : https://github.com/lbryio/lbryum/pull/70

Added comments on what the claim_name() function does in Wallet.py 



