### PR TITLE
Add check in case local height is less than zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
 
 ### Fixed
   * Added timeout to ClientProtocol
+  * Add check for when local height of wallet is less than zero
   *
   *
 


### PR DESCRIPTION
lbryum.network.get_local_height() could be -1 in case the blockchain_headers file is empty (can happen on fresh installs See: https://github.com/lbryio/lbryum/blob/master/lib/blockchain.py#L171 ) , in this case subsequent calls can fail since there is no header at height -1. 

Add checks for these cases where get_local_height() is used.

This patch is required to fix lbry in a box integration testing