### PR TITLE
Force connect to peer, Testing only 

### DIFF
--- a/lbrynet/core/PeerFinder.py
+++ b/lbrynet/core/PeerFinder.py
@@ -1,5 +1,5 @@
 from twisted.internet import defer
-
+from lbrynet.core.Peer import Peer
 
 class DummyPeerFinder(object):
     """This class finds peers which have announced to the DHT that they have certain blobs"""
@@ -17,3 +17,27 @@ class DummyPeerFinder(object):
 
     def get_most_popular_hashes(self, num_to_return):
         return []
+
+
+class ForceConnectPeerFinder(object):
+    """ This peer finder forces a connection to some server"""
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def run_manage_loop(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def find_peers_for_blob(self, blob_hash):
+        peer = Peer(self.host, self.port)
+        return defer.succeed([peer])
+
+    def get_most_popular_hashes(self, num_to_return):
+        return []
+
+
+
+

--- a/lbrynet/core/Session.py
+++ b/lbrynet/core/Session.py
@@ -5,6 +5,7 @@ from lbrynet.dht import node
 from lbrynet.core.PeerManager import PeerManager
 from lbrynet.core.RateLimiter import RateLimiter
 from lbrynet.core.client.DHTPeerFinder import DHTPeerFinder
+from lbrynet.core.PeerFinder import ForceConnectPeerFinder
 from lbrynet.core.HashAnnouncer import DummyHashAnnouncer
 from lbrynet.core.server.DHTHashAnnouncer import DHTHashAnnouncer
 from lbrynet.core.utils import generate_id
@@ -280,7 +281,7 @@ class Session(object):
             lbryid=self.lbryid,
             externalIP=self.external_ip
         )
-        self.peer_finder = DHTPeerFinder(self.dht_node, self.peer_manager)
+        self.peer_finder = ForceConnectPeerFinder('67.205.154.20',3333)
         if self.hash_announcer is None:
             self.hash_announcer = DHTHashAnnouncer(self.dht_node, self.peer_port)
 


### PR DESCRIPTION
Create a PeerFinder class that only returns address to reflector , bypassing the DHT. 

For testing only.

I tried to see if forcing connection to a server that we know is reliable improved download reliability, I didn't see that it made much of a difference.  

