### PR TITLE
fix typo which may not shut down blob_tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ at anytime.
 
 ### Fixed
   * Fixed some log messages throwing exceptions
-  *
+  * Fix shutdown of the blob tracker by Session
 
 ### Deprecated
   *

--- a/lbrynet/core/Session.py
+++ b/lbrynet/core/Session.py
@@ -171,7 +171,7 @@ class Session(object):
         """Stop all services"""
         log.info('Shutting down %s', self)
         ds = []
-        if self.blob_manager is not None:
+        if self.blob_tracker is not None:
             ds.append(defer.maybeDeferred(self.blob_tracker.stop))
         if self.dht_node is not None:
             ds.append(defer.maybeDeferred(self.dht_node.stop))


### PR DESCRIPTION
Session shutdown() was not closing blob_tracker properly