### PR TITLE
Delete reveal and open command from api, not needed for electron

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -2237,50 +2237,6 @@ class Daemon(AuthJSONRPCServer):
         d.addCallback(lambda _: self._render_response(True))
         return d
 
-    @AuthJSONRPCServer.auth_required
-    @defer.inlineCallbacks
-    def jsonrpc_open(self, sd_hash):
-        """
-        Instruct the OS to open a file with its default program.
-
-        Args:
-            'sd_hash': SD hash of file to be opened
-        Returns:
-            True, opens file
-        """
-
-        lbry_file = yield self._get_lbry_file(FileID.SD_HASH, sd_hash)
-        if not lbry_file:
-            raise Exception('Unable to find file for {}'.format(sd_hash))
-
-        try:
-            file_utils.start(lbry_file['download_path'])
-        except IOError:
-            pass
-        defer.returnValue(True)
-
-    @defer.inlineCallbacks
-    @AuthJSONRPCServer.auth_required
-    def jsonrpc_reveal(self, sd_hash):
-        """
-        Reveal a file or directory in file browser
-
-        Args:
-            'path': path to be revealed in file browser
-        Returns:
-            True, opens file browser
-        """
-
-        lbry_file = yield self._get_lbry_file(FileID.SD_HASH, sd_hash)
-        if not lbry_file:
-            raise Exception('Unable to find file for {}'.format(sd_hash))
-
-        try:
-            file_utils.reveal(lbry_file['download_path'])
-        except IOError:
-            pass
-        defer.returnValue(True)
-
     def jsonrpc_get_peers_for_hash(self, blob_hash):
         """
         DEPRECATED. Use `peer_list` instead


### PR DESCRIPTION
Delete the "reveal" and "open" daemon commands from api, as they are not needed for electron. 

