### PR TITLE
use appdirs 1.4.3 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Twisted==16.6.0
-appdirs==1.4.0
+appdirs==1.4.3
 argparse==1.2.1
 base58==0.2.2
 colorama==0.3.7


### PR DESCRIPTION
having trouble installing when I have most recent appdirs installed and lbrynet requirements.txt forces a downgrade into 1.4.0 https://github.com/ActiveState/appdirs/issues/89

appdirs changelog https://github.com/ActiveState/appdirs/blob/master/CHANGES.rst