### PR TITLE
Add timeout to download_sd_blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Fixed timeout behaviour when calling API command get
   *
 
 ### Deprecated

--- a/lbrynet/core/Error.py
+++ b/lbrynet/core/Error.py
@@ -9,6 +9,10 @@ class DuplicateStreamHashError(Exception):
 class DownloadCanceledError(Exception):
     pass
 
+class DownloadTimeoutError(Exception):
+    def __init__(self, download):
+        Exception.__init__(self, 'Failed to download {} within timeout'.format(download))
+        self.download = download
 
 class RequestCanceledError(Exception):
     pass

--- a/lbrynet/core/StreamDescriptor.py
+++ b/lbrynet/core/StreamDescriptor.py
@@ -236,7 +236,7 @@ class StreamDescriptorIdentifier(object):
         return d
 
 
-def download_sd_blob(session, blob_hash, payment_rate_manager):
+def download_sd_blob(session, blob_hash, payment_rate_manager, timeout=None):
     """
     Downloads a single blob from the network
 
@@ -253,5 +253,6 @@ def download_sd_blob(session, blob_hash, payment_rate_manager):
                                           session.peer_finder,
                                           session.rate_limiter,
                                           payment_rate_manager,
-                                          session.wallet)
+                                          session.wallet,
+                                          timeout)
     return downloader.download()

--- a/lbrynet/core/client/StandaloneBlobDownloader.py
+++ b/lbrynet/core/client/StandaloneBlobDownloader.py
@@ -56,7 +56,7 @@ class SingleProgressManager(object):
             safe_stop_looping_call(self.checker)
             self.finished_callback(blob_downloaded)
         elif self.timeout is not None:
-            self.timeout_counter +=1
+            self.timeout_counter += 1
             if self.timeout_counter >= self.timeout:
                 safe_stop_looping_call(self.checker)
                 self.timeout_callback()
@@ -84,7 +84,7 @@ class DummyBlobHandler(object):
 class StandaloneBlobDownloader(object):
     def __init__(self, blob_hash, blob_manager, peer_finder,
                  rate_limiter, payment_rate_manager, wallet,
-                 timeout = None):
+                 timeout=None):
         self.blob_hash = blob_hash
         self.blob_manager = blob_manager
         self.peer_finder = peer_finder

--- a/lbrynet/core/client/StandaloneBlobDownloader.py
+++ b/lbrynet/core/client/StandaloneBlobDownloader.py
@@ -5,11 +5,11 @@ from lbrynet.core.BlobInfo import BlobInfo
 from lbrynet.core.client.BlobRequester import BlobRequester
 from lbrynet.core.client.ConnectionManager import ConnectionManager
 from lbrynet.core.client.DownloadManager import DownloadManager
-from lbrynet.core.Error import InvalidBlobHashError
+from lbrynet.core.Error import InvalidBlobHashError, DownloadTimeoutError
 from lbrynet.core.utils import is_valid_blobhash, safe_start_looping_call, safe_stop_looping_call
 from twisted.python.failure import Failure
 from twisted.internet import defer
-from twisted.internet import LoopingCall
+from twisted.internet.task import LoopingCall
 
 log = logging.getLogger(__name__)
 
@@ -32,14 +32,17 @@ class SingleBlobMetadataHandler(object):
 
 
 class SingleProgressManager(object):
-    def __init__(self, finished_callback, download_manager):
+    def __init__(self, download_manager, finished_callback, timeout_callback, timeout):
         self.finished_callback = finished_callback
+        self.timeout_callback = timeout_callback
         self.download_manager = download_manager
 
-        self.checker = LoopingCall(self._check_if_finished) 
+        self.timeout = timeout
+        self.timeout_counter = 0
+        self.checker = LoopingCall(self._check_if_finished)
 
     def start(self):
-        safe_start_looping_call(self.checker,1) 
+        safe_start_looping_call(self.checker, 1)
         return defer.succeed(True)
 
     def stop(self):
@@ -52,6 +55,11 @@ class SingleProgressManager(object):
             log.debug("The blob %s has been downloaded. Calling the finished callback", str(blob_downloaded))
             safe_stop_looping_call(self.checker)
             self.finished_callback(blob_downloaded)
+        elif self.timeout is not None:
+            self.timeout_counter +=1
+            if self.timeout_counter >= self.timeout:
+                safe_stop_looping_call(self.checker)
+                self.timeout_callback()
 
     def stream_position(self):
         blobs = self.download_manager.blobs
@@ -75,13 +83,15 @@ class DummyBlobHandler(object):
 
 class StandaloneBlobDownloader(object):
     def __init__(self, blob_hash, blob_manager, peer_finder,
-                 rate_limiter, payment_rate_manager, wallet):
+                 rate_limiter, payment_rate_manager, wallet,
+                 timeout = None):
         self.blob_hash = blob_hash
         self.blob_manager = blob_manager
         self.peer_finder = peer_finder
         self.rate_limiter = rate_limiter
         self.payment_rate_manager = payment_rate_manager
         self.wallet = wallet
+        self.timeout = timeout
         self.download_manager = None
         self.finished_deferred = None
 
@@ -99,8 +109,10 @@ class StandaloneBlobDownloader(object):
                                                              self.download_manager)
         self.download_manager.blob_info_finder = SingleBlobMetadataHandler(self.blob_hash,
                                                                            self.download_manager)
-        self.download_manager.progress_manager = SingleProgressManager(self._blob_downloaded,
-                                                                       self.download_manager)
+        self.download_manager.progress_manager = SingleProgressManager(self.download_manager,
+                                                                       self._blob_downloaded,
+                                                                       self._download_timedout,
+                                                                       self.timeout)
         self.download_manager.blob_handler = DummyBlobHandler()
         self.download_manager.wallet_info_exchanger = self.wallet.get_info_exchanger()
         self.download_manager.connection_manager = ConnectionManager(
@@ -119,6 +131,11 @@ class StandaloneBlobDownloader(object):
         self.stop()
         if not self.finished_deferred.called:
             self.finished_deferred.callback(blob)
+
+    def _download_timedout(self):
+        self.stop()
+        if not self.finished_deferred.called:
+            self.finished_deferred.errback(DownloadTimeoutError(self.blob_hash))
 
     def insufficient_funds(self, err):
         self.stop()

--- a/lbrynet/core/client/StandaloneBlobDownloader.py
+++ b/lbrynet/core/client/StandaloneBlobDownloader.py
@@ -52,7 +52,8 @@ class SingleProgressManager(object):
     def _check_if_finished(self):
         if self.stream_position() == 1:
             blob_downloaded = self.download_manager.blobs[0]
-            log.debug("The blob %s has been downloaded. Calling the finished callback", str(blob_downloaded))
+            log.debug("The blob %s has been downloaded. Calling the finished callback",
+                        str(blob_downloaded))
             safe_stop_looping_call(self.checker)
             self.finished_callback(blob_downloaded)
         elif self.timeout is not None:

--- a/lbrynet/core/utils.py
+++ b/lbrynet/core/utils.py
@@ -49,6 +49,13 @@ def call_later(delay, func, *args, **kwargs):
     from twisted.internet import reactor
     return reactor.callLater(delay, func, *args, **kwargs)
 
+def safe_start_looping_call(looping_call, interval_sec):
+    if not looping_call.running:
+        looping_call.start(interval_sec)
+
+def safe_stop_looping_call(looping_call):
+    if looping_call.running:
+        looping_call.stop()
 
 def generate_id(num=None):
     h = get_lbry_hash_obj()

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -599,26 +599,12 @@ class Daemon(AuthJSONRPCServer):
         :param timeout (int): blob timeout
         :return: BlobFile
         """
