### PR TITLE
Remove download_directory from get API command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ at anytime.
 
 ### Removed
   * Remove `claims_in_channel` from `resolve` response
-  *
+  * Removed download_directory argument from API command get
 
 ## [0.11.0] - 2017-06-09
 

--- a/lbrynet/lbrynet_daemon/Daemon.py
+++ b/lbrynet/lbrynet_daemon/Daemon.py
@@ -644,8 +644,7 @@ class Daemon(AuthJSONRPCServer):
         return finished_d
 
     @defer.inlineCallbacks
-    def _download_name(self, name, claim_dict, claim_id, timeout=None, download_directory=None,
-                       file_name=None):
+    def _download_name(self, name, claim_dict, claim_id, timeout=None, file_name=None):
         """
         Add a lbry file to the file manager, start the download, and return the new lbry file.
         If it already exists in the file manager, return the existing lbry file
@@ -662,7 +661,7 @@ class Daemon(AuthJSONRPCServer):
             self.streams[claim_id] = GetStream(self.sd_identifier, self.session,
                                                self.exchange_rate_manager, self.max_key_fee,
                                                conf.settings['data_rate'], timeout,
-                                               download_directory, file_name)
+                                               file_name)
             try:
                 lbry_file, finished_deferred = yield self.streams[claim_id].start(claim_dict, name)
                 finished_deferred.addCallback(
@@ -1450,13 +1449,13 @@ class Daemon(AuthJSONRPCServer):
 
     @AuthJSONRPCServer.auth_required
     @defer.inlineCallbacks
-    def jsonrpc_get(self, uri, file_name=None, timeout=None, download_directory=None):
+    def jsonrpc_get(self, uri, file_name=None, timeout=None):
         """
         Download stream from a LBRY name.
 
         Usage:
             get <uri> [<file_name> | --file_name=<file_name>] [<timeout> | --timeout=<timeout>]
-                      [<download_directory> | --download_directory=<download_directory>]
+
 
         Options:
             <file_name>           : specified name for the downloaded file
@@ -1489,7 +1488,6 @@ class Daemon(AuthJSONRPCServer):
         """
 
         timeout = timeout if timeout is not None else self.download_timeout
-        download_directory = download_directory or self.download_directory
 
         resolved_result = yield self.session.wallet.resolve(uri)
         if resolved_result and uri in resolved_result:
@@ -1523,7 +1521,6 @@ class Daemon(AuthJSONRPCServer):
             result = yield self._get_lbry_file_dict(lbry_file, full_status=True)
         else:
             result = yield self._download_name(name, claim_dict, claim_id, timeout=timeout,
-                                               download_directory=download_directory,
                                                file_name=file_name)
         response = yield self._render_response(result)
         defer.returnValue(response)

--- a/lbrynet/lbrynet_daemon/Downloader.py
+++ b/lbrynet/lbrynet_daemon/Downloader.py
@@ -40,13 +40,13 @@ def safe_stop(looping_call):
 
 class GetStream(object):
     def __init__(self, sd_identifier, session, exchange_rate_manager,
-                 max_key_fee, data_rate=None, timeout=None, download_directory=None,
+                 max_key_fee, data_rate=None, timeout=None,
                  file_name=None):
 
         self.timeout = timeout or conf.settings['download_timeout']
         self.data_rate = data_rate or conf.settings['data_rate']
         self.max_key_fee = max_key_fee or conf.settings['max_key_fee'][1]
-        self.download_directory = download_directory or conf.settings['download_directory']
+        self.download_directory = conf.settings['download_directory']
         self.file_name = file_name
         self.timeout_counter = 0
         self.code = None

--- a/tests/unit/lbrynet_daemon/test_Downloader.py
+++ b/tests/unit/lbrynet_daemon/test_Downloader.py
@@ -18,11 +18,12 @@ from lbrynet.lbrynet_daemon.ExchangeRateManager import ExchangeRateManager
 from tests.mocks import BlobAvailabilityTracker as DummyBlobAvailabilityTracker
 from tests.mocks import ExchangeRateManager as DummyExchangeRateManager
 from tests.mocks import BTCLBCFeed, USDBTCFeed
-
+from tests.mocks import mock_conf_settings
 
 class GetStreamTests(unittest.TestCase):
 
     def init_getstream_with_mocs(self):
+        mock_conf_settings(self)
         sd_identifier = mock.Mock(spec=StreamDescriptorIdentifier)
         session = mock.Mock(spec=Session.Session)
         session.wallet = mock.Mock(spec=Wallet.LBRYumWallet)
@@ -34,12 +35,9 @@ class GetStreamTests(unittest.TestCase):
         exchange_rate_manager = mock.Mock(spec=ExchangeRateManager)
         max_key_fee = {'currency':"LBC", 'amount':10, 'address':''}
         data_rate = {'currency':"LBC", 'amount':0, 'address':''}
-        download_directory = '.'
-
 
         getstream = Downloader.GetStream(sd_identifier, session,
-            exchange_rate_manager, max_key_fee, timeout=10, data_rate=data_rate,
-            download_directory=download_directory)
+            exchange_rate_manager, max_key_fee, timeout=10, data_rate=data_rate)
 
         return getstream
 


### PR DESCRIPTION
Removes the download_directory argument from API command get 

Users should change the download_directory with settings_set 

https://github.com/lbryio/lbry/issues/645