### PR TITLE
claim_show without name also works with CLI now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * claim_show now works properly
   *
 
 ### Deprecated

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1339,16 +1339,28 @@ class Daemon(AuthJSONRPCServer):
         try:
             if claim_id:
                 claim_results = yield self.session.wallet.get_claim(claim_id)
+                check_name = claim_results.get("name", None) if claim_results is not None else None
             elif txid and nout is not None:
                 outpoint = ClaimOutpoint(txid, nout)
                 claim_results = yield self.session.wallet.get_claim_by_outpoint(outpoint)
+                check_name = claim_results.get("name", None)
             else:
                 claim_results = yield self.session.wallet.resolve(name)
                 if claim_results:
                     claim_results = claim_results[name]
+                if claim_results.get('claim') is not None:
+                    check_name = claim_results.get("claim").get("name")
+                else:
+                    check_name = None
+
             result = format_json_out_amount_as_float(claim_results)
         except (TypeError, UnknownNameError, UnknownClaimID, UnknownURI):
+            check_name = None
             result = False
+
+        if name and check_name and (name != check_name):
+            result = "The given name and name returned by server do not match."
+
         response = yield self._render_response(result)
         defer.returnValue(response)
 

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1313,10 +1313,11 @@ class Daemon(AuthJSONRPCServer):
         Resolve claim info from a LBRY name
 
         Usage:
-            claim_show <name> [<txid> | --txid=<txid>] [<nout> | --nout=<nout>]
+            claim_show [<name> | --name=<name>] [<txid> | --txid=<txid>] [<nout> | --nout=<nout>]
                               [<claim_id> | --claim_id=<claim_id>]
 
         Options:
+            <name>, --name=<name>              : look for claim with this name
             <txid>, --txid=<txid>              : look for claim with this txid
             <nout>, --nout=<nout>              : look for claim with this nout
             <claim_id>, --claim_id=<claim_id>  : look for claim with this claim id


### PR DESCRIPTION
Improves upon 2nd point of #644.
However if the user is running the command without name argument, then he/she has to specify `--` before txid, nout or claim_id as the arguments without `--` are positional.