### PR TITLE
non-blocking version check

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -131,7 +131,7 @@ class CheckRemoteVersions(object):
     def __call__(self):
         d = threads.deferToThread(self._get_lbrynet_version)
         d.addErrback(self._trap_and_log_error, 'lbrynet')
-        d.addCallback(lambda _: self._get_lbryum_version())
+        d.addCallback(lambda _: threads.deferToThread(self._get_lbryum_version))
         d.addErrback(self._trap_and_log_error, 'lbryum')
         d.addErrback(log.fail(), 'Failure checking versions on github')
 


### PR DESCRIPTION
this fixes a bug where if github is down the app will fail to start.

-check for new version every 30 min instead of every 12 hours

-check connection problems every 30 seconds instead of every second