### PR TITLE
Fix if statement causing claim with certificate to not get cached, and cause downloading to fail

### DIFF
--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -776,14 +776,14 @@ class Wallet(object):
                     raise UnknownOutpoint(results['outpoint'])
             raise Exception(results['error'])
 
-        # case where return value is {'certificate:{'txid', 'value',...}}
-        elif 'certificate' in results:
+        # case where return value is {'certificate':{'txid', 'value',...},...}
+        if 'certificate' in results:
             results['certificate'] = yield self._decode_and_cache_claim_result(
                                                                         results['certificate'],
                                                                         update_caches)
 
-        # case where return value is {'claim':{'txid','value',...}}
-        elif 'claim' in results:
+        # case where return value is {'claim':{'txid','value',...},...}
+        if 'claim' in results:
             results['claim'] = yield self._decode_and_cache_claim_result(
                                                                      results['claim'],
                                                                      update_caches)


### PR DESCRIPTION
When resolving @certificatename/some_claim , resolve output will be something like {"certificate":{} , "claim":{} } 

Thus the if statement in handle_claim_result would only cache the certificate and not claim. 

Since file downloading relies on the Wallet cache (we really need to remove this reliance) having the claim, downloading would encounter exception here: https://github.com/lbryio/lbry/blob/master/lbrynet/file_manager/EncryptedFileDownloader.py#L111