### PR TITLE
Fix file delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ at anytime.
 ### Fixed
   * Race condition from improper initialization and shutdown of the blob manager database
   * Various fixes for GetStream class used in API command get
+  * Download analytics error
+  * Fixed flag options in file_delete API command
+  *
 
 ### Deprecated
   *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ at anytime.
   * Support resolution of multiple uris with `resolve`, all results are keyed by uri
   * Add `error` responses for failed resolves
   * Add `claim_list_by_channel`, supports multiple channel resolution
+  * Rename delete_target_file argument of delete API command to delete_from_download_dir
+  * Rename delete_all CLI flag -a to --delete_all
 
 ### Fixed
   * Race condition from improper initialization and shutdown of the blob manager database

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -2501,22 +2501,25 @@ class Daemon(AuthJSONRPCServer):
         defer.returnValue(response)
 
     @defer.inlineCallbacks
-    def jsonrpc_cli_test_command(self, pos_arg, pos_args=[], pos_arg2=None, pos_arg3=None):
+    @AuthJSONRPCServer.flags(a_arg='-a', b_arg='-b')
+    def jsonrpc_cli_test_command(self, pos_arg, pos_args=[], pos_arg2=None, pos_arg3=None,
+                                 a_arg=False, b_arg=False):
         """
         This command is only for testing the CLI argument parsing
         Usage:
-            cli_test_command (<pos_arg> | --pos_arg=<pos_arg>)
+            cli_test_command [-a] [-b] (<pos_arg> | --pos_arg=<pos_arg>)
                              [<pos_args>...] [--pos_arg2=<pos_arg2>]
                              [--pos_arg3=<pos_arg3>]
 
         Options:
+            -a, --a_arg                        : a arg
+            -b, --b_arg                        : b arg
             <pos_arg2>, --pos_arg2=<pos_arg2>  : pos arg 2
             <pos_arg3>, --pos_arg3=<pos_arg3>  : pos arg 3
-
         Returns:
             pos args
         """
-        out = (pos_arg, pos_args, pos_arg2, pos_arg3)
+        out = (pos_arg, pos_args, pos_arg2, pos_arg3, a_arg, b_arg)
         response = yield self._render_response(out)
         defer.returnValue(response)
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1547,7 +1547,8 @@ class Daemon(AuthJSONRPCServer):
                         [--name=<name>]
 
         Options:
-            -a                          : delete file from downloads and delete stored blobs
+            -a                          : if there are multiple matching files, allow the deletion
+                                            of multiple files. Otherwise do not delete anything.
             -f                          : delete only from downloads, do not delete blobs
             --sd_hash=<sd_hash>         : delete by file sd hash
             --file_name<file_name>      : delete by file name in downloads folder
@@ -1567,7 +1568,8 @@ class Daemon(AuthJSONRPCServer):
             if not delete_all:
                 log.warning("There are %i files to delete, use narrower filters to select one",
                             len(lbry_files))
-                result = False
+                response = yield self._render_response(False)
+                defer.returnValue(response)
             else:
                 log.warning("Deleting %i files",
                             len(lbry_files))
@@ -1584,6 +1586,7 @@ class Daemon(AuthJSONRPCServer):
                                                               delete_file=delete_target_file)
                 log.info("Deleted %s (%s)", file_name, utils.short_hash(stream_hash))
             result = True
+
         response = yield self._render_response(result)
         defer.returnValue(response)
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1535,28 +1535,30 @@ class Daemon(AuthJSONRPCServer):
 
     @AuthJSONRPCServer.auth_required
     @defer.inlineCallbacks
