### PR TITLE
catch UnknownNamError instead of base Exception for resolve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ at anytime.
   *
 
 ### Changed
-  *
+  * Do not catch base exception in API command resolve
   *
 
 ### Fixed

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -701,7 +701,7 @@ class Wallet(object):
             raise UnknownNameError("No results to return")
 
         if 'error' in results:
-            if results['error'] == 'name is not claimed':
+            if results['error'] in ['name is not claimed', 'claim not found']:
                 raise UnknownNameError(results['error'])
             else:
                 raise Exception(results['error'])

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1538,7 +1538,7 @@ class Daemon(AuthJSONRPCServer):
 
         try:
             resolved = yield self.session.wallet.resolve_uri(uri, check_cache=not force)
-        except Exception:
+        except UnknownNameError:
             resolved = None
         results = yield self._render_response(resolved)
         defer.returnValue(results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ jsonrpc==1.2
 jsonrpclib==0.1.7
 jsonschema==2.5.1
 git+https://github.com/lbryio/lbryschema.git@v0.0.6#egg=lbryschema
-git+https://github.com/lbryio/lbryum.git@v2.7.23#egg=lbryum
+git+https://github.com/lbryio/lbryum.git@v2.7.24#egg=lbryum
 miniupnpc==1.9
 pbkdf2==1.3
 pycrypto==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requires = [
     'envparse',
     'jsonrpc',
     'jsonschema',
-    'lbryum==2.7.23',
+    'lbryum==2.7.24',
     'lbryschema==0.0.6',
     'miniupnpc',
     'pycrypto',


### PR DESCRIPTION
Not good practice to catch base Exception in API command resolve . Catch UnknownNameError instead .

In Wallet, catch lbryum error 'claim not found' as UnknownNameError

Requires : https://github.com/lbryio/lbryum/pull/107