### PR TITLE
Fix inefficient wallet look ups during publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ at anytime.
 
 ### Fixed
   * Removed update_metadata function that could cause update problems
-  *
+  * Fixed inefficient wallet look ups during publishing
   *
 
 ## [0.9.2rc3] - 2017-03-29

--- a/lbrynet/lbryfilemanager/EncryptedFileDownloader.py
+++ b/lbrynet/lbryfilemanager/EncryptedFileDownloader.py
@@ -126,6 +126,16 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
         self.claim_id = yield self.wallet.get_claimid(self.name, self.txid, self.nout)
         defer.returnValue(None)
 
+    # Same as load_file_attributes(), except we set attributes from the arguments,
+    # instead of looking it up on wallet. Used when publishing.
+    def load_file_attributes_from_arg(self, name, sd_hash, txid, nout, claim_id):
+        self.name = name
+        self.sd_hash = sd_hash
+        self.txid = txid
+        self.nout = nout
+        self.outpoint = ClaimOutpoint(self.txid, self.nout)
+        self.claim_id = self.claim_id
+
     @defer.inlineCallbacks
     def _start(self):
         yield EncryptedFileSaver._start(self)

--- a/lbrynet/lbrynet_daemon/Publisher.py
+++ b/lbrynet/lbrynet_daemon/Publisher.py
@@ -42,7 +42,8 @@ class Publisher(object):
 
         claim_out = yield self.make_claim(name, bid, claim_dict)
         self.lbry_file.completed = True
-        yield self.lbry_file.load_file_attributes()
+        yield self.lbry_file.load_file_attributes_from_arg(
+            name, sd_hash, claim_out['txid'], claim_out['nout'], claim_out['claim_id'])
         yield self.lbry_file.save_status()
         defer.returnValue(claim_out)
 


### PR DESCRIPTION
When publishing, Publisher.create_and_publish_stream() would call load_file_attributes() in EncryptedFileDownloader which would look up file attributes using the wallet. Obtaining the claim id in particular is expensive since it results in  making a request to lbryum server 

Loading attributes using the wallet is not necessary because all the attributes are available in the create_and_publish_stream() function. Create load_file_attributes_from_arg() function which sets the attributes from the argument instead of looking it up. 

Without this pr, publishing will not work using lbryum server with channels/lbryschema integration due to https://github.com/lbryio/lbryum-server/issues/18. 