### PR TITLE
Return full LBRY ID and installation ID in jsonrpc_status()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 /docs_build
 /lbry-venv
 
-.idea/.name
+.idea/
 .coverage
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ at anytime.
   *
 
 ### Changed
-  *
+  * Return full `lbry_id` and `installation_id` from `status`
   *
   *
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1061,8 +1061,8 @@ class Daemon(AuthJSONRPCServer):
         best_hash = (yield self.session.wallet.get_best_blockhash()) if has_wallet else None
 
         response = {
-            'lbry_id': base58.b58encode(self.lbryid)[:SHORT_ID_LEN],
-            'installation_id': conf.settings.get_installation_id()[:SHORT_ID_LEN],
+            'lbry_id': base58.b58encode(self.lbryid),
+            'installation_id': conf.settings.installation_id,
             'is_running': self.announced_startup,
             'is_first_run': self.session.wallet.is_first_run if has_wallet else None,
             'startup_status': {

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -247,6 +247,7 @@ create_stream_sd_file = {
 def mock_conf_settings(obj, settings={}):
     original_settings = conf.settings
     conf.settings = conf.Config(conf.FIXED_SETTINGS, conf.ADJUSTABLE_SETTINGS)
+    conf.settings.installation_id = conf.settings.get_installation_id()
     conf.settings.update(settings)
 
     def _reset_settings():


### PR DESCRIPTION
Better to let the client decide whether to display the short or long version