### PR TITLE
Fix how the bug report code accesses Slack API key setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ at anytime.
  * call stopProducing in reflector client file_sender when uploading is done
  * ensure streams in stream_info_manager are saved in lbry_file_manager
  * [#470](https://github.com/lbryio/lbry/issues/470)
+ * Fixed upload of bug reports to Slack ([#472](https://github.com/lbryio/lbry/issues/472))
 
 ## [0.8.1] - 2017-02-01
 ### Changed

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -2679,7 +2679,7 @@ def get_loggly_query_string(installation_id):
 
 
 def report_bug_to_slack(message, installation_id, platform_name, app_version):
-    webhook = utils.deobfuscate(conf.settings.SLACK_WEBHOOK)
+    webhook = utils.deobfuscate(conf.settings['SLACK_WEBHOOK'])
     payload_template = "os: %s\n version: %s\n<%s|loggly>\n%s"
     payload_params = (
         platform_name,


### PR DESCRIPTION
It was trying to access this setting as an attribute, which doesn't work anymore. (Not sure if this is an API change in conf.settings or just a bug.)