### PR TITLE
DaemonControl is using deprecated is_running API command

### DIFF
--- a/lbrynet/lbrynet_daemon/DaemonControl.py
+++ b/lbrynet/lbrynet_daemon/DaemonControl.py
@@ -83,7 +83,7 @@ def start():
 
     try:
         log.debug('Checking for an existing lbrynet daemon instance')
-        JSONRPCProxy.from_url(conf.settings.get_api_connection_string()).is_running()
+        JSONRPCProxy.from_url(conf.settings.get_api_connection_string()).status()
         log.info("lbrynet-daemon is already running")
         return
     except Exception:


### PR DESCRIPTION
DaemonControl is using deprecated is_running API command to check if there is already a daemon running. Use status API command instead.