### PR TITLE
allow claim_show to be specified without name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ at anytime.
 ### Fixed
   *
   *
+  * Allow claim_show to be used without specifying name
 
 ### Deprecated
   *

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1370,7 +1370,7 @@ class Daemon(AuthJSONRPCServer):
         return self.jsonrpc_claim_show(**kwargs)
 
     @defer.inlineCallbacks
-    def jsonrpc_claim_show(self, name, txid=None, nout=None, claim_id=None):
+    def jsonrpc_claim_show(self, name=None, txid=None, nout=None, claim_id=None):
 
         """
         Resolve claim info from a LBRY name


### PR DESCRIPTION
User should be able to use claim_show without specifying name