-
-        def cb(blob):
-            if not finished_d.called:
-                finished_d.callback(blob)
-
-        def eb():
-            if not finished_d.called:
-                finished_d.errback(Exception("Blob (%s) download timed out" %
-                                             blob_hash[:SHORT_ID_LEN]))
-
         if not blob_hash:
             raise Exception("Nothing to download")
 
         rate_manager = rate_manager or self.session.payment_rate_manager
         timeout = timeout or 30
-        finished_d = defer.Deferred(None)
-        reactor.callLater(timeout, eb)
-        d = download_sd_blob(self.session, blob_hash, rate_manager)
-        d.addCallback(cb)
-        return finished_d
+        return download_sd_blob(self.session, blob_hash, rate_manager, timeout)
 
     @defer.inlineCallbacks
     def _download_name(self, name, claim_dict, claim_id, timeout=None, file_name=None):

--- a/lbrynet/daemon/Downloader.py
+++ b/lbrynet/daemon/Downloader.py
@@ -5,7 +5,7 @@ from twisted.internet.task import LoopingCall
 
 from lbryschema.fee import Fee
 
-from lbrynet.core.Error import InsufficientFundsError, KeyFeeAboveMaxAllowed
+from lbrynet.core.Error import InsufficientFundsError, KeyFeeAboveMaxAllowed, DownloadTimeoutError
 from lbrynet.core.StreamDescriptor import download_sd_blob
 from lbrynet.file_manager.EncryptedFileDownloader import ManagedEncryptedFileDownloaderFactory
 from lbrynet.file_manager.EncryptedFileDownloader import ManagedEncryptedFileDownloader
