### PR TITLE
Write "failed to get version from Git" notice to stderr, not stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ at anytime.
   *
 
 ### Changed
-  *
+  * Make `lbrynet-daemon --version` reliably machine readable (writes warning to stderr instead of stdout)
   *
 
 ### Fixed

--- a/lbrynet/core/system_info.py
+++ b/lbrynet/core/system_info.py
@@ -2,6 +2,7 @@ import platform
 import json
 import subprocess
 import os
+import sys
 
 from urllib2 import urlopen
 from lbryschema import __version__ as lbryschema_version
@@ -20,7 +21,7 @@ def get_lbrynet_version():
                     stderr=devnull
                 ).strip().lstrip('v')
         except (subprocess.CalledProcessError, OSError):
-            print "failed to get version from git"
+            sys.stderr.write("failed to get version from git\n")
     return lbrynet_version
 
 


### PR DESCRIPTION
This means the stdout output is always pure JSON which allows the app (and other tools) to parse it.

Needed for https://github.com/lbryio/lbry-app/pull/335