### PR TITLE
remove update_stream

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -715,13 +715,10 @@ class Daemon(AuthJSONRPCServer):
         verify_name_characters(name)
         if bid <= 0.0:
             raise Exception("Invalid bid")
-        if not file_path:
-            claim_out = yield publisher.update_stream(name, bid, metadata)
-        else:
-            claim_out = yield publisher.publish_stream(name, file_path, bid, metadata)
-            if conf.settings['reflect_uploads']:
-                d = reupload.reflect_stream(publisher.lbry_file)
-                d.addCallbacks(lambda _: log.info("Reflected new publication to lbry://%s", name),
+        claim_out = yield publisher.publish_stream(name, file_path, bid, metadata)
+        if conf.settings['reflect_uploads']:
+            d = reupload.reflect_stream(publisher.lbry_file)
+            d.addCallbacks(lambda _: log.info("Reflected new publication to lbry://%s", name),
                                log.exception)
         log.info("Success! Published to lbry://%s txid: %s nout: %d", name, claim_out['txid'],
                  claim_out['nout'])

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -42,15 +42,6 @@ class Publisher(object):
         defer.returnValue(claim_out)
 
     @defer.inlineCallbacks
-    def update_stream(self, name, bid, metadata):
-        my_claim = yield self.wallet.get_my_claim(name)
-        updated_metadata = my_claim['value']
-        for meta_key in metadata:
-            updated_metadata[meta_key] = metadata[meta_key]
-        claim_out = yield self.make_claim(name, bid, updated_metadata)
-        defer.returnValue(claim_out)
-
-    @defer.inlineCallbacks
     def make_claim(self, name, bid, metadata):
         validated_metadata = Metadata(metadata)
         claim_out = yield self.wallet.claim_name(name, bid, validated_metadata)


### PR DESCRIPTION
Same problem as https://github.com/lbryio/lbry/pull/569 , identical code found in Publisher, triggered in case user specified the source instead of file_path in jsonrpc_publish()

Publishing was silently using metadata fields in the old claim and placing it in the new claim. This would cause a problem for example if you specified a key fee in the old claim , but did not in the new claim (indicating free content).

