### PR TITLE
Revert "Reflect missing blobs"

### DIFF
--- a/lbrynet/core/log_support.py
+++ b/lbrynet/core/log_support.py
@@ -117,7 +117,6 @@ def disable_third_party_loggers():
     logging.getLogger('urllib3').setLevel(logging.WARNING)
     logging.getLogger('BitcoinRPC').setLevel(logging.INFO)
     logging.getLogger('lbryum').setLevel(logging.WARNING)
-    logging.getLogger('twisted').setLevel(logging.WARNING)
 
 
 @_log_decorator

--- a/lbrynet/reflector/client/client.py
+++ b/lbrynet/reflector/client/client.py
@@ -94,7 +94,7 @@ class EncryptedFileReflectorClient(Protocol):
 
     def connectionLost(self, reason):
         if reason.check(error.ConnectionDone):
-            log.info('Finished sending data via reflector')
+            log.debug('Finished sending data via reflector')
             self.factory.finished_deferred.callback(True)
         else:
             log.debug('Reflector finished: %s', reason)
@@ -124,9 +124,9 @@ class EncryptedFileReflectorClient(Protocol):
 
         def set_blobs(blob_hashes):
             for blob_hash, position, iv, length in blob_hashes:
+                log.debug("Preparing to send %s", blob_hash)
                 if blob_hash is not None:
                     self.blob_hashes_to_send.append(blob_hash)
-            log.debug("Preparing to send %i blobs", len(self.blob_hashes_to_send))
 
         d.addCallback(set_blobs)
 
@@ -135,7 +135,6 @@ class EncryptedFileReflectorClient(Protocol):
         def set_sd_blobs(sd_blob_hashes):
             for sd_blob_hash in sd_blob_hashes:
                 self.blob_hashes_to_send.append(sd_blob_hash)
-            log.debug("Preparing to send %i sd blobs", len(sd_blob_hashes))
 
         d.addCallback(set_sd_blobs)
         return d
@@ -191,13 +190,11 @@ class EncryptedFileReflectorClient(Protocol):
                 self.file_sender = FileSender()
                 return defer.succeed(True)
             else:
-                log.debug("Reflector already has %s", str(self.next_blob_to_send.blob_hash)[:16])
                 return self.set_not_uploading()
         else:  # Expecting Server Blob Response
             if 'received_blob' not in response_dict:
                 raise ValueError("I don't know if the blob made it to the intended destination!")
             else:
-                log.info("Reflector received %s", str(self.next_blob_to_send.blob_hash)[:16])
                 return self.set_not_uploading()
 
     def open_blob_for_reading(self, blob):
@@ -208,27 +205,22 @@ class EncryptedFileReflectorClient(Protocol):
                 self.next_blob_to_send = blob
                 self.read_handle = read_handle
                 return None
-        else:
-            log.warning("Can't reflect blob %s", str(blob.blob_hash)[:16])
-            return defer.fail(ValueError(
-            "Couldn't open that blob for some reason. blob_hash: {}".format(blob.blob_hash)))
+        raise ValueError(
+            "Couldn't open that blob for some reason. blob_hash: {}".format(blob.blob_hash))
 
     def send_blob_info(self):
-        assert self.next_blob_to_send is not None, "need to have a next blob to send at this point"
         log.debug("Send blob info for %s", self.next_blob_to_send.blob_hash)
+        assert self.next_blob_to_send is not None, "need to have a next blob to send at this point"
+        log.debug('sending blob info')
         self.write(json.dumps({
             'blob_hash': self.next_blob_to_send.blob_hash,
             'blob_size': self.next_blob_to_send.length
         }))
 
-    def skip_missing_blob(self, err, blob_hash):
-        err.trap(ValueError)
-        return self.send_next_request()
-
     def send_next_request(self):
         if self.file_sender is not None:
             # send the blob
-            log.debug('Sending %s to reflector', str(self.next_blob_to_send.blob_hash)[:16])
+            log.debug('Sending the blob')
             return self.start_transfer()
         elif self.blob_hashes_to_send:
             # open the next blob to send
