### PR TITLE
proposal of API commands changes for channels

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1856,6 +1856,27 @@ class Daemon(AuthJSONRPCServer):
         return d
 
     @AuthJSONRPCServer.auth_required
+    def jsonrpc_channel_new(self, channel_name):
+        """
+        WORK IN PROGRESS
+        Make a channel claim, or update if already claimed
+        by user.
+        Args:
+            'channel_name': name of channel, must start with @
+        Returns:
+            (dict) Dictionary containing result of the channel claim
+            {
+                'tx' : (str) hex encoded transaction
+                'txid' : (str) txid of resulting claim
+                'nout' : (int) nout of the resulting claim
+                'fee' : (float) fee paid for the claim transaction
+                'claim_id' : (str) claim ID of the resulting claim
+            }
+
+        """
+        pass
+
+    @AuthJSONRPCServer.auth_required
     def jsonrpc_get_transaction_history(self):
         """
         DEPRECATED. Use `transaction_list` instead


### PR DESCRIPTION
This is the proposed API command for channels 

channel_new 

        WORK IN PROGRESS
        Make a channel claim, or update if already claimed
        by user.
        Args:
            'channel_name': name of channel, must start with @
        Returns:
            (dict) Dictionary containing result of the channel claim
            {
                'tx' : (str) hex encoded transaction
                'txid' : (str) txid of resulting claim
                'nout' : (int) nout of the resulting claim
                'fee' : (float) fee paid for the claim transaction
                'claim_id' : (str) claim ID of the resulting claim
            }




In addition, below are changes to the current API commands for channel 

1. jsonrpc_publish will have new argument "channel_name" to specify which channel a publish belongs to. 

2. jsonrpc_resolve_name will have a new argument "validate_channel" (other alternatives : "validate" , "authenticate", "authenticate_channel" ) which will check the signature, if there is any, and validate it. It will return None if it does not validate. 

Other commands, such as claim_show, claim_list_mine, and claim_list will remain the same, returning channel related claims in the same format. I think this is good enough for now, there could be more new commands (i.e. command for validating signatures) but its better not to make drastic changes all at once. 


