### PR TITLE
wait for address subscriptions before announcing the wallet has started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ at anytime.
 
 ### Changed
   * Added optional `address` and `include_unconfirmed` params to `jsonrpc_wallet_balance` method
-
+  * Wait for subscriptions before announcing wallet has finished starting
+  
 ### Fixed
   * fix stream_cost_estimate throwing exception on non decodeable claims
   *

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -913,6 +913,9 @@ class LBRYumWallet(Wallet):
         d.addCallback(lambda _: self._start_check.start(.1))
         d.addCallback(lambda _: network_start_d)
         d.addCallback(lambda _: self._load_blockchain())
+        d.addCallback(lambda _: log.info("Subscribing to addresses"))
+        d.addCallback(lambda _: self.wallet.wait_until_synchronized(lambda _: None))
+        d.addCallback(lambda _: log.info("Synchronized wallet"))
         return d
 
     def _stop(self):


### PR DESCRIPTION
fixes lbryum requests timing out because there were too many address subscriptions ahead of them after startup