### PR TITLE
get_unused_address / get_new_address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ at anytime.
 
 ## [Unreleased]
 ### Added
-  *
+  * Create wallet_unused_address API command
   *
   *
 
 ### Changed
-  *
+  * wallet_new_address API command always returns new address
   *
   *
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -293,10 +293,10 @@ Returns:
     ]
 ```
 
-## file_seed
+## file_set_status
 
 ```text
-Start or stop seeding a file
+Start or stop downloading a file
 
 Args:
     'status': (str) "start" or "stop"
@@ -634,5 +634,17 @@ Args:
 Returns:
     (list) list of public keys associated with address.
         Could contain more than one public key if multisig.
+```
+
+## wallet_unused_address
+
+```text
+Return an address containing no balance, will create
+a new address if there is none.
+
+Args:
+    None
+Returns:
+    (str) Unused wallet address in base58
 ```
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1985,6 +1985,29 @@ class Daemon(AuthJSONRPCServer):
         d.addCallback(lambda address: self._render_response(address))
         return d
 
+
+    @AuthJSONRPCServer.auth_required
+    def jsonrpc_wallet_unused_address(self):
+        """
+        Return an address containing no balance, will create
+        a new address if there is none.
+
+        Args:
+            None
+        Returns:
+            (str) Unused wallet address in base58
+        """
+
+        def _disp(address):
+            log.info("Got unused wallet address: " + address)
+            return defer.succeed(address)
+
+        d = self.session.wallet.get_unused_address()
+        d.addCallback(_disp)
+        d.addCallback(lambda address: self._render_response(address))
+        return d
+
+
     @AuthJSONRPCServer.auth_required
     def jsonrpc_send_amount_to_address(self, amount, address):
         """


### PR DESCRIPTION
Previously the wallet/API used get_new_address()/ wallet_new_address() which returned an unused address (address containing no balance, generate new one if none). We rename this function to get_unused_address()/wallet_unused_address(), and create a function that always generate a brand new address get_new_address()/wallet_new_address(). 


Internally, get_unused_address is used when generating recieve address for data fees ( to prevent reflector from generating large amount of addresses). get_new_address is used when generating key fee recieve address for publishing. 