### PR TITLE
Fix wallet balance interfaces

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -288,7 +288,7 @@ class Daemon(AuthJSONRPCServer):
 
         def _announce_startup():
             def _wait_for_credits():
-                if float(self.session.wallet.wallet_balance) == 0.0:
+                if float(self.session.wallet.get_balance()) == 0.0:
                     self.startup_status = STARTUP_STAGES[6]
                     return reactor.callLater(1, _wait_for_credits)
                 else:
@@ -332,7 +332,7 @@ class Daemon(AuthJSONRPCServer):
         yield self._setup_lbry_file_manager()
         yield self._setup_query_handlers()
         yield self._setup_server()
-        log.info("Starting balance: " + str(self.session.wallet.wallet_balance))
+        log.info("Starting balance: " + str(self.session.wallet.get_balance()))
         yield _announce_startup()
 
     def _get_platform(self):
@@ -1339,7 +1339,7 @@ class Daemon(AuthJSONRPCServer):
         Returns:
             balance, float
         """
-        return self._render_response(float(self.session.wallet.wallet_balance))
+        return self._render_response(float(self.session.wallet.get_balance()))
 
     def jsonrpc_stop(self):
         """

--- a/lbrynet/lbrynet_daemon/Downloader.py
+++ b/lbrynet/lbrynet_daemon/Downloader.py
@@ -118,9 +118,9 @@ class GetStream(object):
             self.fee = FeeValidator(self.stream_info['fee'])
             max_key_fee = self._convert_max_fee()
             converted_fee = self.exchange_rate_manager.to_lbc(self.fee).amount
