### PR TITLE
Allow zero fee in fee_schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ at anytime.
 
 ### Fixed
   *
-  *
+  * Allow fee fields in metadata with amount 0
   * Allow claim_show to be used without specifying name
 
 ### Deprecated

--- a/lbrynet/metadata/fee_schemas.py
+++ b/lbrynet/metadata/fee_schemas.py
@@ -7,7 +7,7 @@ VER_001 = {
         'amount': {
             'type': 'number',
             'minimum': 0,
-            'exclusiveMinimum': True,
+            'exclusiveMinimum': False,
         },
         'address': {
             'type': 'string'


### PR DESCRIPTION
If a claim specifies the fee field, but sets amount to zero, the daemon will error out (see lbry://the-handbook-of-technical-analysis) 

Allow claims to have a fee field with amount zero , and treat it as free content.