### PR TITLE
Fix restart procedure in DaemonControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Fix restart procedure in DaemonControl
   *
   *
 

--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -131,9 +131,11 @@ def start_server_and_listen(launchui, use_auth, analytics_manager, max_tries=5):
             break
         except Exception as e:
             log.exception('Failed to startup')
+            yield daemon_server.stop()
             analytics_manager.send_server_startup_error(str(e))
         tries += 1
     else:
+        log.warn("Exceeded max tries to start up, stopping")
         reactor.callFromThread(reactor.stop)
 
 


### PR DESCRIPTION
Fix for https://github.com/lbryio/lbry/issues/549

Create a stop() function in DaemonServer, which closes the listening port and shuts down the Daemon. 
This allows a DaemonControl to restart the DaemonServer in case something goes wrong while starting up the Daemon ( you can't restart if the port is already binded, and if you don't shut down the Daemon before restarting, you'll have two Daemon's running at the same time)
