### PR TITLE
The Great API Renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,11 @@
 
 /build
 /dist
+/lbrynet.egg-info
 
 .idea/.name
 .coverage
 .DS_Store
-
-lbrynet.egg-info/PKG-INFO
 
 # temporary files from the twisted.trial test runner
 _trial_temp/

--- a/FAQ.md
+++ b/FAQ.md
@@ -81,6 +81,6 @@ Note: the lbry api can only be used while either the app or lbrynet-daemon comma
     if not status['is_running']:
       print status
     else:
-      for func in api.help():
-        print "%s:\n%s" % (func, api.help({'function': func}))
+      for cmd in api.commands():
+        print "%s:\n%s" % (cmd, api.help({'command': cmd}))
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -77,8 +77,9 @@ Note: the lbry api can only be used while either the app or lbrynet-daemon comma
       sys.exit(0)
   
     api = JSONRPCProxy.from_url(API_CONNECTION_STRING)
-    if not api.is_running():
-      print api.daemon_status()
+    status = api.status()
+    if not status['is_running']:
+      print status
     else:
       for func in api.help():
         print "%s:\n%s" % (func, api.help({'function': func}))

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ except:
   API_CONNECTION_STRING = "http://localhost:5279/lbryapi"
   
 api = JSONRPCProxy.from_url(API_CONNECTION_STRING)
-if not api.is_running():
-  print api.daemon_status()
+status = api.status()
+if not status['is_running']:
+      print status
 else:
   for func in api.help():
     print "%s:\n%s" % (func, api.help({'function': func}))

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ status = api.status()
 if not status['is_running']:
       print status
 else:
