### PR TITLE
clarify publish API command docstring

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -387,7 +387,8 @@ Returns:
 ## publish
 
 ```text
-Make a new name claim and publish associated data to lbrynet
+Make a new name claim and publish associated data to lbrynet,
+update over existing claim if user already has a claim for name.
 
 Fields required in the final Metadata are:
     'title'

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1580,7 +1580,8 @@ class Daemon(AuthJSONRPCServer):
                         description=None, author=None, language=None, license=None,
                         license_url=None, thumbnail=None, preview=None, nsfw=None, sources=None):
         """
-        Make a new name claim and publish associated data to lbrynet
+        Make a new name claim and publish associated data to lbrynet,
+        update over existing claim if user already has a claim for name.
 
         Fields required in the final Metadata are:
             'title'


### PR DESCRIPTION
just a clarification on the docstring for jsonrpc_pulish() that publish will update over existing name