### PR TITLE
fix streams in stream_info_manager not being loaded by lbry_file_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ at anytime.
 ### Fixed
  * fix recursion depth error upon failed blob
  * call stopProducing in reflector client file_sender when uploading is done
+ * ensure streams in stream_info_manager are saved in lbry_file_manager
 
 ## [0.8.1] - 2017-02-01
 ### Changed

--- a/lbrynet/core/Error.py
+++ b/lbrynet/core/Error.py
@@ -98,9 +98,3 @@ class InvalidAuthenticationToken(Exception):
 
 class NegotiationError(Exception):
     pass
-
-
-class MissingLBRYFile(Exception):
-    """
-    Raised by lbry file manager if stream hash has no associated lbry file
-    """

--- a/lbrynet/core/Error.py
+++ b/lbrynet/core/Error.py
@@ -98,3 +98,9 @@ class InvalidAuthenticationToken(Exception):
 
 class NegotiationError(Exception):
     pass
+
+
+class MissingLBRYFile(Exception):
+    """
+    Raised by lbry file manager if stream hash has no associated lbry file
+    """


### PR DESCRIPTION
This migrates any streams tracked by stream_info_manager but not lbry_file_manager to also be included by the file manager

This commit should prevent new streams from having this problem: https://github.com/lbryio/lbry/commit/2126f69c930a4a4d22169cff3533362fe6e0bcaf