### PR TITLE
record traceback in error event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ at anytime.
 ### Changed
  * Remove unused upload_allowed option
 
+### Fixed
+ * add misssing traceback to logging
+
+
 ## [0.8.3] - 2017-02-15
 ### Fixed
  * Get lbry files with pending claims

--- a/lbrynet/analytics/events.py
+++ b/lbrynet/analytics/events.py
@@ -67,6 +67,7 @@ class Events(object):
             'module': log_record.module,
             'lineno': log_record.lineno,
             'name': log_record.name,
+            'traceback': log_record.exc_text,
         }
         return self._event('Error', properties)
 

--- a/lbrynet/analytics/logging_handler.py
+++ b/lbrynet/analytics/logging_handler.py
@@ -8,4 +8,7 @@ class Handler(logging.Handler):
         logging.Handler.__init__(self, level)
 
     def emit(self, record):
+        # We need to call format to ensure that record.message and
+        # record.exc_text attributes are populated
+        self.format(record)
         self.manager.send_error(record)


### PR DESCRIPTION
In investigating #480, turns out log_record.message doesn't have traceback info - so adding another field to record it