### PR TITLE
Fix windows tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,6 +27,8 @@ test_script:
 - pip install .
 - pylint lbrynet
 # disable tests for now so that appveyor can build the app
+- set PYTHONPATH=.
+- trial tests/unit
 #- python -m twisted.trial tests # avoids having to set PYTHONPATH=. (see https://twistedmatrix.com/trac/ticket/9035)
 #- rvm use 2.3.1 && gem install danger --version '~> 4.0' && danger
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,9 @@ test_script:
 - pylint lbrynet
 # disable tests for now so that appveyor can build the app
 - set PYTHONPATH=.
-- trial tests/unit
-#- python -m twisted.trial tests # avoids having to set PYTHONPATH=. (see https://twistedmatrix.com/trac/ticket/9035)
+- trial tests
+# TODO: integration tests do not work
+#- python -m unittest discover tests/integration
 #- rvm use 2.3.1 && gem install danger --version '~> 4.0' && danger
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ at anytime.
   * Fix default directories to comply to XDG
   * Fixed BlobManager causing functional tests to fail, removed its unneeded manage() loop
   * Increased max_key_fee
+  * Fixed unit tests on appveyor Windows build
 
 ### Deprecated
   *

--- a/lbrynet/lbry_file/EncryptedFileMetadataManager.py
+++ b/lbrynet/lbry_file/EncryptedFileMetadataManager.py
@@ -24,7 +24,7 @@ class DBEncryptedFileMetadataManager(object):
         return self._open_db()
 
     def stop(self):
-        self.db_conn = None
+        self.db_conn.close()
         return defer.succeed(True)
 
     def get_all_streams(self):

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -65,6 +65,19 @@ def use_epoll_on_linux():
         sys.modules['twisted.internet.reactor'] = twisted.internet.reactor
 
 
+def init_conf_windows(settings={}):
+    """
+    There is no fork on windows, so imports
+    are freshly initialized in new processes.
+    So conf needs to be intialized for new processes
+    """
+    if os.name == 'nt':
+        original_settings = conf.settings
+        conf.settings = conf.Config(conf.FIXED_SETTINGS, conf.ADJUSTABLE_SETTINGS)
+        conf.settings.installation_id = conf.settings.get_installation_id()
+        conf.settings.update(settings)
+
+
 class LbryUploader(object):
     def __init__(self, sd_hash_queue, kill_event, dead_event,
                  file_size, ul_rate_limit=None, is_generous=False):
@@ -84,6 +97,8 @@ class LbryUploader(object):
 
     def start(self):
         use_epoll_on_linux()
+        init_conf_windows()
+
         from twisted.internet import reactor
         self.reactor = reactor
         logging.debug("Starting the uploader")
@@ -98,6 +113,7 @@ class LbryUploader(object):
         self.sd_identifier = StreamDescriptorIdentifier()
         db_dir = "server"
         os.mkdir(db_dir)
+
         self.session = Session(
             conf.ADJUSTABLE_SETTINGS['data_rate'][1], db_dir=db_dir, lbryid="abcd",
             peer_finder=peer_finder, hash_announcer=hash_announcer, peer_port=5553,
@@ -182,6 +198,7 @@ class LbryUploader(object):
 def start_lbry_reuploader(sd_hash, kill_event, dead_event,
                           ready_event, n, ul_rate_limit=None, is_generous=False):
     use_epoll_on_linux()
+    init_conf_windows()
     from twisted.internet import reactor
 
     logging.debug("Starting the uploader")
@@ -295,6 +312,7 @@ def start_lbry_reuploader(sd_hash, kill_event, dead_event,
 
 def start_blob_uploader(blob_hash_queue, kill_event, dead_event, slow, is_generous=False):
     use_epoll_on_linux()
+    init_conf_windows()
     from twisted.internet import reactor
 
     logging.debug("Starting the uploader")

--- a/tests/unit/core/test_BlobManager.py
+++ b/tests/unit/core/test_BlobManager.py
@@ -100,8 +100,8 @@ class BlobManagerTest(unittest.TestCase):
 
         # open the last blob
         blob = yield self.bm.get_blob(blob_hashes[-1])
-        yield blob.open_for_writing(self.peer)
-        
+        finished_d, write, cancel = yield blob.open_for_writing(self.peer)
+
         # delete the last blob and check if it still exists
         out = yield self.bm.delete_blobs([blob_hash])
         blobs = yield self.bm.get_all_verified_blobs()
@@ -109,4 +109,5 @@ class BlobManagerTest(unittest.TestCase):
         self.assertTrue(blob_hashes[-1] in blobs)
         self.assertTrue(os.path.isfile(os.path.join(self.blob_dir,blob_hashes[-1])))
 
-
+ 
+        blob._close_writer(blob.writers[self.peer][0])

--- a/tests/unit/lbryfile/test_EncryptedFileMetadataManager.py
+++ b/tests/unit/lbryfile/test_EncryptedFileMetadataManager.py
@@ -14,6 +14,7 @@ class DBEncryptedFileMetadataManagerTest(unittest.TestCase):
         self.manager = DBEncryptedFileMetadataManager(self.db_dir)
 
     def tearDown(self):
+        self.manager.stop()
         shutil.rmtree(self.db_dir)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
This fixes and enables twisted trial test on appveyor which does the Windows build. (tests/functional and tests/unit) 

I wasn't able to get integration testing (tests/integration) working on Windows though, so that will be a separate todo.