### PR TITLE
Fix GetStream class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ at anytime.
 
 ### Fixed
   * Race condition from improper initialization and shutdown of the blob manager database
-  *
+  * Various fixes for GetStream class used in API command get
 
 ### Deprecated
   *

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -660,17 +660,15 @@ class Daemon(AuthJSONRPCServer):
             self.analytics_manager.send_download_started(download_id, name, claim_dict)
 
             self.streams[claim_id] = GetStream(self.sd_identifier, self.session,
-                                               self.session.wallet, self.lbry_file_manager,
                                                self.exchange_rate_manager, self.max_key_fee,
                                                conf.settings['data_rate'], timeout,
                                                download_directory, file_name)
             try:
-                download = self.streams[claim_id].start(claim_dict, name)
-                lbry_file = yield download
-                f_d = self.streams[claim_id].finished_deferred
-                f_d.addCallback(lambda _: self.analytics_manager.send_download_finished(download_id,
-                                                                                        name,
-                                                                                        claim_dict))
+                lbry_file, finished_deferred = yield self.streams[claim_id].start(claim_dict, name)
+                finished_deferred.addCallback(
+                    lambda _: self.analytics_manager.send_download_finished(download_id,
+                                                                            name,
+                                                                            claim_dict))
                 result = yield self._get_lbry_file_dict(lbry_file, full_status=True)
                 del self.streams[claim_id]
             except Exception as err:

--- a/tests/unit/lbrynet_daemon/test_Downloader.py
+++ b/tests/unit/lbrynet_daemon/test_Downloader.py
@@ -1,0 +1,60 @@
+import types
+import mock
+import json
+from twisted.trial import unittest
+from twisted.internet import defer
+
+from lbryschema.claim import ClaimDict
+
+from lbrynet.core import Session, PaymentRateManager, Wallet
+from lbrynet.lbrynet_daemon import Downloader
+from lbrynet.core.StreamDescriptor import StreamDescriptorIdentifier,StreamMetadata
+from lbrynet.lbryfile.client.EncryptedFileOptions import add_lbry_file_to_sd_identifier
+from lbrynet.core.HashBlob import TempBlob
+from lbrynet.core.BlobManager import TempBlobManager
+from lbrynet.lbryfilemanager.EncryptedFileDownloader import ManagedEncryptedFileDownloaderFactory
+from lbrynet.lbrynet_daemon.ExchangeRateManager import ExchangeRateManager
+
+from tests.mocks import BlobAvailabilityTracker as DummyBlobAvailabilityTracker
+from tests.mocks import ExchangeRateManager as DummyExchangeRateManager
+from tests.mocks import BTCLBCFeed, USDBTCFeed
+
+
+class GetStreamTests(unittest.TestCase):
+
+    def init_getstream_with_mocs(self):
+        sd_identifier = mock.Mock(spec=StreamDescriptorIdentifier)
+        session = mock.Mock(spec=Session.Session)
+        session.wallet = mock.Mock(spec=Wallet.LBRYumWallet)
+        prm = mock.Mock(spec=PaymentRateManager.NegotiatedPaymentRateManager)
+        session.payment_rate_manager = prm
+        market_feeds = []
+        rates={}
+        exchange_rate_manager = DummyExchangeRateManager(market_feeds, rates)
+        exchange_rate_manager = mock.Mock(spec=ExchangeRateManager)
+        max_key_fee = {'currency':"LBC", 'amount':10, 'address':''}
+        data_rate = {'currency':"LBC", 'amount':0, 'address':''}
+        download_directory = '.'
+
+
+        getstream = Downloader.GetStream(sd_identifier, session,
+            exchange_rate_manager, max_key_fee, timeout=10, data_rate=data_rate,
+            download_directory=download_directory)
+
+        return getstream
+
+    @defer.inlineCallbacks
+    def test_init_exception(self):
+        """
+        test that if initialization would fail, by giving it invaild
+        stream_info, that an exception is thrown
+        """
+
+        getstream = self.init_getstream_with_mocs()
+        name = 'test'
+        stream_info = None
+
+        with self.assertRaises(AttributeError):
+            yield getstream.start(stream_info,name)
+
+


### PR DESCRIPTION
18fec8e
deferToThread was used for check_fee_and_convert() but is unnecessary, I think before this call made network calls to check the exchange rate but is now no longer the case. 
 
a004e92
finished_deferred was being initialized as a Deferred that was never used, and was over written with a different Deferred at the end of download() function. If a user used finished_deferred before download() function was called, this would be erronenous. Initialize finish_deferred to None , so that a user cannot accidentally use this deferred before it is ready. 

This is the reason why the download success metric in metabase is always 0. 

f7bbf81
Exceptions throw in download() function would be swallowed since we yield to data_downloading_deferred in the start() function and do not yield on download(). Thus you'd end up catching the timeout exception that gets error backed by data_downloading_deferred and the Exception thrown in download() would be swallowed.  Fixes https://github.com/lbryio/lbry/issues/673

b98363a
Just removing unnecessary initialization arguments from GetStream 

b00a8ae
remove _running variable in GetStream. I don't see the point of this variable, I guess its to prevent multiple calls of download()? The daemon will never do that so its not needed. 

1f2c9b9
It is possible for download to be manually stopped before a single blob is downloaded. Account for this case and callback data_downloading_deferred

db37791
break up download function to make it testeable. initialize() function will get sd_hash and key_fee , _create_downloader() function creates downloader instance from sd_blob. 

ceec3a3
add simple unit test 

ee3036b
have start() function return downloader and finished_deferred so that user of GetStream knows where to get the finished_deferred from. 

1ee1c77
I think we do not want to errback finished_deferred, a Deferred that GetSream is not responsible for managing. Rather we should call downloader.stop() to stop the download. 
