### PR TITLE
WIP: connection manager speed up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ at anytime.
   *
 
 ### Changed
-  *
+  * Improved ConnectionManager speed
   *
   *
 

--- a/lbrynet/core/client/ConnectionManager.py
+++ b/lbrynet/core/client/ConnectionManager.py
@@ -21,6 +21,7 @@ class PeerConnectionHandler(object):
 class ConnectionManager(object):
     implements(interfaces.IConnectionManager)
     MANAGE_CALL_INTERVAL_SEC = 5
+    TCP_CONNECT_TIMEOUT = 15
 
     def __init__(self, downloader, rate_limiter,
                  primary_request_creators, secondary_request_creators):
@@ -208,7 +209,8 @@ class ConnectionManager(object):
                 lambda c_was_made: self._peer_disconnected(c_was_made, peer))
         self._peer_connections[peer] = PeerConnectionHandler(self._primary_request_creators[:],
                                                              factory)
-        connection = reactor.connectTCP(peer.host, peer.port, factory)
+        connection = reactor.connectTCP(peer.host, peer.port, factory,
+                                        timeout=self.TCP_CONNECT_TIMEOUT)
         self._peer_connections[peer].connection = connection
 
     def _peer_disconnected(self, connection_was_made, peer):

--- a/tests/unit/core/client/test_ConnectionManager.py
+++ b/tests/unit/core/client/test_ConnectionManager.py
@@ -177,12 +177,10 @@ class TestIntegrationConnectionManager(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_parallel_connections(self):
-        # Test to see that we make new connection for each manage call,
+        # Test to see that we make two new connections at a manage call,
         # without it waiting for the connection to complete
         test_peer2 = Peer(LOCAL_HOST, PEER_PORT+1)
         self.primary_request_creator.peers_to_return = [self.TEST_PEER, test_peer2]
-        yield self.connection_manager.manage(schedule_next_call=False)
-        self.assertEqual(1, self.connection_manager.num_peer_connections())
         yield self.connection_manager.manage(schedule_next_call=False)
         self.assertEqual(2, self.connection_manager.num_peer_connections())
         self.assertIn(self.TEST_PEER, self.connection_manager._peer_connections)


### PR DESCRIPTION
Some things to help ConnectionManager go through possible peers faster : 

Timeout TCP connection faster (default timeout was 30 seconds, set to 15 seconds) so it spends less time on peers it cant connect to. 

The old manage() loop was called every second, and each loop connected to a single new peer. Change it so that the manage() loop is called every five seconds, and connects to five new peers (at most) in a single loop (basically connect in parallel instead of in sequence)