### PR TITLE
Change publish to take metadata fields as arguments, docstring change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ at anytime.
 
 ## [Unreleased]
 ### Added
-  *
+  * publish API command can take metadata fields as arguments
   *
   *
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -389,13 +389,42 @@ Returns:
 ```text
 Make a new name claim and publish associated data to lbrynet
 
+Fields required in the final Metadata are:
+    'title'
+    'description'
+    'author'
+    'language'
+    'license',
+    'nsfw'
+
+Metadata can be set by either using the metadata argument or by setting individual arguments
+fee, title, description, author, language, license, license_url, thumbnail, preview, nsfw,
+or sources. Individual arguments will overwrite the fields specified in metadata argument.
+
 Args:
-    'name': (str) name to be claimed, string
+    'name': (str) name to be claimed
     'bid': (float) amount of credits to commit in this claim,
-    'metadata': (dict) Metadata compliant (can be missing sources if a file is provided)
-    'file_path' (optional): (str) path to file to be associated with name, if not given
-                            the stream from your existing claim for the name will be used
-    'fee' (optional): (dict) FeeValidator compliant (i.e. {'LBC':{'amount':10}} )
+    'metadata'(optional): (dict) Metadata to associate with the claim.
+    'file_path'(optional): (str) path to file to be associated with name. If provided,
+                            a lbry stream of this file will be used in 'sources'.
+                            If no path is given but a metadata dict is provided, the source
+                            from the given metadata will be used.
+    'fee'(optional): (dict) Dictionary representing key fee to download content:
+                      {currency_symbol: {'amount': float, 'address': str, optional}}
+                      supported currencies: LBC, USD, BTC
+                      If an address is not provided a new one will be automatically
+                      generated. Default fee is zero.
+    'title'(optional): (str) title of the file
+    'description'(optional): (str) description of the file
+    'author'(optional): (str) author of the file
+    'language'(optional): (str), language code
+    'license'(optional): (str) license for the file
+    'license_url'(optional): (str) URL to license
+    'thumbnail'(optional): (str) thumbnail URL for the file
+    'preview'(optional): (str) preview URL for the file
+    'nsfw'(optional): (bool) True if not safe for work
+    'sources'(optional): (dict){'lbry_sd_hash':sd_hash} specifies sd hash of file
+
 Returns:
     (dict) Dictionary containing result of the claim
     {

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -7,7 +7,6 @@ from lbrynet.core import file_utils
 from lbrynet.lbryfilemanager.EncryptedFileCreator import create_lbry_file
 from lbrynet.lbryfile.StreamDescriptor import publish_sd_blob
 from lbrynet.metadata.Metadata import Metadata
-from lbrynet.metadata.Fee import FeeValidator
 
 
 log = logging.getLogger(__name__)
@@ -19,16 +18,6 @@ class Publisher(object):
         self.lbry_file_manager = lbry_file_manager
         self.wallet = wallet
         self.lbry_file = None
-
-    @defer.inlineCallbacks
-    def add_fee_to_metadata(self, metadata, fee):
-        assert len(fee) == 1, "Too many fees"
-        for currency in fee:
-            if 'address' not in fee[currency]:
-                new_address = yield self.session.wallet.get_new_address()
-                fee[currency]['address'] = new_address
-        metadata['fee'] = FeeValidator(fee)
-        defer.returnValue(metadata)
 
     @defer.inlineCallbacks
     def publish_stream(self, name, file_path, bid, metadata):


### PR DESCRIPTION
Changes partially taken from db refactor branch

https://github.com/lbryio/lbry/pull/505/commits/491fba5b36abe394e1437ca7f74ad7481c27fe2a

jsonrpc_publish can now take metadata fields as arguments 

Change and make docstring more informative 

Move add_fee_to_metadata() function from Publisher class to jsonrpc_publish() so that its consistent with how other metdata fields are handled. 

