### PR TITLE
dummy hash announcer requires hash_queue_size() function

### DIFF
--- a/lbrynet/core/HashAnnouncer.py
+++ b/lbrynet/core/HashAnnouncer.py
@@ -11,5 +11,8 @@ class DummyHashAnnouncer(object):
     def add_supplier(self, *args):
         pass
 
+    def hash_queue_size(self):
+        return 0
+
     def immediate_announce(self, *args):
         pass


### PR DESCRIPTION
DummyHashAnnouncer requires hash_queue_size() function, if to be used in conjunction with DHTHashSupplier (or BlobManager which inherits from DHTHashSupplier) because of this patch https://github.com/lbryio/lbry/pull/465

This fixes scripts download_blob_from_peer.py  and reseed_file.py 