### PR TITLE
fix cli version and --version arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ at anytime.
 ### Changed
   * Do not catch base exception in API command resolve
   * Remove deprecated `lbrynet.metadata` and update what used it to instead use `lbryschema`
-  *
+  * Get version information locally instead of via api for cli
 
 ### Fixed
   * Download analytics error

--- a/lbrynet/lbrynet_daemon/DaemonCLI.py
+++ b/lbrynet/lbrynet_daemon/DaemonCLI.py
@@ -8,6 +8,7 @@ from lbrynet import conf
 from lbrynet.core import utils
 from lbrynet.lbrynet_daemon.auth.client import JSONRPCException, LBRYAPIClient
 from lbrynet.lbrynet_daemon.Daemon import LOADING_WALLET_CODE, Daemon
+from lbrynet.core.system_info import get_platform
 from jsonrpc.common import RPCError
 from urllib2 import URLError, HTTPError
 from httplib import UNAUTHORIZED
@@ -48,6 +49,10 @@ def main():
             print_help_for_command(args[0])
         else:
             print_help()
+        return
+
+    elif method in ['version', '--version']:
+        print utils.json_dumps_pretty(get_platform(get_ip=False))
         return
 
     if method not in Daemon.callable_methods:


### PR DESCRIPTION
This changes lbrynet-cli to show the results of the function lbrynet-daemon uses to reply to `version` requests instead of making the api call. This lets `lbrynet-cli --version` work when lbrynet-daemon isn’t necessarily running.