### PR TITLE
Fix log exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ at anytime.
   * Various fixes for GetStream class used in API command get
   * Download analytics error
   * Fixed flag options in file_delete API command
-  *
+  * Fixed some log messages throwing exceptions
 
 ### Deprecated
   *

--- a/lbrynet/lbryfilemanager/EncryptedFileDownloader.py
+++ b/lbrynet/lbryfilemanager/EncryptedFileDownloader.py
@@ -83,7 +83,7 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
 
     @defer.inlineCallbacks
     def stop(self, err=None, change_status=True):
-        log.debug('Stopping download for %s', short_hash(self.sd_hash))
+        log.debug('Stopping download for stream %s', short_hash(self.stream_hash))
         # EncryptedFileSaver deletes metadata when it's stopped. We don't want that here.
         yield EncryptedFileDownloader.stop(self, err=err)
         if change_status is True:

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -1626,7 +1626,7 @@ class Daemon(AuthJSONRPCServer):
                     del self.streams[lbry_file.claim_id]
                 yield self.lbry_file_manager.delete_lbry_file(lbry_file,
                                                               delete_file=delete_from_download_dir)
-                log.info("Deleted %s (%s)", file_name, utils.short_hash(stream_hash))
+                log.info("Deleted file: %s", file_name)
             result = True
 
         response = yield self._render_response(result)


### PR DESCRIPTION
0b50518
EncryptedFileDownloader could be stopped before self.sd_hash is filled in by load_file_attributes() function. In this case , utils.short_hash() function will throw an exception since self.sd_hash is None . Use stream_hash instead.

114f6ef
This is a complete mystery to me but if a file_name is unicode, ( was checking lbry://casually-successful )
log.info("Deleted %s (%s)", file_name, utils.short_hash(stream_hash))
will throw UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 49: ordinal not in range(128)

But log.info("Deleted file: %s", file_name) will not. There's nothing wrong or unusual about utils.short_hash(stream_hash)... 