### PR TITLE
Add open() API method and refactor/update reveal() API method (WIP)

### DIFF
--- a/lbrynet/core/file_utils.py
+++ b/lbrynet/core/file_utils.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import subprocess
+
+def start(path):
+    """ 
+    Open a file with the OS's default program. (Cross-platform equivalent of os.startfile() for
+    Windows)
+    """
+
+    if not os.path.isfile(path):
+        raise(IOError, "No such file: '%s'" % path)
+
+    if sys.platform == 'darwin':
+        subprocess.Popen(['open', path])
+    elif os.name == 'posix':
+        subprocess.Popen(['xdg-open', path])
+    elif sys.platform == 'win32':
+        os.startfile(path)
+
+def reveal(path):
+    """
+    Reveal a file in file browser.
+    """
+
+    if not os.path.isfile(path):
+        raise(IOError, "No such file: '%s'" % path)
+
+    if sys.platform == 'darwin':
+        subprocess.Popen(['open', '-R', path])
+    elif os.name == 'posix':
+        # No easy way to reveal specific files on Linux, so just open the containing directory
+        subprocess.Popen(['xdg-open', os.path.dirname(path)])
+    elif sys.platform == 'win32':
+        subprocess.Popen(['explorer', '/select', path])

--- a/lbrynet/core/file_utils.py
+++ b/lbrynet/core/file_utils.py
@@ -3,7 +3,7 @@ import sys
 import subprocess
 
 def start(path):
-    """ 
+    """
     Open a file with the OS's default program. (Cross-platform equivalent of os.startfile() for
     Windows)
     """

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -2220,7 +2220,7 @@ class Daemon(AuthJSONRPCServer):
         return d
 
     @AuthJSONRPCServer.auth_required
-    def jsonrpc_open_file(self, p):
+    def jsonrpc_open(self, p):
         """
         Instruct the OS to open a file.
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -2220,6 +2220,27 @@ class Daemon(AuthJSONRPCServer):
         return d
 
     @AuthJSONRPCServer.auth_required
+    def jsonrpc_open_file(self, p):
+        """
+        Instruct the OS to open a file.
+
+        Args:
+            'path': path of file to be opened
+        Returns:
+            True, opens file
+        """
+        path = p['path']
+        if sys.platform == 'darwin':
+            d = threads.deferToThread(subprocess.Popen, ['open', path])
+        elif os.name == 'posix':
+            d = threads.deferToThread(subprocess.Popen, ['xdg-open', path])
+        elif sys.platform == 'win32':
+            d = threads.deferToThread(os.startfile, path)
+
+        d.addCallback(lambda _: self._render_response(True, OK_CODE))
+        return d
+
+    @AuthJSONRPCServer.auth_required
     def jsonrpc_reveal(self, p):
         """
         Reveal a file or directory in file browser

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -4,8 +4,6 @@ import mimetypes
 import os
 import random
 import re
-import subprocess
-import sys
 import base58
 import requests
 import urllib


### PR DESCRIPTION
- Factors out the core logic for both of these into methods on a new module called lbry.core.file_utils
- Both methods now take an SD hash instead of a path (more logical and improves security)
- reveal() now works on Windows
- No longer spins off new threads for the OS calls since they're non-blocking (thanks to @jackrobison for pointing out this wasn't necessary)

Todo before this is ready:
- Tests
- The SD hash is not really the right identifier for this, as you can have multiple files downloaded with the same SD hash. Very soon Jack is planning to create a new unique ID for entries in the file manager, so we should probably wait until that change is in and then switch this to use the new ID.

Fixes this issue: https://app.asana.com/0/search/246741549780800/161594953616366