### PR TITLE
Claim after reflecting

### DIFF
--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -105,10 +105,14 @@ class Publisher(object):
             ip = yield reactor.resolve(reflector_address)
             yield reactor.connectTCP(ip, reflector_port, factory)
             result = yield factory.finished_deferred
-            if result:
-                break
+            if result is True:
+                defer.returnValue(True)
             else:
                 tries += 1
+        else:
+            # TODO: surface this error to the UI
+            log.error('Failed to push file for %s to reflector', self.publish_name)
+            defer.returnValue(False)
 
     @defer.inlineCallbacks
     def _add_to_lbry_files(self, stream_hash):

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -52,9 +52,9 @@ class Publisher(object):
             lbry_file = yield self._create_lbry_file()
             yield self._add_to_lbry_files(lbry_file)
             yield self._create_sd_blob()
-            yield self._claim_name()
             yield self._set_file_status_finished()
             yield self._push_file_to_reflector()
+            yield self._claim_name()
         except Exception:
             log.exception(
                 "An error occurred publishing %s to %s", self.file_name, self.publish_name)

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -138,18 +138,14 @@ class Publisher(object):
         self._update_metadata()
         m = Metadata(self.metadata)
 
-        def set_claim_out(claim_out):
-            log.debug('Name claimed using txid: %s, nout: %d, claim_id: %s, fee :%f',
-                        claim_out['txid'], claim_out['nout'],
-                        claim_out['claim_id'], claim_out['fee'])
-            self.txid = claim_out['txid']
-            self.nout = claim_out['nout']
-            self.claim_id = claim_out['claim_id']
-            self.fee = claim_out['fee']
-
-        d = self.wallet.claim_name(self.publish_name, self.bid_amount, m)
-        d.addCallback(set_claim_out)
-        return d
+        claim_out = yield self.wallet.claim_name(self.publish_name, self.bid_amount, m)
+        log.debug('Name claimed using txid: %s, nout: %d, claim_id: %s, fee :%f',
+                  claim_out['txid'], claim_out['nout'],
+                  claim_out['claim_id'], claim_out['fee'])
+        self.txid = claim_out['txid']
+        self.nout = claim_out['nout']
+        self.claim_id = claim_out['claim_id']
+        self.fee = claim_out['fee']
 
     def _update_metadata(self):
         filename = os.path.join(self.lbry_file.download_directory, self.lbry_file.file_name)


### PR DESCRIPTION
Most of the changes in here are mechanical refactoring and conversion to inlinecallbacks.

The main change in logic is that I moved the name claim to happen AFTER the blobs have been pushed to reflector.  This will increase the amount of time it takes to publish but at the benefit of increasing the reliability of publishing