### PR TITLE
WIP: need consistent interface for obtaining claims through wallet 

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -544,7 +544,7 @@ class Wallet(object):
                     return claim
             return False
 
-        d = self.get_name_claims()
+        d = self.get_my_name_claims()
         d.addCallback(_get_my_unspent_claim)
         d.addCallback(_get_claim_for_return)
         return d
@@ -822,7 +822,7 @@ class Wallet(object):
     def get_best_blockhash(self):
         return defer.fail(NotImplementedError())
 
-    def get_name_claims(self):
+    def get_my_name_claims(self):
         return defer.fail(NotImplementedError())
 
     def _get_claims_for_name(self, name):
@@ -1050,7 +1050,7 @@ class LBRYumWallet(Wallet):
         header = self.network.blockchain.read_header(height)
         return defer.succeed(self.network.blockchain.hash_header(header))
 
-    def get_name_claims(self):
+    def get_my_name_claims(self):
         return self._run_cmd_as_defer_succeed('getnameclaims')
 
     def _get_claims_for_name(self, name):

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1825,7 +1825,7 @@ class Daemon(AuthJSONRPCServer):
                         c[k] = float(c[k])
             return defer.succeed(claims)
 
-        d = self.session.wallet.get_name_claims()
+        d = self.session.wallet.get_my_name_claims()
         d.addCallback(_clean)
         d.addCallback(lambda claims: self._render_response(claims))
         return d

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1842,24 +1842,17 @@ class Daemon(AuthJSONRPCServer):
         """
         return self.jsonrpc_claim_list(**kwargs)
 
-    def jsonrpc_claim_list(self, name=None, txid=None):
+    def jsonrpc_claim_list(self, name):
         """
         Get claims for a name
 
         Args:
-            name: file name
-            txid: transaction id of a name claim transaction
+            name: search for claims on this name
         Returns
             list of name claims
         """
 
-        if name is not None:
-            d = self.session.wallet.get_claims_for_name(name)
-        elif txid is not None:
-            d = self.session.wallet.get_claims_from_tx(txid)
-        else:
-            return server.failure
-
+        d = self.session.wallet.get_claims_for_name(name)
         d.addCallback(lambda r: self._render_response(r))
         return d
 

--- a/tests/unit/core/test_Wallet.py
+++ b/tests/unit/core/test_Wallet.py
@@ -27,7 +27,7 @@ class MocLbryumWallet(Wallet):
         self.wallet_balance = Decimal(10.0)
         self.total_reserved_points = Decimal(0.0)
         self.queued_payments = defaultdict(Decimal)
-    def get_name_claims(self):
+    def get_my_name_claims(self):
         return threads.deferToThread(lambda: [])
 
     def _save_name_metadata(self, name, claim_outpoint, sd_hash):


### PR DESCRIPTION
There's a bunch of different ways to obtain a claim through the wallet, all returning differently formatted dictionary outputs. 

Need to unify this, so that at the very least the output from Daemon API commands "claim_list" and "claim_list_mine" are consistent. 