### PR TITLE
Retry the get call three times before failing

### DIFF
--- a/lbrynet/lbrynet_daemon/Downloader.py
+++ b/lbrynet/lbrynet_daemon/Downloader.py
@@ -72,7 +72,7 @@ class GetStream(object):
             self.finished.callback((True, self.sd_hash, self.download_path))
 
         elif self.timeout_counter >= self.timeout:
-            log.info("Timeout downloading lbry://%s" % self.resolved_name)
+            log.info("Timeout downloading lbry://%s", self.resolved_name)
             self.checker.stop()
             self._d.cancel()
             self.code = STREAM_STAGES[4]
@@ -86,6 +86,11 @@ class GetStream(object):
 
     def start(self, stream_info, name):
         def _cancel(err):
+            # this callback sequence gets cancelled in check_status if
+            # it takes too long when that happens, we want the logic
+            # to live in check_status
+            if err.check(defer.CancelledError):
+                return
             if self.checker:
                 self.checker.stop()
             self.finished.errback(err)


### PR DESCRIPTION
Had instances where I was unable to download a name the first try, but when making a second attempt it worked. The underlying cause could probably be dealt with my improving the connection manager and general blob downloading framework, but this bandaid is a decent solution for now.