-            if converted_fee > self.wallet.wallet_balance:
+            if converted_fee > self.wallet.get_balance():
                 msg = "Insufficient funds to download lbry://{}. Need {:0.2f}, have {:0.2f}".format(
-                    self.resolved_name, converted_fee, self.wallet.wallet_balance)
+                    self.resolved_name, converted_fee, self.wallet.get_balance())
                 raise InsufficientFundsError(msg)
             if converted_fee > max_key_fee:
                 msg = "Key fee {:0.2f} above limit of {:0.2f} didn't download lbry://{}".format(

--- a/tests/unit/core/test_Wallet.py
+++ b/tests/unit/core/test_Wallet.py
@@ -1,7 +1,10 @@
+from decimal import Decimal
+from collections import defaultdict
 from twisted.trial import unittest
-
 from twisted.internet import threads, defer
-from lbrynet.core.Wallet import Wallet
+
+from lbrynet.core.Error import InsufficientFundsError
+from lbrynet.core.Wallet import Wallet, ReservedPoints
 
 test_metadata = {
 'license': 'NASA',
@@ -21,7 +24,9 @@ test_metadata = {
 
 class MocLbryumWallet(Wallet):
     def __init__(self):
-        pass
+        self.wallet_balance = Decimal(10.0)
+        self.total_reserved_points = Decimal(0.0)
+        self.queued_payments = defaultdict(Decimal)
     def get_name_claims(self):
         return threads.deferToThread(lambda: [])
 
@@ -128,3 +133,59 @@ class WalletTest(unittest.TestCase):
         d = wallet.abandon_claim("0578c161ad8d36a7580c557d7444f967ea7f988e194c20d0e3c42c3cabf110dd", 1)
         d.addCallback(lambda claim_out: check_out(claim_out))
         return d
+
+    def test_point_reservation_and_balance(self):
+        # check that point reservations and cancellation changes the balance
+        # properly
+        def update_balance():
+            return defer.succeed(5)
+        wallet = MocLbryumWallet()
+        wallet._update_balance = update_balance
+        d = wallet.update_balance()
+        # test point reservation
+        d.addCallback(lambda _: self.assertEqual(5, wallet.get_balance()))
+        d.addCallback(lambda _: wallet.reserve_points('testid',2))
+        d.addCallback(lambda _: self.assertEqual(3, wallet.get_balance()))
+        d.addCallback(lambda _: self.assertEqual(2, wallet.total_reserved_points))
+        # test reserved points cancellation
+        d.addCallback(lambda _: wallet.cancel_point_reservation(ReservedPoints('testid',2)))
+        d.addCallback(lambda _: self.assertEqual(5, wallet.get_balance()))
+        d.addCallback(lambda _: self.assertEqual(0, wallet.total_reserved_points))
+        # test point sending
+        d.addCallback(lambda _: wallet.reserve_points('testid',2))
+        d.addCallback(lambda reserve_points: wallet.send_points_to_address(reserve_points,1))
+        d.addCallback(lambda _: self.assertEqual(3, wallet.get_balance()))
+        # test failed point reservation
+        d.addCallback(lambda _: wallet.reserve_points('testid',4))
+        d.addCallback(lambda out: self.assertEqual(None,out))
+        return d
+
+    def test_point_reservation_and_claim(self):
+        # check that claims take into consideration point reservations
+        def update_balance():
+            return defer.succeed(5)
+        wallet = MocLbryumWallet()
+        wallet._update_balance = update_balance
+        d = wallet.update_balance()
+        d.addCallback(lambda _: self.assertEqual(5, wallet.get_balance()))
+        d.addCallback(lambda _: wallet.reserve_points('testid',2))
+        d.addCallback(lambda _: wallet.claim_name('test', 4, test_metadata))
+        self.assertFailure(d,InsufficientFundsError)
+        return d
+
+    def test_point_reservation_and_support(self):
+        # check that supports take into consideration point reservations
+        def update_balance():
+            return defer.succeed(5)
+        wallet = MocLbryumWallet()
+        wallet._update_balance = update_balance
+        d = wallet.update_balance()
+        d.addCallback(lambda _: self.assertEqual(5, wallet.get_balance()))
+        d.addCallback(lambda _: wallet.reserve_points('testid',2))
+        d.addCallback(lambda _: wallet.support_claim('test', "f43dc06256a69988bdbea09a58c80493ba15dcfa", 4))
+        self.assertFailure(d,InsufficientFundsError)
+        return d
+
+
+
+


### PR DESCRIPTION
https://github.com/lbryio/lbry/commit/9230fb24dd0eaae379273e152a1d78a3f714702d just removes an unused get_transaction function from Wallet 

https://github.com/lbryio/lbry/commit/39d3947e88cece94209d049c21b3bf31ba6c436a fixes the Wallet interface for obtaining the balance, which was previously confusing and has lead to some bugs. 

Previously,  external classes used class member wallet_balance to fetch the balance of the wallet. However there is a method named get_balance()  which was used by the wallet to periodically pull the balance from lbryum, but should not be used by external classes to obtain the balance. We rename the previous get_balance() function as update_balance()  to avoid confusion , and change the function slightly to have it actually set class member wallet_balance. 

Further, wallet_balance did not consider reserved points (used for reserving credits for downloading) or queued payments (used to schedule payments at a later time) that should be subtracted to prevent external classes from accessing credits that are reserved for future uses.  Thus, a new function get_balance() is created that returns the balance with all the reserved and queued credits subtracted out. Now wallet_balance is only used to store the latest balance update from lbryum wallet. External classes will now exclusively uses get_balance() to retrieve the wallet balance. 

Claim commands also did not consider reserved points and queued payments before making the transaction, thus it could end up causing scheduled payments to fail. Now claim commands will use get_balance() to make sure that it has enough funds. 

Point reservation also did not consider queued payments, thus it could reserve more points than you had available. 

https://github.com/lbryio/lbry/commit/ebcddccd03325088bb8799c820dbf24be5b426a5 adds unit tests to test the above functionalities

Note that this does not solve all the wallet race condition issue, some lbryum changes are necessary (transactions need to be immediately added to wallet upon broadcast) 