### PR TITLE
Change default behavior with daemon cmdline args

### DIFF
--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -44,7 +44,7 @@ def start():
         "--branch",
         help='Branch of lbry-web-ui repo to use, defaults to {}'.format(conf.settings['ui_branch']),
         default=conf.settings['ui_branch'])
-    parser.add_argument('--no-launch', dest='launchui', action="store_false")
+    parser.add_argument('--launch-ui', dest='launchui', action="store_true")
     parser.add_argument("--http-auth", dest="useauth", action="store_true",
                         default=conf.settings['use_auth_http'])
     parser.add_argument(

--- a/packaging/ubuntu/lbry
+++ b/packaging/ubuntu/lbry
@@ -28,7 +28,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 if [ -z "$(pgrep lbrynet-daemon)" ]; then
   echo "running lbrynet-daemon"
-  $DIR/lbrynet-daemon --no-launch &
+  $DIR/lbrynet-daemon &
   sleep 3 # let the daemon load before connecting
 fi
 


### PR DESCRIPTION
By default the daemon now doesn't launch the UI and outputs logs to the console

Removes `--no-launch`, UI can be launched with `--launch-ui` 
Removes `--log-to-console`, logging can be turned off with `--quiet`