### PR TITLE
Remove update_metadata() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Removed update_metadata function that could cause update problems
   *
   *
 

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -603,12 +603,6 @@ class Wallet(object):
         d = self._get_claims_for_name(name)
         return d
 
-    def update_metadata(self, new_metadata, old_metadata):
-        meta_for_return = old_metadata if isinstance(old_metadata, dict) else {}
-        for k in new_metadata:
-            meta_for_return[k] = new_metadata[k]
-        return defer.succeed(Metadata(meta_for_return))
-
     def _process_claim_out(self, claim_out):
         claim_out.pop('success')
         claim_out['fee'] = float(claim_out['fee'])
@@ -637,10 +631,9 @@ class Wallet(object):
             log.info("Updating claim")
             if self.get_balance() < Decimal(bid) - Decimal(my_claim['amount']):
                 raise InsufficientFundsError()
-            new_metadata = yield self.update_metadata(_metadata, my_claim['value'])
             old_claim_outpoint = ClaimOutpoint(my_claim['txid'], my_claim['nout'])
             claim = yield self._send_name_claim_update(name, my_claim['claim_id'],
-                                                       old_claim_outpoint, new_metadata, bid)
+                                                       old_claim_outpoint, _metadata, bid)
             claim['claim_id'] = my_claim['claim_id']
         else:
             log.info("Making a new claim")


### PR DESCRIPTION
During updates, publishing was silently using metadata fields in the old claim and placing it in the new claim. This would cause a problem for example if you specified a key fee in the old claim , but did not in the new claim (indicating free content). 

Treat metadata specified in the update as the de-facto metadata.

Am i missing something here?