### PR TITLE
Remove point reservation (payment queueing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ at anytime.
   *
 
 ### Removed
-  *
+  * Removed payment queueing and therefore ability for clients to make data payments
   *
 
 ## [0.14.1] - 2017-07-07

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -386,10 +386,7 @@ class Wallet(object):
             raise ValueError('storage must be an instance of MetaDataStorage')
         self._storage = storage
         self.next_manage_call = None
-        self.wallet_balance = Decimal(0.0)
-        self.total_reserved_points = Decimal(0.0)
         self.peer_addresses = {}  # {Peer: string}
-        self.queued_payments = defaultdict(Decimal)  # {address(string): amount(Decimal)}
         self.expected_balances = defaultdict(Decimal)  # {address(string): amount(Decimal)}
         self.current_address_given_to_peer = {}  # {Peer: address(string)}
         # (Peer, address(string), amount(Decimal), time(datetime), count(int),

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -601,6 +601,20 @@ class Wallet(object):
                   str(address))
         return defer.succeed(True)
 
+    def send_amount_to_address(self, amount, address):
+        """
+        Send a payment of amount to address
+
+        @param amount : amount to send in lbry credits
+
+        @param address: address to send to
+
+        @return: txid if successful , Exception will be thrown otherwise
+        """
+        rounded_amount = Decimal(str(round(amount, 8)))
+        d = self._do_send_many({address:rounded_amount})
+        return d
+
     def add_expected_payment(self, peer, amount):
         """Increase the number of points expected to be paid by a peer"""
         rounded_amount = Decimal(str(round(amount, 8)))
@@ -1379,6 +1393,11 @@ class LBRYumWallet(Wallet):
         defer.returnValue(txid)
 
     def _do_send_many(self, payments_to_send):
+        """
+        Send transactions from wallet
+
+        payment_to_send - dictionary where key is address, value is amount in lbry credits
+        """
         def broadcast_send_many(paytomany_out):
             if 'hex' not in paytomany_out:
                 raise Exception('Unexpected paytomany output:{}'.format(paytomany_out))

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -32,13 +32,6 @@ from lbrynet.core.Error import UnknownClaimID, UnknownURI
 
 log = logging.getLogger(__name__)
 
-
-class ReservedPoints(object):
-    def __init__(self, identifier, amount):
-        self.identifier = identifier
-        self.amount = amount
-
-
 class ClaimOutpoint(dict):
     def __init__(self, txid, nout):
         if len(txid) != 64:

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -514,15 +514,6 @@ class Wallet(object):
         d.addBoth(set_manage_not_running)
         return d
 
-    @defer.inlineCallbacks
-    def update_balance(self):
-        """ obtain balance from lbryum wallet and set self.wallet_balance
-        """
-        balance = yield self._update_balance()
-        if self.wallet_balance != balance:
-            log.debug("Got a new balance: %s", balance)
-        self.wallet_balance = balance
-
     def get_info_exchanger(self):
         return LBRYcrdAddressRequester(self)
 
@@ -928,7 +919,7 @@ class Wallet(object):
         return self._get_claim_metadata_for_sd_hash(sd_hash)
 
     def get_balance(self):
-        return self._update_balance()
+        return self._get_balance()
 
     def _check_expected_balances(self):
         now = datetime.datetime.now()
@@ -980,7 +971,7 @@ class Wallet(object):
 
     # ======== Must be overridden ======== #
 
-    def _update_balance(self):
+    def _get_balance(self):
         return defer.fail(NotImplementedError())
 
     def get_new_address(self):
@@ -1215,7 +1206,7 @@ class LBRYumWallet(Wallet):
         func = getattr(cmd_runner, cmd.name)
         return threads.deferToThread(func, *args, **kwargs)
 
-    def _update_balance(self):
+    def _get_balance(self):
         accounts = None
         exclude_claimtrietx = True
         d = self._run_cmd_as_defer_succeed('getbalance', accounts, exclude_claimtrietx)

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -1000,7 +1000,7 @@ class Wallet(object):
         return self._get_claim_metadata_for_sd_hash(sd_hash)
 
     def get_balance(self):
-        return self.wallet_balance - self.total_reserved_points - sum(self.queued_payments.values())
+        return self._update_balance()
 
     def _check_expected_balances(self):
         now = datetime.datetime.now()

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -28,7 +28,7 @@ from lbrynet import conf
 from lbrynet.core.sqlite_helpers import rerun_if_locked
 from lbrynet.interfaces import IRequestCreator, IQueryHandlerFactory, IQueryHandler, IWallet
 from lbrynet.core.client.ClientRequest import ClientRequest
-from lbrynet.core.Error import RequestCanceledError, InsufficientFundsError, UnknownNameError
+from lbrynet.core.Error import RequestCanceledError, UnknownNameError
 from lbrynet.core.Error import UnknownClaimID, UnknownURI
 from lbrynet.core.utils import safe_start_looping_call, safe_stop_looping_call
 
@@ -754,9 +754,6 @@ class Wallet(object):
         decoded = ClaimDict.load_dict(metadata)
         serialized = decoded.serialized
 
-        if self.get_balance() < Decimal(bid):
-            raise InsufficientFundsError()
-
         claim = yield self._send_name_claim(name, serialized.encode('hex'),
                                             bid, certificate_id, claim_address, change_address)
 
@@ -789,9 +786,6 @@ class Wallet(object):
                 raise Exception(msg)
             claim_out = self._process_claim_out(claim_out)
             return defer.succeed(claim_out)
-
-        if self.get_balance() < amount:
-            raise InsufficientFundsError()
 
         d = self._support_claim(name, claim_id, amount)
         d.addCallback(lambda claim_out: _parse_support_claim_out(claim_out))

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -2243,10 +2243,7 @@ class Daemon(AuthJSONRPCServer):
         elif not amount:
             raise NullFundsError()
 