@@ -238,8 +230,7 @@ class EncryptedFileReflectorClient(Protocol):
             d = self.blob_manager.get_blob(blob_hash, True)
             d.addCallback(self.open_blob_for_reading)
             # send the server the next blob hash + length
-            d.addCallbacks(lambda _: self.send_blob_info(),
-                           lambda err: self.skip_missing_blob(err, blob_hash))
+            d.addCallback(lambda _: self.send_blob_info())
             return d
         else:
             # close connection

--- a/lbrynet/reflector/reupload.py
+++ b/lbrynet/reflector/reupload.py
@@ -27,7 +27,6 @@ def _reflect_stream(lbry_file, reflector_server):
     )
     d = reactor.resolve(reflector_address)
     d.addCallback(lambda ip: reactor.connectTCP(ip, reflector_port, factory))
-    d.addCallback(lambda _: log.info("Connected to %s", reflector_address))
     d.addCallback(lambda _: factory.finished_deferred)
     return d
 
@@ -41,11 +40,13 @@ def _reflect_if_unavailable(reflector_has_stream, lbry_file, reflector_server):
 
 
 def _catch_error(err, uri):
-    msg = "An error occurred while checking availability for lbry://%s: %s"
-    log.error(msg, uri, err.getTraceback())
+    log.error("An error occurred while checking availability for lbry://%s", uri)
+    log.debug("Traceback: %s", err.getTraceback())
 
 
 def check_and_restore_availability(lbry_file, reflector_server):
-    d = _reflect_stream(lbry_file, reflector_server)
-    d.addErrback(_catch_error, lbry_file.uri)
+    d = _check_if_reflector_has_stream(lbry_file, reflector_server)
+    d.addCallbacks(
+        lambda send_stream: _reflect_if_unavailable(send_stream, lbry_file, reflector_server),
+        lambda err: _catch_error(err, lbry_file.uri))
     return d


### PR DESCRIPTION
Reverts lbryio/lbry#440

This caused:
```
2017-01-26 10:09:51,312 WARNING  lbrynet.reflector.client.client:154: An error occurred handling the response: Traceback (most recent call last):
  File "/Users/jobevers/projects/lbryio/lbry/lbrynet/reflector/client/client.py", line 226, in skip_missing_blob
    return self.send_next_request()
  File "/Users/jobevers/projects/lbryio/lbry/lbrynet/reflector/client/client.py", line 239, in send_next_request
    d.addCallback(self.open_blob_for_reading)
  File "/Users/jobevers/.virtualenvs/lbry/lib/python2.7/site-packages/twisted/internet/defer.py", line 317, in addCallback
    callbackKeywords=kw)
  File "/Users/jobevers/.virtualenvs/lbry/lib/python2.7/site-packages/twisted/internet/defer.py", line 306, in addCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/Users/jobevers/.virtualenvs/lbry/lib/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/Users/jobevers/projects/lbryio/lbry/lbrynet/reflector/client/client.py", line 212, in open_blob_for_reading
    log.warning("Can't reflect blob %s", str(blob.blob_hash)[:16])
  File "/Users/jobevers/.pythonz/pythons/CPython-2.7.11/lib/python2.7/logging/__init__.py", line 1171, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/jobevers/.pythonz/pythons/CPython-2.7.11/lib/python2.7/logging/__init__.py", line 1277, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args, exc_info, func, extra)
  File "/Users/jobevers/.pythonz/pythons/CPython-2.7.11/lib/python2.7/logging/__init__.py", line 1251, in makeRecord
    rv = LogRecord(name, level, fn, lno, msg, args, exc_info, func)
  File "/Users/jobevers/.pythonz/pythons/CPython-2.7.11/lib/python2.7/logging/__init__.py", line 263, in __init__
    if (args and len(args) == 1 and isinstance(args[0], collections.Mapping)
  File "/Users/jobevers/.virtualenvs/lbry/lib/python2.7/abc.py", line 132, in __instancecheck__
    if subclass is not None and subclass in cls._abc_cache:
exceptions.RuntimeError: maximum recursion depth exceeded while calling a Python object
```