### PR TITLE
fix double_download tests failing on BlobManager

### DIFF
--- a/lbrynet/core/BlobManager.py
+++ b/lbrynet/core/BlobManager.py
@@ -104,7 +104,6 @@ class DiskBlobManager(BlobManager):
         if self._next_manage_call is not None and self._next_manage_call.active():
             self._next_manage_call.cancel()
             self._next_manage_call = None
-        self.db_conn = None
         return defer.succeed(True)
 
     def get_blob(self, blob_hash, length=None):


### PR DESCRIPTION
This is a temporary fix for https://github.com/lbryio/lbry/issues/527

I don't think there's any need to set self.db_conn to None here in BlobManager. 

I think we probably are not shutting down the BlobManager properly (self.db_conn.close() never gets called) , but since the BlobManager should persist for the lifespan of the app this temporary fix should be ok.

