### PR TITLE
Fix #449: Block to deep error

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -199,8 +199,6 @@ class Wallet(object):
         self.max_expected_payment_time = datetime.timedelta(minutes=3)
         self.stopped = True
 
-        self.is_lagging = None
-
         self.manage_running = False
         self._manage_count = 0
         self._balance_refresh_time = 3

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -895,14 +895,12 @@ class LBRYumWallet(Wallet):
 
     def _start(self):
         network_start_d = defer.Deferred()
+        self.config = make_config(self._config)
 
         def setup_network():
-            self.config = make_config(self._config)
             self.network = Network(self.config)
             log.info("Loading the wallet")
             return defer.succeed(self.network.start())
-
-        d = setup_network()
 
         def check_started():
             if self.network.is_connecting():
@@ -919,6 +917,7 @@ class LBRYumWallet(Wallet):
 
         self._start_check = task.LoopingCall(check_started)
 
+        d = setup_network()
         d.addCallback(lambda _: self._load_wallet())
         d.addCallback(self._save_wallet)
         d.addCallback(lambda _: self._start_check.start(.1))

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -24,8 +24,8 @@ from lbrynet.core.Error import (UnknownNameError, InvalidStreamInfoError, Reques
 from lbrynet.db_migrator.migrate1to2 import UNSET_NOUT
 from lbrynet.metadata.Metadata import Metadata
 
+
 log = logging.getLogger(__name__)
-alert = logging.getLogger("lbryalert." + __name__)
 
 
 class ReservedPoints(object):
@@ -895,7 +895,7 @@ class LBRYumWallet(Wallet):
         def setup_network():
             self.config = make_config(self._config)
             self.network = Network(self.config)
-            alert.info("Loading the wallet")
+            log.info("Loading the wallet")
             return defer.succeed(self.network.start())
 
         d = setup_network()
@@ -904,7 +904,7 @@ class LBRYumWallet(Wallet):
             if self.network.is_connecting():
                 if not self.printed_retrieving_headers and \
                         self.network.blockchain.retrieving_headers:
-                    alert.info("Running the wallet for the first time. This may take a moment.")
+                    log.info("Running the wallet for the first time. This may take a moment.")
                     self.printed_retrieving_headers = True
                 return False
             self._start_check.stop()
@@ -988,7 +988,7 @@ https://github.com/lbryio/lbry/issues/437 to reduce your wallet size")
                 if self._caught_up_counter != 0:
                     msg += "All caught up. "
                 msg += "Wallet loaded."
-                alert.info(msg)
+                log.info(msg)
                 self._catch_up_check.stop()
                 self._catch_up_check = None
                 blockchain_caught_d.callback(True)
@@ -1010,9 +1010,9 @@ https://github.com/lbryio/lbry/issues/437 to reduce your wallet size")
                 self.max_behind = self.blocks_behind
             self.catchup_progress = int(100 * (self.blocks_behind / (5 + self.max_behind)))
             if self._caught_up_counter == 0:
-                alert.info('Catching up with the blockchain')
+                log.info('Catching up with the blockchain')
             if self._caught_up_counter % 30 == 0:
-                alert.info('Blocks left: %d', (remote_height - local_height))
+                log.info('Blocks left: %d', (remote_height - local_height))
 
             self._caught_up_counter += 1
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -82,13 +82,10 @@ STREAM_STAGES = [
 CONNECTION_STATUS_CONNECTED = 'connected'
 CONNECTION_STATUS_VERSION_CHECK = 'version_check'
 CONNECTION_STATUS_NETWORK = 'network_connection'
-CONNECTION_STATUS_WALLET = 'wallet_catchup_lag'
 CONNECTION_MESSAGES = {
     CONNECTION_STATUS_CONNECTED: 'No connection problems detected',
     CONNECTION_STATUS_VERSION_CHECK: "There was a problem checking for updates on github",
     CONNECTION_STATUS_NETWORK: "Your internet connection appears to have been interrupted",
-    CONNECTION_STATUS_WALLET: "Catching up with the blockchain is slow. " +
-                              "If this continues try restarting LBRY",
 }
 
 PENDING_ID = "not set"
@@ -386,9 +383,6 @@ class Daemon(AuthJSONRPCServer):
 
         if not self.git_lbrynet_version or not self.git_lbryum_version:
             self.connection_status_code = CONNECTION_STATUS_VERSION_CHECK
-
-        elif self.startup_status[0] == 'loading_wallet' and self.session.wallet.is_lagging:
-            self.connection_status_code = CONNECTION_STATUS_WALLET
 
         if not self.connected_to_internet:
             self.connection_status_code = CONNECTION_STATUS_NETWORK
@@ -1122,7 +1116,7 @@ class Daemon(AuthJSONRPCServer):
                 progress = 0
                 if status['blocks_behind'] > 0:
                     message += ' ' + str(status['blocks_behind']) + " blocks behind."
-                    progress = self.session.wallet.catchup_progress
+                    progress = status['blocks_behind']
 
             return {
                 'message': message,


### PR DESCRIPTION
What was happening was the wallet claimed to be caught up before it
actually was and so the wallet’s local_height was still the value from
when lbry was last run, frequently more than 20 or 50 blocks
behind. _get_value_for_name uses the block at local_height as the
basis for the proof.  If _get_value_for_name is called during that
time between when the wallet claims to be caught up and it actually
is, the “Block too deep error” happens.  And since the discover page
of the UI does name resolution right away, the error basically happens
anytime somebody starts the app after not using it for a few hours.

This changes the startup behaviour of the wallet to
- use the `updated` callback provided by lbryum
- check that local_height and network_height match before declaring
  that the wallet has caught up

For reference, the error is raised here:
https://github.com/lbryio/lbrycrd/blob/1b896ae75b0fc7081ab9e4a1b7d45c94dcd73cbd/src/rpc/claimtrie.cpp#L688