### PR TITLE
#734 - Blob Encryption bottleneck

### DIFF
--- a/lbrynet/core/BlobManager.py
+++ b/lbrynet/core/BlobManager.py
@@ -184,6 +184,7 @@ class DiskBlobManager(BlobManager):
         # threads.
 
         def create_tables(transaction):
+            transaction.execute('PRAGMA journal_mode=WAL')
             transaction.execute("create table if not exists blobs (" +
                                 "    blob_hash text primary key, " +
                                 "    blob_length integer, " +

--- a/lbrynet/core/HashBlob.py
+++ b/lbrynet/core/HashBlob.py
@@ -1,4 +1,5 @@
-from io import BytesIO, StringIO
+from StringIO import StringIO
+from io import BytesIO
 import logging
 import os
 import tempfile

--- a/lbrynet/core/HashBlob.py
+++ b/lbrynet/core/HashBlob.py
@@ -1,4 +1,4 @@
-from StringIO import StringIO
+from io import BytesIO, StringIO
 import logging
 import os
 import tempfile
@@ -6,6 +6,7 @@ import threading
 import shutil
 from twisted.internet import interfaces, defer, threads
 from twisted.protocols.basic import FileSender
+from twisted.web.client import FileBodyProducer
 from twisted.python.failure import Failure
 from zope.interface import implements
 from lbrynet import conf
@@ -387,17 +388,14 @@ class BlobFileCreator(HashBlobCreator):
     def __init__(self, blob_manager, blob_dir):
         HashBlobCreator.__init__(self, blob_manager)
         self.blob_dir = blob_dir
-        self.buffer = StringIO()
+        self.buffer = BytesIO()
 
     def _close(self):
         if self.blob_hash is not None:
-            def _twrite(data, blob_dir, blob_hash):
-                with open(os.path.join(blob_dir, blob_hash), 'w') as out_file:
-                    out_file.write(data.getvalue())
-            d = threads.deferToThread(_twrite, self.buffer,
-                                      self.blob_dir, self.blob_hash)
-            del self.buffer
-            return d
+            self.buffer.seek(0)
+            out_path = os.path.join(self.blob_dir, self.blob_hash)
+            producer = FileBodyProducer(self.buffer)
+            return producer.startProducing(open(out_path, 'wb'))
         return defer.succeed(True)
 
     def _write(self, data):

--- a/lbrynet/core/HashBlob.py
+++ b/lbrynet/core/HashBlob.py
@@ -387,19 +387,21 @@ class BlobFileCreator(HashBlobCreator):
     def __init__(self, blob_manager, blob_dir):
         HashBlobCreator.__init__(self, blob_manager)
         self.blob_dir = blob_dir
-        self.out_file = tempfile.NamedTemporaryFile(delete=False, dir=self.blob_dir)
+        self.buffer = StringIO()
 
     def _close(self):
-        temp_file_name = self.out_file.name
-        self.out_file.close()
         if self.blob_hash is not None:
-            shutil.move(temp_file_name, os.path.join(self.blob_dir, self.blob_hash))
-        else:
-            os.remove(temp_file_name)
+            def _twrite(data, blob_dir, blob_hash):
+                with open(os.path.join(blob_dir, blob_hash), 'w') as out_file:
+                    out_file.write(data.getvalue())
+            d = threads.deferToThread(_twrite, self.buffer,
+                                      self.blob_dir, self.blob_hash)
+            del self.buffer
+            return d
         return defer.succeed(True)
 
     def _write(self, data):
-        self.out_file.write(data)
+        self.buffer.write(data)
 
 
 class TempBlobCreator(HashBlobCreator):

--- a/lbrynet/core/StreamCreator.py
+++ b/lbrynet/core/StreamCreator.py
@@ -51,12 +51,17 @@ class StreamCreator(object):
             current_blob = self.current_blob
             d = current_blob.close()
             d.addCallback(self._blob_finished)
+            d.addErrback(self._error)
             self.finished_deferreds.append(d)
             self.current_blob = None
         self._finalize()
         dl = defer.DeferredList(self.finished_deferreds)
         dl.addCallback(lambda _: self._finished())
+        dl.addErrback(self._error)
         return dl
+
+    def _error(self, error):
+        log.error(error)
 
     def _finalize(self):
         pass

--- a/lbrynet/core/cryptoutils.py
+++ b/lbrynet/core/cryptoutils.py
@@ -1,9 +1,9 @@
-from Crypto.Hash import SHA384
 import seccure
+import hashlib
 
 
 def get_lbry_hash_obj():
-    return SHA384.new()
+    return hashlib.sha384()
 
 
 def get_pub_key(pass_phrase):

--- a/lbrynet/cryptstream/CryptBlob.py
+++ b/lbrynet/cryptstream/CryptBlob.py
@@ -1,11 +1,15 @@
 import binascii
 import logging
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers import Cipher, modes
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
+from cryptography.hazmat.primitives.padding import PKCS7
+from cryptography.hazmat.backends import default_backend
 from lbrynet import conf
 from lbrynet.core.BlobInfo import BlobInfo
 
 
 log = logging.getLogger(__name__)
+backend = default_backend()
 
 
 class CryptBlobInfo(BlobInfo):
@@ -31,7 +35,9 @@ class StreamBlobDecryptor(object):
         self.length = length
         self.buff = b''
         self.len_read = 0
-        self.cipher = AES.new(self.key, AES.MODE_CBC, self.iv)
+        cipher = Cipher(AES(self.key), modes.CBC(self.iv), backend=backend)
+        self.unpadder = PKCS7(AES.block_size).unpadder()
+        self.cipher = cipher.decryptor()
 
     def decrypt(self, write_func):
         """
@@ -42,22 +48,19 @@ class StreamBlobDecryptor(object):
         """
 
         def remove_padding(data):
-            pad_len = ord(data[-1])
-            data, padding = data[:-1 * pad_len], data[-1 * pad_len:]
-            for c in padding:
-                assert ord(c) == pad_len
-            return data
+            return self.unpadder.update(data) + self.unpadder.finalize()
 
         def write_bytes():
             if self.len_read < self.length:
-                num_bytes_to_decrypt = greatest_multiple(len(self.buff), self.cipher.block_size)
+                num_bytes_to_decrypt = greatest_multiple(len(self.buff), (AES.block_size / 8))
                 data_to_decrypt, self.buff = split(self.buff, num_bytes_to_decrypt)
-                write_func(self.cipher.decrypt(data_to_decrypt))
+                write_func(self.cipher.update(data_to_decrypt))
 
         def finish_decrypt():
-            assert len(self.buff) % self.cipher.block_size == 0
+            assert len(self.buff) % (AES.block_size / 8) == 0
             data_to_decrypt, self.buff = self.buff, b''
-            write_func(remove_padding(self.cipher.decrypt(data_to_decrypt)))
+            last_chunk = self.cipher.update(data_to_decrypt) + self.cipher.finalize()
+            write_func(remove_padding(last_chunk))
 
         def decrypt_bytes(data):
             self.buff += data
@@ -84,8 +87,9 @@ class CryptStreamBlobMaker(object):
         self.iv = iv
         self.blob_num = blob_num
         self.blob = blob
-        self.cipher = AES.new(self.key, AES.MODE_CBC, self.iv)
-        self.buff = b''
+        cipher = Cipher(AES(self.key), modes.CBC(self.iv), backend=backend)
+        self.padder = PKCS7(AES.block_size).padder()
+        self.cipher = cipher.encryptor()
         self.length = 0
 
     def write(self, data):
@@ -104,10 +108,11 @@ class CryptStreamBlobMaker(object):
             done = True
         else:
             num_bytes_to_write = len(data)
-        self.length += num_bytes_to_write
         data_to_write = data[:num_bytes_to_write]
-        self.buff += data_to_write
-        self._write_buffer()
+        self.length += len(data_to_write)
+        padded_data = self.padder.update(data_to_write)
+        encrypted_data = self.cipher.update(padded_data)
+        self.blob.write(encrypted_data)
         return done, num_bytes_to_write
 
     def close(self):
@@ -119,20 +124,10 @@ class CryptStreamBlobMaker(object):
         log.debug("called the finished_callback from CryptStreamBlobMaker.close")
         return d
 
-    def _write_buffer(self):
-        num_bytes_to_encrypt = (len(self.buff) // AES.block_size) * AES.block_size
-        data_to_encrypt, self.buff = split(self.buff, num_bytes_to_encrypt)
-        encrypted_data = self.cipher.encrypt(data_to_encrypt)
-        self.blob.write(encrypted_data)
-
     def _close_buffer(self):
-        data_to_encrypt, self.buff = self.buff, b''
-        assert len(data_to_encrypt) < AES.block_size
-        pad_len = AES.block_size - len(data_to_encrypt)
-        padded_data = data_to_encrypt + chr(pad_len) * pad_len
-        self.length += pad_len
-        assert len(padded_data) == AES.block_size
-        encrypted_data = self.cipher.encrypt(padded_data)
+        self.length += (AES.block_size / 8) - (self.length % (AES.block_size / 8))
+        padded_data = self.padder.finalize()
+        encrypted_data = self.cipher.update(padded_data) + self.cipher.finalize()
         self.blob.write(encrypted_data)
 
     def _return_info(self, blob_hash):

--- a/lbrynet/cryptstream/CryptStreamCreator.py
+++ b/lbrynet/cryptstream/CryptStreamCreator.py
@@ -78,6 +78,7 @@ class CryptStreamCreator(StreamCreator):
         def close_blob(blob):
             d = blob.close()
             d.addCallback(self._blob_finished)
+            d.addErrback(self._error)
             self.finished_deferreds.append(d)
 
         while len(data) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Twisted==16.6.0
+cryptography==1.9
 appdirs==1.4.3
 argparse==1.2.1
 docopt==0.6.2

--- a/scripts/encrypt_blob.py
+++ b/scripts/encrypt_blob.py
@@ -5,6 +5,8 @@ import sys
 
 from twisted.internet import defer
 from twisted.internet import reactor
+from twisted.protocols import basic
+from twisted.web.client import FileBodyProducer
 
 from lbrynet import conf
 from lbrynet.core import log_support
@@ -46,10 +48,8 @@ def encrypt_blob(filename, key, iv):
     yield manager.setup()
     creator = CryptStreamCreator(manager, filename, key, iv_generator(iv))
     with open(filename, 'r') as infile:
-        data = infile.read(2**14)
-        while data:
-            yield creator.write(data)
-            data = infile.read(2**14)
+        producer = FileBodyProducer(infile, readSize=2**22)
+        yield producer.startProducing(creator)
     yield creator.stop()
 
 


### PR DESCRIPTION
* Added WAL pragma to sqlite3
* use hashlib for sha384 instead of pycrypto
* Changed pycrypto -> cryptography for encrypt/decrypt
* Removed manual PKCS7 padding, use a lib instead
* Turns `cryptography` lib a direct dependency (was indirect, added to requirements file)
* added a bit more of error handling to cryptblob



To profile:
```bash
$ dd if=/dev/urandom of=/tmp/test bs=1M count=600
# activate virtualenv
$ pip install plop
$ cd scripts/
$ python -m plop.collector encrypt_blob.py /tmp/test '61616161616161616161616161616161' '69696969696969696969696969696969'
$ python -m plop.viewer
# go to localhost:8888 on a browser
```