### PR TITLE
Fix fee validation in publisher and clarify publish docstring

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1692,7 +1692,7 @@ class Daemon(AuthJSONRPCServer):
             'metadata': dict, Metadata compliant (can be missing sources if a file is provided)
             'file_path' (optional): str, path to file to be associated with name, if not given
                                     the stream from your existing claim for the name will be used
-            'fee' (optional): dict, FeeValidator compliant
+            'fee' (optional): dict, FeeValidator compliant (i.e. {'LBC':{'amount':10}} )
         Returns:
             'tx' : hex encoded transaction
             'txid' : txid of resulting transaction

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -22,7 +22,6 @@ class Publisher(object):
 
     @defer.inlineCallbacks
     def add_fee_to_metadata(self, metadata, fee):
-        metadata['fee'] = FeeValidator(fee)
         assert len(fee) == 1, "Too many fees"
         for currency in fee:
             if 'address' not in fee[currency]:


### PR DESCRIPTION
There was a bug in publisher  which made it not accept Fee dict structure without addresses in them ( i think just someone forgot to delete a line) such as {'LBC':{'amount':0.01}}

Also clarified publish docstring what fee dict would look like. 