### PR TITLE
Make sure window paths of directories are in string not unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ at anytime.
   * Fixed BlobManager causing functional tests to fail, removed its unneeded manage() loop
   * Increased max_key_fee
   * Fixed unit tests on appveyor Windows build
+  * Fixed [#692](https://github.com/lbryio/lbry/issues/692) 
 
 ### Deprecated
   *

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -43,6 +43,21 @@ settings_encoders = {
     '.yml': yaml.safe_dump
 }
 
+def _win_path_to_bytes(path):
+    """
+    Encode Windows paths to string. appdirs.user_data_dir()
+    on windows will return unicode path, unlike other platforms
+    which returns string. This will cause problems
+    because we use strings for filenames and combining them with
+    os.path.join() will result in errors.
+    """
+    for encoding in ('ASCII', 'MBCS'):
+        try:
+            return path.encode(encoding)
+        except (UnicodeEncodeError, LookupError):
+            pass
+    return path
+
 if sys.platform.startswith('darwin'):
     platform = DARWIN
     default_download_directory = os.path.join(os.path.expanduser('~'), 'Downloads')
@@ -57,6 +72,10 @@ elif sys.platform.startswith('win'):
         get_path(FOLDERID.RoamingAppData, UserHandle.current), 'lbrynet')
     default_lbryum_dir = os.path.join(
         get_path(FOLDERID.RoamingAppData, UserHandle.current), 'lbryum')
+
+    default_download_directory = _win_path_to_bytes(default_download_directory)
+    default_data_dir = _win_path_to_bytes(default_data_dir)
+    default_lbryum_dir = _win_path_to_bytes(default_lbryum_dir)
 else:
     platform = LINUX
     default_download_directory = os.path.join(os.path.expanduser('~'), 'Downloads')

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -1,7 +1,6 @@
 import os
 
 from twisted.trial import unittest
-
 from lbrynet import conf
 
 
@@ -54,3 +53,11 @@ class SettingsTest(unittest.TestCase):
         self.assertEqual('cli_test_string', settings['test'])
         settings.set('test', 'runtime_takes_precedence', data_types=(conf.TYPE_RUNTIME,))
         self.assertEqual('runtime_takes_precedence', settings['test'])
+
+    def test_data_dir(self):
+        # check if these directories are returned as string and not unicode
+        # otherwise there will be problems when calling os.path.join on
+        # unicode directory names with string file names
+        self.assertEqual(str, type(conf.default_download_directory))
+        self.assertEqual(str, type(conf.default_data_dir))
+        self.assertEqual(str, type(conf.default_lbryum_dir))


### PR DESCRIPTION
Likely fix for 

https://github.com/lbryio/lbry/issues/692 
https://github.com/lbryio/lbry/issues/661

data directories in windows were being returned as unicode type, which will result in problems when using os.path.join with filenames that are of string type. 

Added unit tests in test_conf.py to make sure the data directories are in string not unicode. 

relevant discussion where I got the solution from :
https://github.com/pypa/pip/issues/3463
the resulting pr where I got the solution from:
https://github.com/pypa/pip/pull/4000