### PR TITLE
Fix downloading not timing out properly when unable to download sd blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
 
 ### Fixed
   * Fixed ExchangeRateManager freezing the app
+  * Fixed download not timing out properly when downloading sd blob
   *
   *
 

--- a/lbrynet/lbrynet_daemon/Downloader.py
+++ b/lbrynet/lbrynet_daemon/Downloader.py
@@ -176,13 +176,13 @@ class GetStream(object):
         log.info("Downloading lbry://%s (%s) --> %s", name, self.sd_hash[:6], self.download_path)
         self.finished_deferred = self.downloader.start()
         self.finished_deferred.addCallback(self.finish, name)
-        yield self.data_downloading_deferred
 
     @defer.inlineCallbacks
     def start(self, stream_info, name):
         try:
             safe_start(self.checker)
-            yield self.download(stream_info, name)
+            self.download(stream_info, name)
+            yield self.data_downloading_deferred
             defer.returnValue(self.download_path)
         except Exception as err:
             safe_stop(self.checker)


### PR DESCRIPTION
When running command "get" on name "0ne-osx-desktop" (starts with numerical zero), it was discovered that if you are unable to download the sd_blob, the download never times out, thus the "get" command stalls forever. 

If you look at Downloader class, start() is yielding to download() which means that it waits for sd_blob_download() to finish. sd_blob_download() does not have a timeout so it never finishes. You have to call download() and than yield to data_downloading_deferred() to get the proper behavior. 

We really need a proper timeout mechanism in the correct base classes as I stated here https://github.com/lbryio/lbry/issues/504 to prevent these issues from happening, and to avoid writing timeout codes all over the place.  