### PR TITLE
Fix update_stream in publisher 

### DIFF
--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -716,9 +716,9 @@ class Daemon(AuthJSONRPCServer):
         if bid <= 0.0:
             raise Exception("Invalid bid")
         if not file_path:
-            claim_out = yield publisher.update_stream(name, bid, metadata)
+            claim_out = yield publisher.publish_stream(name, bid, metadata)
         else:
-            claim_out = yield publisher.publish_stream(name, file_path, bid, metadata)
+            claim_out = yield publisher.create_and_publish_stream(name, bid, metadata, file_path)
             if conf.settings['reflect_uploads']:
                 d = reupload.reflect_stream(publisher.lbry_file)
                 d.addCallbacks(lambda _: log.info("Reflected new publication to lbry://%s", name),

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -19,8 +19,11 @@ class Publisher(object):
         self.wallet = wallet
         self.lbry_file = None
 
+    """
+    Create lbry file and make claim
+    """
     @defer.inlineCallbacks
-    def publish_stream(self, name, file_path, bid, metadata):
+    def create_and_publish_stream(self, name, bid, metadata, file_path):
         log.info('Starting publish for %s', name)
         file_name = os.path.basename(file_path)
         with file_utils.get_read_handle(file_path) as read_handle:
@@ -39,6 +42,14 @@ class Publisher(object):
         self.lbry_file.completed = True
         yield self.lbry_file.load_file_attributes()
         yield self.lbry_file.save_status()
+        defer.returnValue(claim_out)
+
+    """
+    Make a claim without creating a lbry file
+    """
+    @defer.inlineCallbacks
+    def publish_stream(self, name, bid, metadata):
+        claim_out = yield self.make_claim(name, bid, metadata)
         defer.returnValue(claim_out)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Redo of https://github.com/lbryio/lbry/pull/576, I misunderstood what this code was doing. 

In Publisher class, 

publish_stream() was used to create a lbry file and make a claim, triggered when file_path was specified in jsonrpc_publish(). 

update_stream() was used to only make a claim, without creating a lbry file, triggered when no file_path was specified and the source was specified indicating already created lbry file in jsonrpc_publish().  It also incorrectly assumed that it was an update and would try to fetch a previous claim, and reuse the fields in the previous claim (same issue as https://github.com/lbryio/lbry/pull/569). Note that just because a source is specified, does not mean it is necessarily an update. 

Rename publish_stream() to create_and_publish_stream()

Rename update_stream() to publish_stream() ,  remove the code that fetched the previous claim and reused its field. 