-        reserved_points = self.session.wallet.reserve_points(address, amount)
-        if reserved_points is None:
-            raise InsufficientFundsError()
-        yield self.session.wallet.send_points_to_address(reserved_points, amount)
+        yield self.session.wallet.send_amount_to_address(amount, address)
         self.analytics_manager.send_credits_sent()
         defer.returnValue(True)
 

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -43,7 +43,7 @@ from lbrynet.core.Wallet import LBRYumWallet, SqliteStorage, ClaimOutpoint
 from lbrynet.core.looping_call_manager import LoopingCallManager
 from lbrynet.core.server.BlobRequestHandler import BlobRequestHandlerFactory
 from lbrynet.core.server.ServerProtocol import ServerProtocolFactory
-from lbrynet.core.Error import InsufficientFundsError, UnknownNameError, NoSuchSDHash
+from lbrynet.core.Error import UnknownNameError, NoSuchSDHash
 from lbrynet.core.Error import NoSuchStreamHash, UnknownClaimID, UnknownURI
 from lbrynet.core.Error import NullFundsError, NegativeFundsError
 
@@ -1680,8 +1680,6 @@ class Daemon(AuthJSONRPCServer):
             raise Exception("Invalid channel name")
         if amount <= 0:
             raise Exception("Invalid amount")
-        if amount > self.session.wallet.get_balance():
-            raise InsufficientFundsError()
 
         result = yield self.session.wallet.claim_new_channel(channel_name, amount)
         self.analytics_manager.send_new_channel()
@@ -1790,10 +1788,6 @@ class Daemon(AuthJSONRPCServer):
 
         if bid <= 0.0:
             raise Exception("Invalid bid")
-
-        if bid >= self.session.wallet.get_balance():
-            raise InsufficientFundsError('Insufficient funds. ' \
-                                         'Make sure you have enough LBC to deposit')
 
         metadata = metadata or {}
         if fee is not None:

--- a/lbrynet/daemon/Downloader.py
+++ b/lbrynet/daemon/Downloader.py
@@ -128,10 +128,7 @@ class GetStream(object):
 
     def _pay_key_fee(self, address, fee_lbc, name):
         log.info("Pay key fee %f --> %s", fee_lbc, address)
-        reserved_points = self.wallet.reserve_points(address, fee_lbc)
-        if reserved_points is None:
-            raise InsufficientFundsError('Unable to pay the key fee of %s for %s' % (fee_lbc, name))
-        return self.wallet.send_points_to_address(reserved_points, fee_lbc)
+        return self.wallet.send_amount_to_address(fee_lbc, address)
 
     @defer.inlineCallbacks
     def pay_key_fee(self, fee, name):

--- a/lbrynet/interfaces.py
+++ b/lbrynet/interfaces.py
@@ -603,47 +603,6 @@ class IWallet(Interface):
         @rtype: An object implementing IQueryHandlerFactory
         """
 
-    def reserve_points(self, peer, amount):
-        """Ensure a certain amount of points are available to be sent as
-        payment, before the service is rendered
-
-        @param peer: The peer to which the payment will ultimately be sent
-        @type peer: Peer
-
-        @param amount: The amount of points to reserve
-        @type amount: float
-
-        @return: A ReservedPoints object which is given to send_points
-        once the service has been rendered
-        @rtype: ReservedPoints
-
-        """
-
-    def cancel_point_reservation(self, reserved_points):
-        """
-        Return all of the points that were reserved previously for some ReservedPoints object
-
-        @param reserved_points: ReservedPoints previously returned by reserve_points
-        @type reserved_points: ReservedPoints
-
-        @return: None
-        """
-
-    def send_points(self, reserved_points, amount):
-        """
-        Schedule a payment to be sent to a peer
-
-        @param reserved_points: ReservedPoints object previously returned by reserve_points.
-        @type reserved_points: ReservedPoints
-
-        @param amount: amount of points to actually send, must be less than or equal to the
-            amount reserved in reserved_points
-        @type amount: float
-
-        @return: Deferred which fires when the payment has been scheduled
-        @rtype: Deferred which fires with anything
-        """
-
     def get_balance(self):
         """
         Return the balance of this wallet

--- a/tests/unit/core/test_Wallet.py
+++ b/tests/unit/core/test_Wallet.py
@@ -4,7 +4,7 @@ from twisted.trial import unittest
 from twisted.internet import threads, defer
 
 from lbrynet.core.Error import InsufficientFundsError
-from lbrynet.core.Wallet import Wallet, ReservedPoints, InMemoryStorage
+from lbrynet.core.Wallet import Wallet, InMemoryStorage
 
 test_metadata = {
 'license': 'NASA',


### PR DESCRIPTION
Remove payment queuing/point reservation feature in the wallet and send transactions immediately. This removes ability for clients to send data fee payments. However, there is no changes that will prevent servers from asking for data fee payments (non generous hosting). 

a) sending is no longer queued , API command send_amount_to_address() will immediately send 

d) The Wallet class's manage() function has been reworked to use LoopingCall . The only thing it does now is check expected balances (from recieving data fees).  Before it queued payments and updated the balance from lbryum which it no longer needs to do. Calls to get the wallet balance is a direct query now to lbryum.

e) Checks for insufficients funds that the Daemon and Wallet used to make has been deleted. These checks no longer need to exist in lbry daemon because lbryum can do it now since there is no queued payments that it doesn't know about. Fixes https://github.com/lbryio/lbry/issues/748

c) Clients will no longer attempt to send data fee payments in BlobRequester. If data fee is more than 0 , it will log a warning and continue to attempt to download without queuing data fee payments.  



