### PR TITLE
fix wallet_public_key API command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Fix wallet_public_key API command
   *
   *
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -633,8 +633,9 @@ Returns:
 Get public key from wallet address
 
 Args:
-    'wallet': (str) wallet address in base58
+    'address': (str) wallet address in base58
 Returns:
-    (str) Public key in hex encoding
+    (list) list of public keys associated with address.
+        Could contain more than one public key if multisig.
 ```
 

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -1101,8 +1101,10 @@ class LBRYumWallet(Wallet):
     def _address_is_mine(self, address):
         return self._run_cmd_as_defer_succeed('ismine', address)
 
-    def get_pub_keys(self, wallet):
-        return self._run_cmd_as_defer_succeed('getpubkyes', wallet)
+    # returns a list of public keys associated with address
+    # (could be multiple public keys if a multisig address)
+    def get_pub_keys(self, address):
+        return self._run_cmd_as_defer_succeed('getpubkeys', address)
 
     def _save_wallet(self, val):
         self.wallet.storage.write()

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -2052,18 +2052,20 @@ class Daemon(AuthJSONRPCServer):
         return self.jsonrpc_wallet_public_key(wallet)
 
     @AuthJSONRPCServer.auth_required
-    def jsonrpc_wallet_public_key(self, wallet):
+    def jsonrpc_wallet_public_key(self, address):
         """
         Get public key from wallet address
 
         Args:
-            'wallet': (str) wallet address in base58
+            'address': (str) wallet address in base58
         Returns:
-            (str) Public key in hex encoding
+            (list) list of public keys associated with address.
+                Could contain more than one public key if multisig.
         """
 
-        d = self.session.wallet.get_pub_keys(wallet)
+        d = self.session.wallet.get_pub_keys(address)
         d.addCallback(lambda r: self._render_response(r))
+        return d
 
     @AuthJSONRPCServer.auth_required
     def jsonrpc_get_new_address(self):


### PR DESCRIPTION
fix spelling error getpubkyes

argument 'wallet' changed to 'address' to be less confusing

clarify that the command returns a list in the doc string 

return the deferred 

update api docs