@@ -88,7 +88,7 @@ class GetStream(object):
         self.timeout_counter += 1
         if self.timeout_counter >= self.timeout:
             if not self.data_downloading_deferred.called:
-                self.data_downloading_deferred.errback(Exception("Timeout"))
+                self.data_downloading_deferred.errback(DownloadTimeoutError(self.file_name))
             safe_stop(self.checker)
         else:
             d = self.downloader.status()

--- a/lbrynet/daemon/Downloader.py
+++ b/lbrynet/daemon/Downloader.py
@@ -63,7 +63,6 @@ class GetStream(object):
     def _check_status(self, status):
         stop_condition = (status.num_completed > 0 or
                 status.running_status == ManagedEncryptedFileDownloader.STATUS_STOPPED)
-
         if stop_condition and not self.data_downloading_deferred.called:
             self.data_downloading_deferred.callback(True)
         if self.data_downloading_deferred.called:
@@ -75,7 +74,6 @@ class GetStream(object):
         """
         Check if we've got the first data blob in the stream yet
         """
-
         self.timeout_counter += 1
         if self.timeout_counter >= self.timeout:
             if not self.data_downloading_deferred.called:

--- a/tests/unit/lbrynet_daemon/test_Downloader.py
+++ b/tests/unit/lbrynet_daemon/test_Downloader.py
@@ -2,17 +2,18 @@ import types
 import mock
 import json
 from twisted.trial import unittest
-from twisted.internet import defer
+from twisted.internet import defer, task
 
 from lbryschema.claim import ClaimDict
 
 from lbrynet.core import Session, PaymentRateManager, Wallet
+from lbrynet.core.Error import DownloadTimeoutError
 from lbrynet.daemon import Downloader
 from lbrynet.core.StreamDescriptor import StreamDescriptorIdentifier,StreamMetadata
 from lbrynet.lbry_file.client.EncryptedFileOptions import add_lbry_file_to_sd_identifier
-from lbrynet.core.HashBlob import TempBlob
-from lbrynet.core.BlobManager import TempBlobManager
-from lbrynet.file_manager.EncryptedFileDownloader import ManagedEncryptedFileDownloaderFactory
+
+from lbrynet.file_manager.EncryptedFileStatusReport import EncryptedFileStatusReport
+from lbrynet.file_manager.EncryptedFileDownloader import ManagedEncryptedFileDownloader, ManagedEncryptedFileDownloaderFactory
 from lbrynet.daemon.ExchangeRateManager import ExchangeRateManager
 
 from tests.mocks import BlobAvailabilityTracker as DummyBlobAvailabilityTracker
@@ -20,10 +21,48 @@ from tests.mocks import ExchangeRateManager as DummyExchangeRateManager
 from tests.mocks import BTCLBCFeed, USDBTCFeed
 from tests.mocks import mock_conf_settings
 
