### PR TITLE
Rename API command file_seed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ at anytime.
 
 ### Changed
   * Removed check_pending logic from Daemon
-  *
+  * Renamed API command file_seed to file_set_status
   *
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -487,25 +487,9 @@ Returns:
 ```text
 Get daemon settings
 
-Args:
-    None
 Returns:
     (dict) Dictionary of daemon settings
-    {
-        'run_on_startup': (bool) currently not supported
-        'data_rate': (float) data rate
-        'max_key_fee': (float) maximum key fee
-        'download_directory': (str) path of where files are downloaded
-        'max_upload': (float), currently not supported
-        'max_download': (float), currently not supported
-        'download_timeout': (int) download timeout in seconds
-        'max_search_results': (int) max search results
-        'wallet_type': (str) wallet type
-        'delete_blobs_on_remove': (bool) delete blobs on removal
-        'peer_port': (int) peer port
-        'dht_node_port': (int) dht node port
-        'use_upnp': (bool) use upnp if true
-    }
+    See ADJUSTABLE_SETTINGS in lbrynet/conf.py for full list of settings
 ```
 
 ## settings_set
@@ -521,8 +505,10 @@ Args:
     'max_upload': (float), currently not supported
     'max_download': (float), currently not supported
     'download_timeout': (int) download timeout in seconds
+    'search_timeout': (float) search timeout in seconds
+    'cache_time': (int) cache timeout in seconds
 Returns:
-    (dict) settings dict
+    (dict) Updated dictionary of daemon settings
 ```
 
 ## status
@@ -614,6 +600,17 @@ Args:
     'address': (str) address to check in base58
 Returns:
     (bool) true, if address is associated with current wallet
+```
+
+## wallet_list
+
+```text
+List wallet addresses
+
+Args:
+    None
+Returns:
+    List of wallet addresses
 ```
 
 ## wallet_new_address

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1467,22 +1467,22 @@ class Daemon(AuthJSONRPCServer):
     @AuthJSONRPCServer.auth_required
     def jsonrpc_stop_lbry_file(self, **kwargs):
         """
-        DEPRECATED. Use `file_seed status=stop` instead.
+        DEPRECATED. Use `file_set_status status=stop` instead.
         """
-        return self.jsonrpc_file_seed(status='stop', **kwargs)
+        return self.jsonrpc_file_set_status(status='stop', **kwargs)
 
     @AuthJSONRPCServer.auth_required
     def jsonrpc_start_lbry_file(self, **kwargs):
         """
-        DEPRECATED. Use `file_seed status=start` instead.
+        DEPRECATED. Use `file_set_status status=start` instead.
         """
-        return self.jsonrpc_file_seed(status='start', **kwargs)
+        return self.jsonrpc_file_set_status(status='start', **kwargs)
 
     @AuthJSONRPCServer.auth_required
     @defer.inlineCallbacks
-    def jsonrpc_file_seed(self, status, **kwargs):
+    def jsonrpc_file_set_status(self, status, **kwargs):
         """
-        Start or stop seeding a file
+        Start or stop downloading a file
 
         Args:
             'status': (str) "start" or "stop"
@@ -1503,10 +1503,11 @@ class Daemon(AuthJSONRPCServer):
 
         if status == 'start' and lbry_file.stopped or status == 'stop' and not lbry_file.stopped:
             yield self.lbry_file_manager.toggle_lbry_file_running(lbry_file)
-            msg = "Started seeding file" if status == 'start' else "Stopped seeding file"
+            msg = "Started downloading file" if status == 'start' else "Stopped downloading file"
         else:
             msg = (
-                "File was already being seeded" if status == 'start' else "File was already stopped"
+                "File was already being downloaded" if status == 'start'
+                    else "File was already stopped"
             )
         response = yield self._render_response(msg)
         defer.returnValue(response)


### PR DESCRIPTION
"seeding a file" generally refers to the act of making a file accessible to peers in a p2p network. 

API command file_seed did not actually do that, the command is either for stopping or restarting a download. 

I renamed it to file_set_status but open to other suggestions. 

Also ran the gen_api_docs.py script , I see that there are some other API changes that needs this.