### PR TITLE
Prevent excessive generation of new addresses

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -1035,7 +1035,10 @@ class LBRYumWallet(Wallet):
         return d
 
     def get_new_address(self):
-        d = defer.succeed(self.wallet.create_new_address())
+        addr = self.wallet.get_unused_address(account=None)
+        if addr is None:
+            addr = self.wallet.create_new_address()
+        d = defer.succeed(addr)
         d.addCallback(self._save_wallet)
         return d
 


### PR DESCRIPTION
Use an unused address (address that has no balance on it) when calling get_new_address() if possible. 

This is a temporary fix to the fact that lbrynet generates a new address every time a download request is made by a peer, and making the lbryum wallet very large after the node runs for some time. 

This will break download fee (fees paid to download from a dht node) calculations, since two different download requests can get the same payment address. But since download fees should be set to zero for most nodes now, it shouldn't cause any problems. A better fix would involve creating payment requests that expire after a certain time, but is a bit involved. 

This will also prevent the refresh button on the "My Wallet" UI in lbry web ui from creating a new address (since it just returns an unused address which will be the same unless someone sends some credits to it)
