### PR TITLE
Fix file_list failing due to malformed supports in the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ at anytime.
 
 ### Fixed
   * peer_port is settable using `settings_set`
+  * Fix for https://github.com/lbryio/lbry/issues/750
+  *
 
 ### Deprecated
   *


### PR DESCRIPTION

 fix for https://github.com/lbryio/lbry/issues/750

It was found that malformed support and amount data was entering the claim cache due to improper formatting that was fixed in https://github.com/lbryio/lbryum/pull/135. 

This was causing problems when trying to retrieve it through file_list. Since file_list gets the claim from cache regardless of whether it expired or not, this the malformed support would throw exception when processing the effective amount here  https://github.com/lbryio/lbry/blob/master/lbrynet/core/Wallet.py#L78

  File "site-packages\lbrynet\core\Wallet.py", line 134, in get_cached_claim
  File "site-packages\lbrynet\core\Wallet.py", line 78, in __init__
TypeError: list indices must be integers, not str

and cause the file_list command to fail. Resolving claims through the claim cache would also fail, but would happen less frequently because expired items in the claim cache would not be used. 

0da7bdd

is broken out of https://github.com/lbryio/lbry/pull/730. A lot of code duplication in Wallet._handle_claim_result() where it decodes and caches the claim . Create a _decode_and_cache_claim_result() function to solve this. Do not always put things in the cache because we know that some commands do not return the full details of a claim. Also fixes to always uses smart_decode instead of ClaimDict.load_dict()


b5e4d97

Detect if we have a malformed support and amount data in the cache. If detected, return the corrected values and fix them in the database. 





