### PR TITLE
Increase download timeout

### DIFF
--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -162,7 +162,7 @@ ADJUSTABLE_SETTINGS = {
     'delete_blobs_on_remove': (bool, True),
     'dht_node_port': (int, 4444),
     'download_directory': (str, default_download_directory),
-    'download_timeout': (int, 30),
+    'download_timeout': (int, 60),
     'host_ui': (bool, True),
     'is_generous_host': (bool, True),
     'known_dht_nodes': (list, DEFAULT_DHT_NODES, server_port),


### PR DESCRIPTION
I'm finding that the daemon get command will often timeout , and there has also been reports here https://github.com/lbryio/lbry/issues/533 that report the same thing. Testing download of "what" several times, I've found that it times out about 40% of the time. 

The download_timeout is the number of seconds to wait for before the first blob (that's not the sd_blob) is downloaded. Setting it to 60 seconds and testing download of what, it succeeded 100% of the time. Not sure if the timeout is long enough for everyone though. 

I believe this is happening now because we have more peers on the network than before with many of them not being reliable, and the ConnectionManager often finds an unreliable peer and wastes time connecting to them. 