-  for func in api.help():
-    print "%s:\n%s" % (func, api.help({'function': func}))
+    for cmd in api.commands():
+        print "%s:\n%s" % (cmd, api.help({'command': cmd}))
 ```
 
 If you've installed lbrynet, it comes with a file sharing application, called `lbrynet-daemon`, which breaks

--- a/lbrynet/core/Error.py
+++ b/lbrynet/core/Error.py
@@ -96,9 +96,5 @@ class InvalidAuthenticationToken(Exception):
     pass
 
 
-class SubhandlerError(Exception):
-    pass
-
-
 class NegotiationError(Exception):
     pass

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -859,7 +859,7 @@ class LBRYumWallet(Wallet):
         def setup_network():
             self.config = make_config(self._config)
             self.network = Network(self.config)
-            alert.info("Loading the wallet...")
+            alert.info("Loading the wallet")
             return defer.succeed(self.network.start())
 
         d = setup_network()
@@ -867,7 +867,7 @@ class LBRYumWallet(Wallet):
         def check_started():
             if self.network.is_connecting():
                 if not self.printed_retrieving_headers and self.network.blockchain.retrieving_headers:
-                    alert.info("Running the wallet for the first time...this may take a moment.")
+                    alert.info("Running the wallet for the first time. This may take a moment.")
                     self.printed_retrieving_headers = True
                 return False
             self._start_check.stop()

--- a/lbrynet/create_network.py
+++ b/lbrynet/create_network.py
@@ -14,7 +14,7 @@ amount = 0
 
 
 def destroyNetwork(nodes):
-    print 'Destroying Kademlia network...'
+    print 'Destroying Kademlia network'
     i = 0
     for node in nodes:
         i += 1
@@ -50,12 +50,12 @@ def main():
     else:
         import socket
         ipAddress = socket.gethostbyname(socket.gethostname())
-        print 'Network interface IP address omitted; using %s...' % ipAddress
+        print 'Network interface IP address omitted; using %s' % ipAddress
 
     startPort = 4000
     port = startPort+1
     nodes = []
-    print 'Creating Kademlia network...'
+    print 'Creating Kademlia network'
     try:
         node = os.spawnlp(
             os.P_NOWAIT, 'lbrynet-launch-node', 'lbrynet-launch-node', str(startPort))

--- a/lbrynet/dht_scripts.py
+++ b/lbrynet/dht_scripts.py
@@ -16,10 +16,10 @@ def print_usage():
 def join_network(udp_port, known_nodes):
     lbryid = generate_id()
 
-    log.info('Creating Node...')
+    log.info('Creating Node')
     node = Node(udpPort=udp_port, lbryid=lbryid)
 
-    log.info('Joining network...')
+    log.info('Joining network')
     d = node.joinNetwork(known_nodes)
 
     def log_network_size():

--- a/lbrynet/dhttest.py
+++ b/lbrynet/dhttest.py
@@ -59,7 +59,7 @@ def storeValueCallback(*args, **kwargs):
     """ Callback function that is invoked when the storeValue() operation succeeds """
     print 'Value has been stored in the DHT'
     # Now that the value has been stored, schedule that the value is read again after 2.5 seconds
-    print 'Scheduling retrieval in 2.5 seconds...'
+    print 'Scheduling retrieval in 2.5 seconds'
     twisted.internet.reactor.callLater(2.5, getValue)
 
 
@@ -72,7 +72,7 @@ def getValue():
     """ Retrieves the value of the specified key (KEY) from the DHT """
     global node, KEY
     # Get the value for the specified key (immediately returns a Twisted deferred result)
-    print ('\nRetrieving value from DHT for key "%s"...' %
+    print ('\nRetrieving value from DHT for key "%s"' %
            binascii.unhexlify("f7d9dc4de674eaa2c5a022eb95bc0d33ec2e75c6"))
     deferredResult = node.iterativeFindValue(
         binascii.unhexlify("f7d9dc4de674eaa2c5a022eb95bc0d33ec2e75c6"))
@@ -91,13 +91,13 @@ def getValueCallback(result):
     print result
 
     # Either way, schedule a "delete" operation for the key
-    print 'Scheduling shutdown in 2.5 seconds...'
+    print 'Scheduling shutdown in 2.5 seconds'
     twisted.internet.reactor.callLater(2.5, stop)
 
 
 def stop():
     """ Stops the Twisted reactor, and thus the script """
-    print '\nStopping Kademlia node and terminating script...'
+    print '\nStopping Kademlia node and terminating script'
     twisted.internet.reactor.stop()
 
 if __name__ == '__main__':
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     #
     # If you wish to have a pure Kademlia network, use the
     # entangled.kademlia.node.Node class instead
-    print 'Creating Node...'
+    print 'Creating Node'
     node = Node(udpPort=int(sys.argv[1]), lbryid=lbryid)
 
     # Schedule the node to join the Kademlia/Entangled DHT

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -94,10 +94,6 @@ CONNECTION_MESSAGES = {
                               "If this continues try restarting LBRY",
 }
 
-BAD_REQUEST = 400
-NOT_FOUND = 404
-OK_CODE = 200
-
 PENDING_ID = "not set"
 SHORT_ID_LEN = 20
 
@@ -206,10 +202,7 @@ class Daemon(AuthJSONRPCServer):
         AuthJSONRPCServer.__init__(self, conf.settings.use_auth_http)
         reactor.addSystemEventTrigger('before', 'shutdown', self._shutdown)
 
-        self.allowed_during_startup = [
-            'get_time_behind_blockchain', 'stop',
-            'status', 'version'
-        ]
+        self.allowed_during_startup = ['get_time_behind_blockchain', 'stop','status', 'version']
         last_version = {'last_version': {'lbrynet': lbrynet_version, 'lbryum': lbryum_version}}
         conf.settings.update(last_version)
         self.db_dir = conf.settings.data_dir
@@ -1122,9 +1115,9 @@ class Daemon(AuthJSONRPCServer):
 
             d.addCallback(_include_blockchain_status)
 
-        d.addCallback(lambda x: self._render_response(response, OK_CODE))
+        d.addCallback(lambda x: self._render_response(response))
         return d
-        # return self._render_response(response, OK_CODE)
+        # return self._render_response(response)
 
     def jsonrpc_get_best_blockhash(self):
         """
@@ -1132,7 +1125,7 @@ class Daemon(AuthJSONRPCServer):
         """
         d = self.jsonrpc_status({'blockchain_status': True})
         d.addCallback(lambda x: self._render_response(
-            x['result']['blockchain_status']['best_blockhash'], OK_CODE))
+            x['result']['blockchain_status']['best_blockhash']))
         return d
 
     def jsonrpc_is_running(self):
@@ -1140,7 +1133,7 @@ class Daemon(AuthJSONRPCServer):
         DEPRECATED. Use `status` instead
         """
         d = self.jsonrpc_status({'blockchain_status': True})
-        d.addCallback(lambda x: self._render_response(x['result']['is_running'], OK_CODE))
+        d.addCallback(lambda x: self._render_response(x['result']['is_running']))
         return d
 
     def jsonrpc_daemon_status(self):
@@ -1173,7 +1166,7 @@ class Daemon(AuthJSONRPCServer):
 
         d = self.jsonrpc_status()
         d.addCallback(_simulate_old_daemon_status)
-        d.addCallback(lambda x: self._render_response(x, OK_CODE))  # is this necessary?
+        d.addCallback(lambda x: self._render_response(x))  # is this necessary?
         return d
 
     def jsonrpc_is_first_run(self):
@@ -1181,7 +1174,7 @@ class Daemon(AuthJSONRPCServer):
         DEPRECATED. Use `status` instead
         """
         d = self.jsonrpc_status({'blockchain_status': True})
-        d.addCallback(lambda x: self._render_response(x['result']['is_first_run'], OK_CODE))
+        d.addCallback(lambda x: self._render_response(x['result']['is_first_run']))
         return d
 
     def jsonrpc_get_lbry_session_info(self):
@@ -1194,7 +1187,7 @@ class Daemon(AuthJSONRPCServer):
             'lbry_id': x['result']['lbry_id'],
             'managed_blobs': x['result']['session_status']['managed_blobs'],
             'managed_streams': x['result']['session_status']['managed_streams'],
-        }, OK_CODE))
+        }))
         return d
 
     def jsonrpc_get_time_behind_blockchain(self):
@@ -1202,7 +1195,7 @@ class Daemon(AuthJSONRPCServer):
         DEPRECATED. Use `status` instead
         """
         d = self.jsonrpc_status({'blockchain_status': True})  # blockchain_status=True is needed
-        d.addCallback(lambda x: self._render_response(x['result']['blocks_behind'], OK_CODE))
+        d.addCallback(lambda x: self._render_response(x['result']['blocks_behind']))
         return d
 
     def jsonrpc_version(self):
@@ -1247,7 +1240,7 @@ class Daemon(AuthJSONRPCServer):
         }
 
         log.info("Get version info: " + json.dumps(msg))
-        return self._render_response(msg, OK_CODE)
+        return self._render_response(msg)
 
     def jsonrpc_report_bug(self, p):
         """
@@ -1262,7 +1255,7 @@ class Daemon(AuthJSONRPCServer):
         bug_message = p['message']
         platform_name = self._get_platform()['platform']
         report_bug_to_slack(bug_message, self.lbryid, platform_name, lbrynet_version)
-        return self._render_response(True, OK_CODE)
+        return self._render_response(True)
 
     def jsonrpc_get_settings(self):
         """
@@ -1297,7 +1290,7 @@ class Daemon(AuthJSONRPCServer):
         log.info("Get daemon settings")
         settings_dict = conf.settings.get_dict()
         settings_dict['lbryid'] = binascii.hexlify(settings_dict['lbryid'])
-        return self._render_response(settings_dict, OK_CODE)
+        return self._render_response(settings_dict)
 
     @AuthJSONRPCServer.auth_required
     def jsonrpc_set_settings(self, p):
@@ -1333,7 +1326,7 @@ class Daemon(AuthJSONRPCServer):
         d.addErrback(lambda err: log.info(err.getTraceback()))
         d.addCallback(lambda _: _log_settings_change())
         d.addCallback(
-            lambda _: self._render_response(conf.settings.get_adjustable_settings_dict(), OK_CODE))
+            lambda _: self._render_response(conf.settings.get_adjustable_settings_dict()))
 
         return d
 
@@ -1352,17 +1345,17 @@ class Daemon(AuthJSONRPCServer):
         """
 
         if not p:
-            return self._render_response(", ".join(sorted(self.callable_methods.keys())), OK_CODE)
+            return self._render_response(", ".join(sorted(self.callable_methods.keys())))
         elif 'callable_during_startup' in p:
-            return self._render_response(", ".join(sorted(self.allowed_during_startup)), OK_CODE)
+            return self._render_response(", ".join(sorted(self.allowed_during_startup)))
         elif 'function' in p:
             fn = self.callable_methods.get(p['function'])
             if fn is None:
                 return self._render_response(
-                    "Function '" + p['function'] + "' is not a valid function", OK_CODE)
-            return self._render_response(textwrap.dedent(fn.__doc__), OK_CODE)
+                    "Function '" + p['function'] + "' is not a valid function")
+            return self._render_response(textwrap.dedent(fn.__doc__))
         else:
-            return self._render_response(textwrap.dedent(self.jsonrpc_help.__doc__), OK_CODE)
+            return self._render_response(textwrap.dedent(self.jsonrpc_help.__doc__))
 
     def jsonrpc_commands(self):
         """
@@ -1371,7 +1364,7 @@ class Daemon(AuthJSONRPCServer):
         Returns:
             list
         """
-        return self._render_response(sorted(self.callable_methods.keys()), OK_CODE)
+        return self._render_response(sorted(self.callable_methods.keys()))
 
     def jsonrpc_get_balance(self):
         """
@@ -1386,7 +1379,7 @@ class Daemon(AuthJSONRPCServer):
         Returns:
             balance, float
         """
-        return self._render_response(float(self.session.wallet.wallet_balance), OK_CODE)
+        return self._render_response(float(self.session.wallet.wallet_balance))
 
     def jsonrpc_stop(self):
         """
@@ -1408,7 +1401,7 @@ class Daemon(AuthJSONRPCServer):
         d = self._shutdown()
         d.addCallback(lambda _: _display_shutdown_message())
         d.addCallback(lambda _: reactor.callLater(0.0, reactor.stop))
-        return self._render_response("Shutting down", OK_CODE)
+        return self._render_response("Shutting down")
 
     def jsonrpc_get_lbry_files(self):
         """
@@ -1437,7 +1430,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self._get_lbry_files()
-        d.addCallback(lambda r: self._render_response([d[1] for d in r if d[0]], OK_CODE))
+        d.addCallback(lambda r: self._render_response([d[1] for d in r if d[0]]))
 
         return d
 
@@ -1468,7 +1461,7 @@ class Daemon(AuthJSONRPCServer):
             'sd_hash': string
         """
         d = self._get_deferred_for_lbry_file(p)
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def _get_deferred_for_lbry_file(self, p):
@@ -1493,11 +1486,11 @@ class Daemon(AuthJSONRPCServer):
 
         name = p.get(FileID.NAME)
         if not name:
-            return self._render_response(None, BAD_REQUEST)
+            return self._render_response(None)
 
         d = self._resolve_name(name, force_refresh=force)
         d.addCallbacks(
-            lambda info: self._render_response(info, OK_CODE),
+            lambda info: self._render_response(info),
             # TODO: Is server.failure a module? It looks like it:
             #
             # In [1]: import twisted.web.server
@@ -1544,7 +1537,7 @@ class Daemon(AuthJSONRPCServer):
         nout = p.get('nout', None)
         d = self.session.wallet.get_claim_info(name, txid, nout)
         d.addCallback(_convert_amount_to_float)
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def _process_get_parameters(self, p):
@@ -1605,7 +1598,7 @@ class Daemon(AuthJSONRPCServer):
                 'stream_hash': params.sd_hash if params.stream_info else lbry_file.sd_hash,
                 'path': os.path.join(lbry_file.download_directory, lbry_file.file_name)
             }
-            response = yield self._render_response(message, OK_CODE)
+            response = yield self._render_response(message)
             defer.returnValue(response)
 
         download_id = utils.random_string()
@@ -1622,7 +1615,7 @@ class Daemon(AuthJSONRPCServer):
         except Exception as e:
             self.analytics_manager.send_download_errored(download_id, name, stream_info)
             log.exception('Failed to get %s', params.name)
-            response = yield self._render_response(str(e), OK_CODE)
+            response = yield self._render_response(str(e))
         else:
             # TODO: should stream_hash key be changed to sd_hash?
             message = {
@@ -1635,7 +1628,7 @@ class Daemon(AuthJSONRPCServer):
                     lambda _: self.analytics_manager.send_download_finished(
                         download_id, name, stream_info)
                 )
-            response = yield self._render_response(message, OK_CODE)
+            response = yield self._render_response(message)
         defer.returnValue(response)
 
     @AuthJSONRPCServer.auth_required
@@ -1685,7 +1678,7 @@ class Daemon(AuthJSONRPCServer):
             msg = "Started seeding file" if status == 'start' else "Stopped seeding file"
         else:
             msg = "File was already being seeded" if status == 'start' else "File was already stopped"
-        defer.returnValue(self._render_response(msg, OK_CODE))
+        defer.returnValue(self._render_response(msg))
 
     @AuthJSONRPCServer.auth_required
     def jsonrpc_delete_lbry_file(self, p):
@@ -1724,7 +1717,7 @@ class Daemon(AuthJSONRPCServer):
             d = self._get_lbry_file(searchtype, value, return_json=False)
             d.addCallback(_delete_file)
 
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def jsonrpc_get_est_cost(self, p):
@@ -1748,7 +1741,7 @@ class Daemon(AuthJSONRPCServer):
         name = p.get(FileID.NAME, None)
 
         d = self.get_est_cost(name, size)
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -1827,7 +1820,7 @@ class Daemon(AuthJSONRPCServer):
                 d.addCallback(lambda claim_out: _reflect_if_possible(sd_hash, claim_out))
 
         d.addCallback(lambda claim_out: self._add_to_pending_claims(name, claim_out))
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
 
         return d
 
@@ -1854,7 +1847,7 @@ class Daemon(AuthJSONRPCServer):
 
         def _disp(x):
             log.info("Abandoned name claim tx " + str(x))
-            return self._render_response(x, OK_CODE)
+            return self._render_response(x)
 
         d = defer.Deferred()
         d.addCallback(lambda _: self.session.wallet.abandon_claim(p['txid'], p['nout']))
@@ -1901,7 +1894,7 @@ class Daemon(AuthJSONRPCServer):
         claim_id = p['claim_id']
         amount = p['amount']
         d = self.session.wallet.support_claim(name, claim_id, amount)
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     # TODO: merge this into claim_list
@@ -1919,7 +1912,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.wallet.get_my_claim(p[FileID.NAME])
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -1950,7 +1943,7 @@ class Daemon(AuthJSONRPCServer):
 
         d = self.session.wallet.get_name_claims()
         d.addCallback(_clean)
-        d.addCallback(lambda claims: self._render_response(claims, OK_CODE))
+        d.addCallback(lambda claims: self._render_response(claims))
         return d
 
     def jsonrpc_get_claims_for_name(self, p):
@@ -1983,7 +1976,7 @@ class Daemon(AuthJSONRPCServer):
         else:
             return server.failure
 
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -2005,7 +1998,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.wallet.get_history()
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def jsonrpc_get_transaction(self, p):
@@ -2025,7 +2018,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.wallet.get_transaction(p['txid'])
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -2047,7 +2040,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.wallet.address_is_mine(p['address'])
-        d.addCallback(lambda is_mine: self._render_response(is_mine, OK_CODE))
+        d.addCallback(lambda is_mine: self._render_response(is_mine))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -2069,7 +2062,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.wallet.get_pub_keys(p['wallet'])
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
 
     @AuthJSONRPCServer.auth_required
     def jsonrpc_get_new_address(self):
@@ -2095,7 +2088,7 @@ class Daemon(AuthJSONRPCServer):
 
         d = self.session.wallet.get_new_address()
         d.addCallback(_disp)
-        d.addCallback(lambda address: self._render_response(address, OK_CODE))
+        d.addCallback(lambda address: self._render_response(address))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -2121,7 +2114,7 @@ class Daemon(AuthJSONRPCServer):
         if reserved_points is None:
             return defer.fail(InsufficientFundsError())
         d = self.session.wallet.send_points_to_address(reserved_points, amount)
-        d.addCallback(lambda _: self._render_response(True, OK_CODE))
+        d.addCallback(lambda _: self._render_response(True))
         return d
 
     def jsonrpc_get_block(self, p):
@@ -2148,7 +2141,7 @@ class Daemon(AuthJSONRPCServer):
         else:
             # TODO: return a useful error message
             return server.failure
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -2172,8 +2165,8 @@ class Daemon(AuthJSONRPCServer):
         timeout = p.get('timeout', conf.settings.sd_download_timeout)
         d = self._download_sd_blob(sd_hash, timeout)
         d.addCallbacks(
-            lambda r: self._render_response(r, OK_CODE),
-            lambda _: self._render_response(False, OK_CODE))
+            lambda r: self._render_response(r),
+            lambda _: self._render_response(False))
         return d
 
     def jsonrpc_get_nametrie(self):
@@ -2188,7 +2181,7 @@ class Daemon(AuthJSONRPCServer):
 
         d = self.session.wallet.get_nametrie()
         d.addCallback(lambda r: [i for i in r if 'txid' in i.keys()])
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def jsonrpc_log(self, p):
@@ -2204,7 +2197,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         log.info("API client log request: %s" % p['message'])
-        return self._render_response(True, OK_CODE)
+        return self._render_response(True)
 
     def jsonrpc_upload_log(self, p=None):
         """
@@ -2247,7 +2240,7 @@ class Daemon(AuthJSONRPCServer):
             exclude_previous = True
 
         d = self._upload_log(log_type=log_type, exclude_previous=exclude_previous, force=force)
-        d.addCallback(lambda _: self._render_response(True, OK_CODE))
+        d.addCallback(lambda _: self._render_response(True))
         return d
 
     @AuthJSONRPCServer.auth_required
@@ -2272,7 +2265,7 @@ class Daemon(AuthJSONRPCServer):
             d = self.lbry_ui_manager.setup(branch=p['branch'], check_requirements=check_require)
         else:
             d = self.lbry_ui_manager.setup(check_requirements=check_require)
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
 
         return d
 
@@ -2293,7 +2286,7 @@ class Daemon(AuthJSONRPCServer):
             # No easy way to reveal specific files on Linux, so just open the containing directory
             d = threads.deferToThread(subprocess.Popen, ['xdg-open', os.path.dirname(path)])
 
-        d.addCallback(lambda _: self._render_response(True, OK_CODE))
+        d.addCallback(lambda _: self._render_response(True))
         return d
 
     def jsonrpc_get_peers_for_hash(self, p):
@@ -2316,7 +2309,7 @@ class Daemon(AuthJSONRPCServer):
 
         d = self.session.peer_finder.find_peers_for_blob(blob_hash)
         d.addCallback(lambda r: [[c.host, c.port, c.is_available()] for c in r])
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def jsonrpc_announce_all_blobs_to_dht(self):
@@ -2336,7 +2329,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.blob_manager.immediate_announce_all_blobs()
-        d.addCallback(lambda _: self._render_response("Announced", OK_CODE))
+        d.addCallback(lambda _: self._render_response("Announced"))
         return d
 
     def jsonrpc_reflect(self, p):
@@ -2353,8 +2346,8 @@ class Daemon(AuthJSONRPCServer):
         d = self._get_lbry_file(FileID.SD_HASH, sd_hash, return_json=False)
         d.addCallback(self._reflect)
         d.addCallbacks(
-            lambda _: self._render_response(True, OK_CODE),
-            lambda err: self._render_response(err.getTraceback(), OK_CODE))
+            lambda _: self._render_response(True),
+            lambda err: self._render_response(err.getTraceback()))
         return d
 
     def jsonrpc_get_blob_hashes(self):
@@ -2374,7 +2367,7 @@ class Daemon(AuthJSONRPCServer):
         """
 
         d = self.session.blob_manager.get_all_verified_blobs()
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def jsonrpc_reflect_all_blobs(self):
@@ -2395,7 +2388,7 @@ class Daemon(AuthJSONRPCServer):
 
         d = self.session.blob_manager.get_all_verified_blobs()
         d.addCallback(self._reflect_blobs)
-        d.addCallback(lambda r: self._render_response(r, OK_CODE))
+        d.addCallback(lambda r: self._render_response(r))
         return d
 
     def jsonrpc_get_mean_availability(self):
@@ -2408,7 +2401,7 @@ class Daemon(AuthJSONRPCServer):
             Mean peers for a blob
         """
 
-        d = self._render_response(self.session.blob_tracker.last_mean_availability, OK_CODE)
+        d = self._render_response(self.session.blob_tracker.last_mean_availability)
         return d
 
     def jsonrpc_get_availability(self, p):
@@ -2440,15 +2433,15 @@ class Daemon(AuthJSONRPCServer):
             lambda _: [])
         d.addCallback(self.session.blob_tracker.get_availability_for_blobs)
         d.addCallback(_get_mean)
-        d.addCallback(lambda result: self._render_response(result, OK_CODE))
+        d.addCallback(lambda result: self._render_response(result))
 
         return d
 
     @AuthJSONRPCServer.auth_required
     def jsonrpc_test_api_authentication(self):
         if self._use_authentication:
-            return self._render_response(True, OK_CODE)
-        return self._render_response("Not using authentication", OK_CODE)
+            return self._render_response(True)
+        return self._render_response("Not using authentication")
 
 
 def get_lbryum_version_from_github():

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1682,7 +1682,9 @@ class Daemon(AuthJSONRPCServer):
             yield self.lbry_file_manager.toggle_lbry_file_running(lbry_file)
             msg = "Started seeding file" if status == 'start' else "Stopped seeding file"
         else:
-            msg = "File was already being seeded" if status == 'start' else "File was already stopped"
+            msg = (
+                "File was already being seeded" if status == 'start' else "File was already stopped"
+            )
         defer.returnValue(self._render_response(msg))
 
     @AuthJSONRPCServer.auth_required

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1336,27 +1336,20 @@ class Daemon(AuthJSONRPCServer):
 
     def jsonrpc_help(self, p=None):
         """
-        Function to retrieve docstring for API function
+        Return a useful message for an API command
 
         Args:
-            'function': optional, function to retrieve documentation for
-            'callable_during_startup': optional, returns functions that are callable during startup
+            'command': optional, command to retrieve documentation for
         Returns:
-            if given a function, returns given documentation
-            if given callable_during_startup flag, returns list of
-            functions callable during the startup sequence
-            if no params are given, returns the list of callable functions
+            if given a command, returns documentation about that command
+            otherwise returns general help message
         """
 
-        if not p:
-            return self._render_response(", ".join(sorted(self.callable_methods.keys())))
-        elif 'callable_during_startup' in p:
-            return self._render_response(", ".join(sorted(self.allowed_during_startup)))
-        elif 'function' in p:
-            fn = self.callable_methods.get(p['function'])
+        if p and 'command' in p:
+            fn = self.callable_methods.get(p['command'])
             if fn is None:
                 return self._render_response(
-                    "No help available for '" + p['function'] + "'. It is not a valid function."
+                    "No help available for '" + p['command'] + "'. It is not a valid command."
                 )
             return self._render_response(textwrap.dedent(fn.__doc__))
         else:

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -75,7 +75,7 @@ DOWNLOAD_TIMEOUT_CODE = 'timeout'
 DOWNLOAD_RUNNING_CODE = 'running'
 DOWNLOAD_STOPPED_CODE = 'stopped'
 STREAM_STAGES = [
-    (INITIALIZING_CODE, 'Initializing...'),
+    (INITIALIZING_CODE, 'Initializing'),
     (DOWNLOAD_METADATA_CODE, 'Downloading metadata'),
     (DOWNLOAD_RUNNING_CODE, 'Started %s, got %s/%s blobs, stream status: %s'),
     (DOWNLOAD_STOPPED_CODE, 'Paused stream'),
@@ -637,7 +637,7 @@ class Daemon(AuthJSONRPCServer):
     def _setup_data_directory(self):
         old_revision = 1
         self.startup_status = STARTUP_STAGES[1]
-        log.info("Loading databases...")
+        log.info("Loading databases")
         if self.created_data_dir:
             self._write_db_revision_file(self.current_db_revision)
             log.debug("Created the db revision file: %s", self.db_revision_file)
@@ -662,7 +662,7 @@ class Daemon(AuthJSONRPCServer):
 
         if old_revision < self.current_db_revision:
             from lbrynet.db_migrator import dbmigrator
-            log.info("Upgrading your databases...")
+            log.info("Upgrading your databases")
             d = threads.deferToThread(
                 dbmigrator.migrate_db, self.db_dir, old_revision, self.current_db_revision)
             d.addCallback(lambda _: update_version_file_and_print_success())
@@ -1315,7 +1315,8 @@ class Daemon(AuthJSONRPCServer):
         elif 'function' in p:
             fn = self.callable_methods.get(p['function'])
             if fn is None:
-                return self._render_response("Function not found", OK_CODE)
+                return self._render_response(
+                    "Function '" + p['function'] + "' is not a valid function", OK_CODE)
             return self._render_response(textwrap.dedent(fn.__doc__), OK_CODE)
         else:
             return self._render_response(textwrap.dedent(self.jsonrpc_help.__doc__), OK_CODE)

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -261,7 +261,6 @@ class Daemon(AuthJSONRPCServer):
 
         self.analytics_manager = analytics_manager
         self.lbryid = conf.settings.lbryid
-        self.daemon_conf = conf.settings.get_conf_filename()
 
         self.wallet_user = None
         self.wallet_password = None
@@ -1357,7 +1356,8 @@ class Daemon(AuthJSONRPCServer):
             fn = self.callable_methods.get(p['function'])
             if fn is None:
                 return self._render_response(
-                    "Function '" + p['function'] + "' is not a valid function")
+                    "No help available for '" + p['function'] + "'. It is not a valid function."
+                )
             return self._render_response(textwrap.dedent(fn.__doc__))
         else:
             return self._render_response(textwrap.dedent(self.jsonrpc_help.__doc__))
@@ -2220,29 +2220,26 @@ class Daemon(AuthJSONRPCServer):
 
         """
 
+        exclude_previous = True
+        force = False
+        log_type = None
+
         if p:
             if 'name_prefix' in p:
                 log_type = p['name_prefix'] + '_api'
             elif 'log_type' in p:
                 log_type = p['log_type'] + '_api'
-            else:
-                log_type = None
 
             if 'exclude_previous' in p:
                 exclude_previous = p['exclude_previous']
-            else:
-                exclude_previous = True
 
             if 'message' in p:
                 log.info("Upload log message: " + str(p['message']))
 
             if 'force' in p:
                 force = p['force']
-            else:
-                force = False
         else:
             log_type = "api"
-            exclude_previous = True
 
         d = self._upload_log(log_type=log_type, exclude_previous=exclude_previous, force=force)
         d.addCallback(lambda _: self._render_response(True))

--- a/lbrynet/lbrynet_daemon/DaemonCLI.py
+++ b/lbrynet/lbrynet_daemon/DaemonCLI.py
@@ -2,17 +2,11 @@ import sys
 import argparse
 import json
 from lbrynet import conf
+import os
 from lbrynet.lbrynet_daemon.auth.client import LBRYAPIClient
+from lbrynet.lbrynet_daemon.Daemon import LOADING_WALLET_CODE
 from jsonrpc.common import RPCError
-
-
-
-help_msg = "Usage: lbrynet-cli method kwargs\n" \
-             + "Examples: " \
-             + "lbrynet-cli resolve_name name=what\n" \
-             + "lbrynet-cli get_balance\n" \
-             + "lbrynet-cli help function=resolve_name\n" \
-             + "\n******lbrynet-cli functions******\n"
+from urllib2 import URLError
 
 
 def guess_type(x):
@@ -31,35 +25,41 @@ def guess_type(x):
 def get_params_from_kwargs(params):
     params_for_return = {}
     for i in params:
+        if '=' not in i:
+            print 'WARNING: Argument "' + i + '" is missing a parameter name. Please use name=value'
+            continue
         eq_pos = i.index('=')
-        k, v = i[:eq_pos], i[eq_pos+1:]
+        k, v = i[:eq_pos], i[eq_pos + 1:]
         params_for_return[k] = guess_type(v)
     return params_for_return
 
 
 def main():
     conf.initialize_settings()
-    api = LBRYAPIClient.config()
+    api = LBRYAPIClient.get_client()
 
     try:
-        status = api.daemon_status()
-        assert status.get('code', False) == "started"
-    except Exception:
-        try:
-            conf.settings.update({'use_auth_http': not conf.settings.use_auth_http})
-            api = LBRYAPIClient.config()
-            status = api.daemon_status()
-            assert status.get('code', False) == "started"
-        except Exception:
-            print "lbrynet-daemon isn't running"
-            sys.exit(1)
+        status = api.status()
+    except URLError:
+        print "Could not connect to lbrynet-daemon. Are you sure it's running?"
+        sys.exit(1)
+
+    if status['startup_status']['code'] != "started":
+        print "Daemon is in the process of starting. Please try again in a bit."
+        message = status['startup_status']['message']
+        if message:
+            if status['startup_status']['code'] == LOADING_WALLET_CODE \
+                    and status['blocks_behind'] > 0:
+                message += '. Blocks left: ' + str(status['blocks_behind'])
+            print "  Status: " + message
+        sys.exit(1)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('method', nargs=1)
     parser.add_argument('params', nargs=argparse.REMAINDER, default=None)
     args = parser.parse_args()
 
-    meth = args.method[0]
+    method = args.method[0]
     params = {}
 
     if len(args.params) > 1:
@@ -70,34 +70,41 @@ def main():
         except ValueError:
             params = get_params_from_kwargs(args.params)
 
-    msg = help_msg
-    for f in api.help():
-        msg += f + "\n"
+    if method in ['--help', '-h', 'help']:
+        helpmsg = api.help(params).strip()
+        if params is not None and 'function' in params:
+            print "\n" + params['function'] + ": " + helpmsg + "\n"
+        else:
+            print "Usage: lbrynet-cli method [params]\n" \
+                  + "Examples: \n" \
+                  + "  lbrynet-cli get_balance\n" \
+                  + "  lbrynet-cli resolve_name name=what\n" \
+                  + "  lbrynet-cli help function=resolve_name\n" \
+                  + "\nAvailable functions:\n" \
+                  + helpmsg + "\n"
 
-    if meth in ['--help', '-h', 'help']:
-        print msg
-        sys.exit(1)
-
-    if meth in api.help():
+    elif method not in api.commands():
+        print "Error: function \"" + method + "\" does not exist.\n" + \
+              "See \"" + os.path.basename(sys.argv[0]) + " help\""
+    else:
         try:
-            if params:
-                result = LBRYAPIClient.config(service=meth, params=params)
-            else:
-                result = LBRYAPIClient.config(service=meth, params=params)
-            print json.dumps(result, sort_keys=True)
+            result = api.call(method, params)
+            print json.dumps(result, sort_keys=True, indent=2)
         except RPCError as err:
             # TODO: The api should return proper error codes
             # and messages so that they can be passed along to the user
             # instead of this generic message.
             # https://app.asana.com/0/158602294500137/200173944358192
-            print "Something went wrong, here's the usage for %s:" % meth
-            print api.help({'function': meth})
+            print "Something went wrong, here's the usage for %s:" % method
+            print api.help({'function': method})
             print "Here's the traceback for the error you encountered:"
             print err.msg
-
-    else:
-        print "Unknown function"
-        print msg
+        except KeyError as err:
+            print "Something went wrong, here's the usage for %s:" % method
+            print api.help({'function': method})
+            if hasattr(err, 'msg'):
+                print "Here's the traceback for the error you encountered:"
+                print err.msg
 
 
 if __name__ == '__main__':

--- a/lbrynet/lbrynet_daemon/DaemonCLI.py
+++ b/lbrynet/lbrynet_daemon/DaemonCLI.py
@@ -1,12 +1,88 @@
-import sys
 import argparse
 import json
-from lbrynet import conf
 import os
+import sys
+
+from lbrynet import conf
 from lbrynet.lbrynet_daemon.auth.client import LBRYAPIClient
 from lbrynet.lbrynet_daemon.Daemon import LOADING_WALLET_CODE
 from jsonrpc.common import RPCError
 from urllib2 import URLError
+
+
+def main():
+    parser = argparse.ArgumentParser(add_help=False)
+    _, arguments = parser.parse_known_args()
+
+    if len(arguments) < 1:
+        print_help()
+        return 1
+
+    method = arguments[0]
+    try:
+        params = parse_params(arguments[1:])
+    except InvalidParameters as e:
+        print_error(e.message)
+        return 1
+
+    conf.initialize_settings()
+    api = LBRYAPIClient.get_client()
+
+    # TODO: check if port is bound. Error if its not
+
+    try:
+        status = api.status()
+    except URLError:
+        print_error("Could not connect to daemon. Are you sure it's running?",
+                    suggest_help=False)
+        return 1
+
+    if status['startup_status']['code'] != "started":
+        print "Daemon is in the process of starting. Please try again in a bit."
+        message = status['startup_status']['message']
+        if message:
+            if (
+                status['startup_status']['code'] == LOADING_WALLET_CODE
+                and status['blocks_behind'] > 0
+            ):
+                message += '. Blocks left: ' + str(status['blocks_behind'])
+            print "  Status: " + message
+        return 1
+
+    if method in ['--help', '-h', 'help']:
+        if len(params) == 0:
+            print_help()
+            print "\nCOMMANDS\n" + wrap_list_to_term_width(api.commands(), prefix='   ')
+        else:
+            print api.help(params).strip()
+
+    elif method not in api.commands():
+        print_error("Function '" + method + "' is not a valid function.")
+
+    else:
+        try:
+            result = api.call(method, params)
+            if isinstance(result, basestring):
+                # printing the undumped string is prettier
+                print result
+            else:
+                print json.dumps(result, sort_keys=True, indent=2, separators=(',', ': '))
+        except RPCError as err:
+            handle_error(err, api, method)
+        except KeyError as err:
+            handle_error(err, api, method)
+
+
+def handle_error(err, api, method):
+    # TODO: The api should return proper error codes
+    # and messages so that they can be passed along to the user
+    # instead of this generic message.
+    # https://app.asana.com/0/158602294500137/200173944358192
+    print "Something went wrong, here's the usage for %s:" % method
+    print api.help({'function': method})
+    if hasattr(err, 'msg'):
+        print "Here's the traceback for the error you encountered:"
+        print err.msg
 
 
 def guess_type(x):
@@ -22,15 +98,42 @@ def guess_type(x):
         return x
 
 
+def parse_params(params):
+    if len(params) > 1:
+        return get_params_from_kwargs(params)
+    elif len(params) == 1:
+        try:
+            return json.loads(params[0])
+        except ValueError:
+            return get_params_from_kwargs(params)
+    else:
+        return {}
+
+
+class InvalidParameters(Exception):
+    pass
+
+
 def get_params_from_kwargs(params):
     params_for_return = {}
     for i in params:
-        if '=' not in i:
-            print 'WARNING: Argument "' + i + '" is missing a parameter name. Please use name=value'
-            continue
-        eq_pos = i.index('=')
-        params_for_return[i[:eq_pos]] = guess_type(i[eq_pos + 1:])
+        try:
+            eq_pos = i.index('=')
+        except ValueError:
+            raise InvalidParameters('{} is not in <key>=<value> format'.format(i))
+        k, v = i[:eq_pos], i[eq_pos + 1:]
+        params_for_return[k] = guess_type(v)
     return params_for_return
+
+
+def print_help_suggestion():
+    print "See `{} help` for more information.".format(os.path.basename(sys.argv[0]))
+
+
+def print_error(message, suggest_help=True):
+    print "ERROR: " + message
+    if suggest_help:
+        print_help_suggestion()
 
 
 def print_help():
@@ -60,94 +163,21 @@ def wrap_list_to_term_width(l, width=None, separator=', ', prefix=''):
             width = 80
 
     lines = []
-    curr_line = prefix
+    curr_line = ''
     for item in l:
         new_line = curr_line + item + separator
-        if len(new_line) > width:
+        if len(new_line) + len(prefix) > width:
             lines.append(curr_line)
-            curr_line = prefix + item + separator
+            curr_line = item + separator
         else:
             curr_line = new_line
+    lines.append(curr_line)
 
-    return "\n".join(lines)
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('params', nargs=argparse.ZERO_OR_MORE, default=None)
-    args = parser.parse_args()
-
-    if len(args.params) < 1:
-        print_help()
-        sys.exit(1)
-
-    method = args.params[0]
-    params = args.params[1:]
-
-    if len(params) > 1:
-        params = get_params_from_kwargs(params)
-    elif len(params) == 1:
-        try:
-            params = json.loads(params[0])
-        except ValueError:
-            params = get_params_from_kwargs(params)
-    else:
-        params = {}
-
-    conf.initialize_settings()
-    api = LBRYAPIClient.get_client()
-
-    # TODO: check if port is bound
-
-    try:
-        status = api.status()
-    except URLError:
-        print "Could not connect to lbrynet-daemon. Are you sure it's running?"
-        sys.exit(1)
-
-    if status['startup_status']['code'] != "started":
-        print "Daemon is in the process of starting. Please try again in a bit."
-        message = status['startup_status']['message']
-        if message:
-            if status['startup_status']['code'] == LOADING_WALLET_CODE \
-                    and status['blocks_behind'] > 0:
-                message += '. Blocks left: ' + str(status['blocks_behind'])
-            print "  Status: " + message
-        sys.exit(1)
-
-    if method in ['--help', '-h', 'help']:
-        if len(params) == 0:
-            print_help()
-            print "\nCOMMANDS\n" + wrap_list_to_term_width(api.commands(), prefix='   ')
-        else:
-            print api.help(params).strip()
-
-    elif method not in api.commands():
-        print (
-            "Function '" + method + "' is not a valid function.\n"
-            "See '" + os.path.basename(sys.argv[0]) + " help'"
-        )
-
-    else:
-        try:
-            result = api.call(method, params)
-            print json.dumps(result, sort_keys=True, indent=2)
-        except RPCError as err:
-            # TODO: The api should return proper error codes
-            # and messages so that they can be passed along to the user
-            # instead of this generic message.
-            # https://app.asana.com/0/158602294500137/200173944358192
-            print "Something went wrong, here's the usage for %s:" % method
-            print api.help({'function': method})
-            print "Here's the traceback for the error you encountered:"
-            print err.msg
-        except KeyError as err:
-            print "Something went wrong, here's the usage for %s:" % method
-            print api.help({'function': method})
-            if hasattr(err, 'msg'):
-                print "Here's the traceback for the error you encountered:"
-                print err.msg
+    ret = prefix + ("\n" + prefix).join(lines)
+    if ret.endswith(separator):
+        ret = ret[:-len(separator)]
+    return ret
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -9,7 +9,7 @@ from jsonrpc.proxy import JSONRPCProxy
 from lbrynet import analytics
 from lbrynet import conf
 from lbrynet.core import utils
-from lbrynet.lbrynet_daemon.auth import client
+from lbrynet.lbrynet_daemon.auth.client import LBRYAPIClient
 from lbrynet.lbrynet_daemon.DaemonServer import DaemonServer
 
 
@@ -24,7 +24,7 @@ def stop():
     conf.initialize_settings()
     log_support.configure_console()
     try:
-        client.LBRYAPIClient.config().stop()
+        LBRYAPIClient.get_client().call('stop')
     except Exception:
         log.exception('Failed to stop deamon')
     else:

--- a/lbrynet/lbrynet_daemon/Downloader.py
+++ b/lbrynet/lbrynet_daemon/Downloader.py
@@ -18,7 +18,7 @@ DOWNLOAD_RUNNING_CODE = 'running'
 # TODO: is this ever used?
 DOWNLOAD_STOPPED_CODE = 'stopped'
 STREAM_STAGES = [
-    (INITIALIZING_CODE, 'Initializing...'),
+    (INITIALIZING_CODE, 'Initializing'),
     (DOWNLOAD_METADATA_CODE, 'Downloading metadata'),
     (DOWNLOAD_RUNNING_CODE, 'Started stream'),
     (DOWNLOAD_STOPPED_CODE, 'Paused stream'),

--- a/lbrynet/lbrynet_daemon/auth/client.py
+++ b/lbrynet/lbrynet_daemon/auth/client.py
@@ -37,22 +37,22 @@ class AuthAPIClient(object):
             raise AttributeError  # Python internal stuff
 
         def f(*args):
-            return self.call(name, args)
+            return self.call(name, args[0] if args else {})
 
         return f
 
     def call(self, method, params={}):
         self.__id_count += 1
-        pre_auth_postdata = {
+        pre_auth_post_data = {
             'version': '1.1',
             'method': method,
-            'params': params,
+            'params': [params],
             'id': self.__id_count
         }
-        to_auth = get_auth_message(pre_auth_postdata)
+        to_auth = get_auth_message(pre_auth_post_data)
         token = self.__api_key.get_hmac(to_auth)
-        pre_auth_postdata.update({'hmac': token})
-        postdata = json.dumps(pre_auth_postdata)
+        pre_auth_post_data.update({'hmac': token})
+        post_data = json.dumps(pre_auth_post_data)
         service_url = self.__service_url
         auth_header = self.__auth_header
         cookies = self.__cookies
@@ -60,7 +60,7 @@ class AuthAPIClient(object):
 
         req = requests.Request(method='POST',
                                url=service_url,
-                               data=postdata,
+                               data=post_data,
                                headers={
                                    'Host': host,
                                    'User-Agent': USER_AGENT,
@@ -97,7 +97,6 @@ class AuthAPIClient(object):
     def config(cls, key_name=None, key=None, pw_path=None,
                timeout=HTTP_TIMEOUT,
                connection=None, count=0,
-               service=None,
                cookies=None, auth=None,
                url=None, login_url=None):
 
@@ -153,8 +152,7 @@ class AuthAPIClient(object):
             assert cookies.get(LBRY_SECRET, False), "Missing cookie"
             secret = cookies.get(LBRY_SECRET)
             api_key = APIKey(secret, api_key_name)
-        return cls(api_key, timeout, conn, id_count, service, cookies,
-                   auth_header, url, service_url)
+        return cls(api_key, timeout, conn, id_count, cookies, auth_header, url, service_url)
 
 
 class LBRYAPIClient(object):

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -318,5 +318,5 @@ class AuthJSONRPCServer(AuthorizedBase):
             log.exception("Failed to render API response: %s", result)
             self._render_error(err, request, id_, version)
 
-    def _render_response(self, result, code):
-        return defer.succeed({'result': result, 'code': code})
+    def _render_response(self, result):
+        return defer.succeed({'result': result, 'code': 200})

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -15,6 +15,8 @@ from lbrynet.lbrynet_daemon.auth.client import LBRY_SECRET
 
 log = logging.getLogger(__name__)
 
+EMPTY_PARAMS = [{}]
+
 
 def default_decimal(obj):
     if isinstance(obj, Decimal):
@@ -131,6 +133,7 @@ class AuthJSONRPCServer(AuthorizedBase):
             if self._initialize_session(session_id):
                 def expire_session():
                     self._unregister_user_session(session_id)
+
                 session.startCheckingExpiration()
                 session.notifyOnExpire(expire_session)
                 message = "OK"
@@ -182,7 +185,7 @@ class AuthJSONRPCServer(AuthorizedBase):
             self._render_error(err, request, id_, version)
             return server.NOT_DONE_YET
 
-        if args == [{}]:
+        if args == EMPTY_PARAMS:
             d = defer.maybeDeferred(function)
         else:
             d = defer.maybeDeferred(function, *args)
@@ -308,7 +311,7 @@ class AuthJSONRPCServer(AuthorizedBase):
         if version == jsonrpclib.VERSION_PRE1:
             if not isinstance(result, jsonrpclib.Fault):
                 result_for_return = (result_for_return,)
-            # Convert the result (python) to JSON-RPC
+
         try:
             encoded_message = jsonrpclib.dumps(
                 result_for_return, id=id_, version=version, default=default_decimal)

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -141,7 +141,8 @@ class AuthJSONRPCServer(AuthorizedBase):
                 self._set_headers(request, message, True)
                 self._render_message(request, message)
                 return server.NOT_DONE_YET
-            session.touch()
+            else:
+                session.touch()
 
         request.content.seek(0, 0)
         content = request.content.read()
@@ -284,6 +285,7 @@ class AuthJSONRPCServer(AuthorizedBase):
         return False
 
     def _verify_token(self, session_id, message, token):
+        assert token is not None, InvalidAuthenticationToken
         to_auth = get_auth_message(message)
         api_key = self.sessions.get(session_id)
         assert api_key.compare_hmac(to_auth, token), InvalidAuthenticationToken

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -279,7 +279,7 @@ class AuthJSONRPCServer(AuthorizedBase):
         return version_for_return
 
     def _callback_render(self, result, request, id_, version, auth_required=False):
-        result_for_return = result if not isinstance(result, dict) else result['result']
+        result_for_return = result
 
         if version == jsonrpclib.VERSION_PRE1:
             if not isinstance(result, jsonrpclib.Fault):
@@ -295,4 +295,4 @@ class AuthJSONRPCServer(AuthorizedBase):
             self._render_error(err, request, id_, version)
 
     def _render_response(self, result):
-        return defer.succeed({'result': result, 'code': 200})
+        return defer.succeed(result)

--- a/packaging/osx/lbry-osx-app/lbry_uri_handler/LBRYURIHandler.py
+++ b/packaging/osx/lbry-osx-app/lbry_uri_handler/LBRYURIHandler.py
@@ -34,7 +34,7 @@ class LBRYURIHandler(object):
         except:
             cmd = r'DIR = "$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"' \
                   r'if [-z "$(pgrep lbrynet-daemon)"]; then' \
-                    r'echo "running lbrynet-daemon..."' \
+                    r'echo "running lbrynet-daemon"' \
                     r'$DIR / lbrynet - daemon &' \
                     r'sleep 3  # let the daemon load before connecting' \
                   r'fi'

--- a/packaging/ubuntu/lbry
+++ b/packaging/ubuntu/lbry
@@ -27,7 +27,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 
 if [ -z "$(pgrep lbrynet-daemon)" ]; then
-  echo "running lbrynet-daemon..."
+  echo "running lbrynet-daemon"
   $DIR/lbrynet-daemon --no-launch &
   sleep 3 # let the daemon load before connecting
 fi

--- a/packaging/uri_handler/LBRYURIHandler.py
+++ b/packaging/uri_handler/LBRYURIHandler.py
@@ -11,7 +11,7 @@ from lbrynet import conf
 class LBRYURIHandler(object):
     def __init__(self):
         self.started_daemon = False
-        self.daemon = LBRYAPIClient.config()
+        self.daemon = LBRYAPIClient.get_client()
 
     def handle_osx(self, lbry_name):
         self.check_daemon()

--- a/packaging/uri_handler/LBRYURIHandler.py
+++ b/packaging/uri_handler/LBRYURIHandler.py
@@ -27,7 +27,7 @@ class LBRYURIHandler(object):
         if not self.started_daemon:
             cmd = r'DIR = "$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"' \
                   r'if [-z "$(pgrep lbrynet-daemon)"]; then' \
-                    r'echo "running lbrynet-daemon..."' \
+                    r'echo "running lbrynet-daemon"' \
                     r'$DIR / lbrynet - daemon &' \
                     r'sleep 3  # let the daemon load before connecting' \
                   r'fi'

--- a/packaging/uri_handler/LBRYURIHandler.py
+++ b/packaging/uri_handler/LBRYURIHandler.py
@@ -49,7 +49,8 @@ class LBRYURIHandler(object):
 
     def check_daemon(self):
         try:
-            self.started_daemon = self.daemon.is_running()
+            status = self.daemon.call('status')
+            self.started_daemon = status['is_running']
         except:
             self.started_daemon = False
 

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -944,7 +944,7 @@ class TestTransfer(TestCase):
             self.assertEqual(hashsum.hexdigest(), "4ca2aafb4101c1e42235aad24fbb83be")
 
         def delete_lbry_file():
-            logging.debug("deleting the file...")
+            logging.debug("deleting the file")
             d = self.lbry_file_manager.delete_lbry_file(downloaders[0])
             d.addCallback(lambda _: self.lbry_file_manager.get_count_for_stream_hash(downloaders[0].stream_hash))
             d.addCallback(


### PR DESCRIPTION
Several things happened here:

- Renamed many API endpoints. The goal is to use noun_verb style as much as possible (e.g. file_seed, claim_new, etc). 
- Old API endpoints still work, but are deprecated and ready for removal.
- CLI interaction is more pleasant. Error messages are nicer, help text is nicer, commands list is nicer.
- CLI no longer knows/cares whether or not api authentication is being used (its all handled in client)
- Subhandler functionality has been removed from AuthJsonRpc. We don't use it.
- Removed trailing ellipses from a bunch of messages.

@jackrobison the daemon ignores `use_auth_http` in daemon_settings.yml. this can cause the daemon and the CLI to be out of sync regarding when to use authenticated requests. 