### PR TITLE
Fix broken descriptor_get command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ at anytime.
 ### Fixed
   * Fixed jsonrpc_reflect()
   * Fixed api help return
-  *
+  * Fixed API command descriptor_get
 
 ## [0.9.1rc2] - 2017-03-15
 ### Added


### PR DESCRIPTION
https://github.com/lbryio/lbry/pull/469 This pull request broke descriptor_get API command. The command would always return null because _download_sd_blob() function had a crucial deferred that was setup in line 762 of Daemon.py but was never part of any callback chain.

d = download_sd_blob(self.session, sd_blob_hash, rate_manager)

I fixed it so that it uses jsonrpc_blob_get with encoding json (code reuse is nice). It doesn't save the sd blob to the stream_info_manager but I don't really see a great reason why it should do so.  Since _download_sd_blob() is not used anywhere else, it can be deleted.  