+class MocDownloader(object):
+    def __init__(self):
+        self.finish_deferred = defer.Deferred(None)
+        self.stop_called = False
+
+        self.name = 'test'
+        self.num_completed = 0
+        self.num_known = 1
+        self.running_status = ManagedEncryptedFileDownloader.STATUS_RUNNING
+
+    @defer.inlineCallbacks
+    def status(self):
+        out = yield EncryptedFileStatusReport(self.name, self.num_completed, self.num_known, self.running_status)
+        defer.returnValue(out)
+
+    def start(self):
+        return self.finish_deferred
+
+    def stop(self):
+        self.stop_called = True
+        self.finish_deferred.callback(True)
+
+def moc_initialize(self,stream_info):
+    self.sd_hash ="d5169241150022f996fa7cd6a9a1c421937276a3275eb912790bd07ba7aec1fac5fd45431d226b8fb402691e79aeb24b"
+    return None
+
+def moc_download_sd_blob(self):
+    return None
+
+def moc_download(self, sd_blob, name, key_fee):
+    self.pay_key_fee(key_fee, name)
+    self.downloader = MocDownloader()
+    self.downloader.start()
+
+def moc_pay_key_fee(self, key_fee, name):
+    self.pay_key_fee_called = True
+
 class GetStreamTests(unittest.TestCase):
 
     def init_getstream_with_mocs(self):
         mock_conf_settings(self)
+
         sd_identifier = mock.Mock(spec=StreamDescriptorIdentifier)
         session = mock.Mock(spec=Session.Session)
         session.wallet = mock.Mock(spec=Wallet.LBRYumWallet)
@@ -37,8 +76,11 @@ class GetStreamTests(unittest.TestCase):
         data_rate = {'currency':"LBC", 'amount':0, 'address':''}
 
         getstream = Downloader.GetStream(sd_identifier, session,
-            exchange_rate_manager, max_key_fee, timeout=10, data_rate=data_rate)
+            exchange_rate_manager, max_key_fee, timeout=3, data_rate=data_rate)
+        getstream.pay_key_fee_called = False
 
+        self.clock = task.Clock()
+        getstream.checker.clock = self.clock
         return getstream
 
     @defer.inlineCallbacks
@@ -55,4 +97,87 @@ class GetStreamTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             yield getstream.start(stream_info,name)
 
