### PR TITLE
Add back id

### DIFF
--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -399,7 +399,16 @@ class Logger(logging.Logger):
                 self.name, level, fn, lno, msg, msg_args, exc_info, func, msg_kwargs)
             self.handle(record)
             if callback:
-                return callback(err, *args, **kwargs)
+                try:
+                    return callback(err, *args, **kwargs)
+                except Exception:
+                    # log.fail is almost always called within an
+                    # errback. If callback fails and we didn't catch
+                    # the exception we would need to attach a second
+                    # errback to deal with that, which we will almost
+                    # never do and then we end up with an unhandled
+                    # error that will get swallowed by twisted
+                    self.exception('Failed to run callback')
         return _fail
 
     def trace(self, msg, *args, **kwargs):

--- a/lbrynet/lbrynet_daemon/auth/server.py
+++ b/lbrynet/lbrynet_daemon/auth/server.py
@@ -211,7 +211,7 @@ class AuthJSONRPCServer(AuthorizedBase):
         # handle deferredLists that won't peacefully cancel, namely
         # get_lbry_files
         d.addErrback(trap, ConnectionDone, ConnectionLost, defer.CancelledError, RuntimeError)
-        d.addErrback(log.fail(self._render_error, request, version=version),
+        d.addErrback(log.fail(self._render_error, request, id_, version=version),
                      'Failed to process %s', function_name)
         d.addBoth(lambda _: log.debug("%s took %f",
                                       function_name,


### PR DESCRIPTION
When a command would error, the `_render_error` function was failing to call because the id_ parameter was missing. Additionally, twisted was silencing the error.