-    @AuthJSONRPCServer.flags(delete_target_file='-f', delete_all='-a')
-    def jsonrpc_file_delete(self, delete_target_file=False, delete_all=False, **kwargs):
+    @AuthJSONRPCServer.flags(delete_from_download_dir='-f', delete_all='--delete_all')
+    def jsonrpc_file_delete(self, delete_from_download_dir=False, delete_all=False, **kwargs):
         """
         Delete a LBRY file
 
         Usage:
-            file_delete [-a] [-f] [--sd_hash=<sd_hash>] [--file_name=<file_name>]
+            file_delete [-f] [--delete_all] [--sd_hash=<sd_hash>] [--file_name=<file_name>]
                         [--stream_hash=<stream_hash>] [--claim_id=<claim_id>]
                         [--outpoint=<outpoint>] [--rowid=<rowid>]
                         [--name=<name>]
 
         Options:
-            -a, --delete_all            : if there are multiple matching files, allow the deletion
-                                            of multiple files. Otherwise do not delete anything.
-            -f, --delete_target_file    : delete file from download directory, instead of just blobs
-            --sd_hash=<sd_hash>         : delete by file sd hash
-            --file_name<file_name>      : delete by file name in downloads folder
-            --stream_hash=<stream_hash> : delete by file stream hash
-            --claim_id=<claim_id>       : delete by file claim id
-            --outpoint=<outpoint>       : delete by file claim outpoint
-            --rowid=<rowid>             : delete by file row id
-            --name=<name>               : delete by associated name claim of file
+            -f, --delete_from_download_dir  : delete file from download directory,
+                                                instead of just deleting blobs
+            --delete_all                    : if there are multiple matching files,
+                                                allow the deletion of multiple files.
+                                                Otherwise do not delete anything.
+            --sd_hash=<sd_hash>             : delete by file sd hash
+            --file_name<file_name>          : delete by file name in downloads folder
+            --stream_hash=<stream_hash>     : delete by file stream hash
+            --claim_id=<claim_id>           : delete by file claim id
+            --outpoint=<outpoint>           : delete by file claim outpoint
+            --rowid=<rowid>                 : delete by file row id
+            --name=<name>                   : delete by associated name claim of file
 
         Returns:
             (bool) true if deletion was successful
@@ -1583,7 +1585,7 @@ class Daemon(AuthJSONRPCServer):
                 if lbry_file.claim_id in self.streams:
                     del self.streams[lbry_file.claim_id]
                 yield self.lbry_file_manager.delete_lbry_file(lbry_file,
-                                                              delete_file=delete_target_file)
+                                                              delete_file=delete_from_download_dir)
                 log.info("Deleted %s (%s)", file_name, utils.short_hash(stream_hash))
             result = True
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1536,20 +1536,20 @@ class Daemon(AuthJSONRPCServer):
     @AuthJSONRPCServer.auth_required
     @defer.inlineCallbacks
     @AuthJSONRPCServer.flags(delete_target_file='-f', delete_all='-a')
-    def jsonrpc_file_delete(self, delete_target_file=True, delete_all=False, **kwargs):
+    def jsonrpc_file_delete(self, delete_target_file=False, delete_all=False, **kwargs):
         """
         Delete a LBRY file
 
         Usage:
-            file_delete [-a | -f] [--sd_hash=<sd_hash>] [--file_name=<file_name>]
+            file_delete [-a] [-f] [--sd_hash=<sd_hash>] [--file_name=<file_name>]
                         [--stream_hash=<stream_hash>] [--claim_id=<claim_id>]
                         [--outpoint=<outpoint>] [--rowid=<rowid>]
                         [--name=<name>]
 
         Options:
-            -a                          : if there are multiple matching files, allow the deletion
+            -a, --delete_all            : if there are multiple matching files, allow the deletion
                                             of multiple files. Otherwise do not delete anything.
-            -f                          : delete only from downloads, do not delete blobs
+            -f, --delete_target_file    : delete file from download directory, instead of just blobs
             --sd_hash=<sd_hash>         : delete by file sd hash
             --file_name<file_name>      : delete by file name in downloads folder
             --stream_hash=<stream_hash> : delete by file stream hash

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -77,21 +77,36 @@ class TestIntegration(unittest.TestCase):
 
         out,err = lbrynet_cli(['cli_test_command','1'])
         out = json.loads(out)
-        self.assertEqual([1,[],None,None], out)
+        self.assertEqual([1,[],None,None,False,False], out)
 
         out,err = lbrynet_cli(['cli_test_command','1','--pos_arg2=1'])
         out = json.loads(out)
-        self.assertEqual([1,[],1,None], out)
+        self.assertEqual([1,[],1,None,False,False], out)
 
 
         out,err = lbrynet_cli(['cli_test_command','1', '--pos_arg2=2','--pos_arg3=3'])
         out = json.loads(out)
-        self.assertEqual([1,[],2,3], out)
+        self.assertEqual([1,[],2,3,False,False], out)
 
         out,err = lbrynet_cli(['cli_test_command','1','2','3'])
         out = json.loads(out)
         # TODO: variable length arguments don't have guess_type() on them
-        self.assertEqual([1,['2','3'],None,None], out)
+        self.assertEqual([1,['2','3'],None,None,False,False], out)
+
+
+        out,err = lbrynet_cli(['cli_test_command','1','-a'])
+        out = json.loads(out)
+        self.assertEqual([1,[],None,None,True,False], out)
+
+        out,err = lbrynet_cli(['cli_test_command','1','--a_arg'])
+        out = json.loads(out)
+        self.assertEqual([1,[],None,None,True,False], out)
+
+
+        out,err = lbrynet_cli(['cli_test_command','1','-a','-b'])
+        out = json.loads(out)
+        self.assertEqual([1,[],None,None,True,True], out)
+
 
 
     def test_status(self):


### PR DESCRIPTION
Fixed various issues in API command file_delete

file_delete should have been preventing deletion of multiple files by default but it was not doing so. Fix this, and make sure that if delete_all flag is True, it allows deletion of multiple files.

delete_target_file was not accurately describing what it was doing, it was described as "delete only from downloads, do not delete blobs". However, the flag will cause the file to be delete from downloads, and blobs are always deleted. delete_target_file should be by default False, since presumably the user will most likely just want to delete the blobs so he can stop seeding them but will want to keep the actual file. 

Added longer flag options, --delete_all  and --delete_target_file (can be used instead of -a and -f) 

Added tests to make sure that the flags are being processed properly in the CLI. 