+
+    @defer.inlineCallbacks
+    def test_sd_blob_download_timeout(self):
+        """
+        test that if download_sd_blob fails due to timeout,
+        DownloadTimeoutError is raised
+        """
+        def download_sd_blob(self):
+            raise DownloadTimeoutError(self.file_name)
+
+        getstream  = self.init_getstream_with_mocs()
+        getstream._initialize = types.MethodType(moc_initialize, getstream)
+        getstream._download_sd_blob = types.MethodType(download_sd_blob, getstream)
+        getstream._download = types.MethodType(moc_download, getstream)
+        getstream.pay_key_fee = types.MethodType(moc_pay_key_fee, getstream)
+        name='test'
+        stream_info = None
+        with self.assertRaises(DownloadTimeoutError):
+            yield getstream.start(stream_info,name)
+        self.assertFalse(getstream.pay_key_fee_called)
+
+
+    @defer.inlineCallbacks
+    def test_timeout(self):
+        """
+        test that timeout (set to 2 here) exception is raised
+        when download times out while downloading first blob, and key fee is paid
+        """
+        getstream  = self.init_getstream_with_mocs()
+        getstream._initialize = types.MethodType(moc_initialize, getstream)
+        getstream._download_sd_blob = types.MethodType(moc_download_sd_blob, getstream)
+        getstream._download = types.MethodType(moc_download, getstream)
+        getstream.pay_key_fee = types.MethodType(moc_pay_key_fee, getstream)
+        name='test'
+        stream_info = None
+        start = getstream.start(stream_info,name)
+        self.clock.advance(1)
+        self.clock.advance(1)
+        with self.assertRaises(DownloadTimeoutError):
+            yield start
+        self.assertTrue(getstream.downloader.stop_called)
+        self.assertTrue(getstream.pay_key_fee_called)
+
+    @defer.inlineCallbacks
+    def test_finish_one_blob(self):
+        """
+        test that if we have 1 completed blob, start() returns
+        and key fee is paid
+        """
+        getstream  = self.init_getstream_with_mocs()
+        getstream._initialize = types.MethodType(moc_initialize, getstream)
+
+        getstream._download_sd_blob = types.MethodType(moc_download_sd_blob, getstream)
+        getstream._download = types.MethodType(moc_download, getstream)
+        getstream.pay_key_fee = types.MethodType(moc_pay_key_fee, getstream)
+        name='test'
+        stream_info = None
+        start = getstream.start(stream_info,name)
+
+        getstream.downloader.num_completed = 1
+        self.clock.advance(1)
+
+        downloader, f_deferred = yield start
+        self.assertTrue(getstream.pay_key_fee_called)
+
+
+    @defer.inlineCallbacks
+    def test_finish_stopped_downloader(self):
+        """
+        test that if we have a stopped downloader, beforfe a blob is downloaded,
+        start() returns
+        """
+        getstream  = self.init_getstream_with_mocs()
+        getstream._initialize = types.MethodType(moc_initialize, getstream)
+        getstream._download_sd_blob = types.MethodType(moc_download_sd_blob, getstream)
+        getstream._download = types.MethodType(moc_download, getstream)
+        name='test'
+        stream_info = None
+        start = getstream.start(stream_info,name)
+
+        getstream.downloader.running_status = ManagedEncryptedFileDownloader.STATUS_STOPPED
+        self.clock.advance(1)
+        downloader, f_deferred = yield start
 


### PR DESCRIPTION
Fixes https://github.com/lbryio/lbry/issues/716 and https://github.com/lbryio/lbry/issues/504 by adding a timeout argument to function download_sd_blob(). The timeout detects if the blob has been downloaded within a specified time, and if not, it throws DownloadTimeoutError and cleans everything up. 

As a side effect, the timeout behaviour when calling API command get is a bit different now.
Now it will wait 180 seconds (or whatever the timeout is set to) for the sd blob to download, and if it does , waits another 180 seconds for the first blob to download. Before it waited 180 seconds for both the sd blob and first blob. 

f1845c1
In SingleProgressManager, which we will add the timeout mechanism, use twisted's LoopingCall mechanism instead of reactor.callLater to do looping calls as it is much simpler. safe_start_looping_call and safe_stop_looping_call is added to lbrynet.utils and should be used by other classes which need looping calls. 

ccb7991
Add timeout do download_sd_blob(). Make SingleProgressManager , which checks when a single blob is downloaded, also responsible for keeping track of the timeout. Create DownloadTimeoutError in lbrynet.Error to use as a standard exception for indicating timeouts. 

 a5f4396
Use the newly added timeout mechanism for download_sd_blob in GetStream class. Note that GetStream still has its own timeout mechanism for checking when a single blob (that is not the sd blob) is downloaded. Getstream's timeout mechanism is started after download_sd_blob() is finished. 

345a1f2
Just breaking up GetStream for unit testing 

 6995169
use DownloadTimeoutError instead of generic Exception 

 0452338
use safe_start_looping_call in lbrynet.utils 

7ee0489
added unit tests for GetStream

eba854a
Use timeout mechanism in download_sd_blob() instead of creating its own in Daemon._download_blob()

 f058f18
This is a fix for test_double_download in function/test_misc. It was revealed in test_double_download that when starting the DownloadManager, progress_manager.start() could stop the download (due to it already having the blobs), but then after it would call connection_manager.start() and leave the ConnectionManager running (the tests would then fail as Reactor is unclean).

So have ConnectionManager start up first , and then start the progress manager. Also simplify the resume_downloading() and stop_downloading() command by using inline callbacks instead of Deferred lists.

Note also here the complexity and exception swallowing in CryptStreamDownloader that uses resume_downloading() and stop_downloading(). This should be fixed in a future PR. 
 