### PR TITLE
Fix stream_cost_estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * fix stream_cost_estimate throwing exception on non decodeable claims
   *
   *
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -889,12 +889,13 @@ class Daemon(AuthJSONRPCServer):
         """
         try:
             claim_response = yield self.session.wallet.resolve_uri(uri)
+        #TODO: fix me, this is a hack
         except Exception:
             claim_response = None
 
         result = None
         if claim_response and 'claim' in claim_response:
-            if 'value' in claim_response['claim']:
+            if 'value' in claim_response['claim'] and claim_response['claim']['value'] is not None:
                 claim_value = ClaimDict.load_dict(claim_response['claim']['value'])
                 cost = yield self._get_est_cost_from_metadata(claim_value, uri)
                 result = round(cost, 5)

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1720,7 +1720,8 @@ class Daemon(AuthJSONRPCServer):
             'size' (optional): (int) stream size, in bytes. if provided an sd blob
                                 won't be downloaded.
         Returns:
-            (float) Estimated cost in lbry credits
+            (float) Estimated cost in lbry credits, returns None if uri is not
+                resolveable
         """
         cost = yield self.get_est_cost(uri, size)
         defer.returnValue(cost)


### PR DESCRIPTION
stream_cost_estimate will throw exception when claim value is non decodeable instead of returning None. 

Have it return None, and clarify this in the docstring. 