### PR TITLE
Exclude tests folders in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(name=package_name,
       url=url,
       author=author,
       keywords=keywords,
-      packages=find_packages(base_dir),
+      packages=find_packages(base_dir, exclude=['tests']),
       install_requires=requires,
       entry_points={'console_scripts': console_scripts},
       package_data={


### PR DESCRIPTION
Without this, it would install our tests folder as a module tests in python 

See https://github.com/lbryio/lbry/issues/498