### PR TITLE
Adding timeout to ClientProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Added timeout to ClientProtocol
   *
   *
 


### PR DESCRIPTION
Add a timeout to ClientProtocol using TimeoutMixIn:  http://twistedmatrix.com/documents/9.0.0/api/twisted.protocols.policies.TimeoutMixin.html  . 

If a peer does not send anything within 30 seconds, close the connection and mark peer as down.  Also add a unit test for the timeout. 