### PR TITLE
Add option for clients to seek head blob first when downloading 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ at anytime.
 
 ### Added
   * Added option to announce head blob only if seeding
+  * Adeed option to download by seeking head blob first
   *
 
 ### Fixed

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -255,6 +255,7 @@ ADJUSTABLE_SETTINGS = {
     'known_dht_nodes': (list, DEFAULT_DHT_NODES, server_port),
     'lbryum_wallet_dir': (str, default_lbryum_dir),
     'max_connections_per_stream': (int, 5),
+    'seek_head_blob_first': (bool, False),
     # TODO: writing json on the cmd line is a pain, come up with a nicer
     # parser for this data structure. maybe 'USD:25'
     'max_key_fee': (json.loads, {'currency': 'USD', 'amount': 50.0}),

--- a/lbrynet/core/client/BlobRequester.py
+++ b/lbrynet/core/client/BlobRequester.py
@@ -64,10 +64,19 @@ class BlobRequester(object):
             return defer.succeed(False)
         return self._send_next_request(peer, protocol)
 
-    def get_new_peers(self):
-        d = self._get_hash_for_peer_search()
-        d.addCallback(self._find_peers_for_hash)
-        return d
+    @defer.inlineCallbacks
+    def get_new_peers_for_head_blob(self):
+        """ look for peers for the head blob """
+        head_blob_hash = self._download_manager.get_head_blob_hash()
+        peers = yield self._find_peers_for_hash(head_blob_hash)
+        defer.returnValue(peers)
+
+    @defer.inlineCallbacks
+    def get_new_peers_for_next_unavailable(self):
+        """ look for peers for the next unavailable blob """
+        blob_hash = yield self._get_hash_for_peer_search()
+        peers = yield self._find_peers_for_hash(blob_hash)
+        defer.returnValue(peers)
 
     ######### internal calls #########
     def should_send_next_request(self, peer):

--- a/lbrynet/core/client/ConnectionManager.py
+++ b/lbrynet/core/client/ConnectionManager.py
@@ -168,8 +168,7 @@ class ConnectionManager(object):
             return []
         out = [peer for peer in peers if peer not in self._peer_connections]
         random.shuffle(out)
-        out = out[0:new_conns_needed]
-        return out
+        return out[0:new_conns_needed]
 
     @defer.inlineCallbacks
     def _get_new_peers(self):
@@ -182,7 +181,7 @@ class ConnectionManager(object):
         log.debug("%s Trying to get a new peer to connect to", self._get_log_name())
 
         # find peers for the head blob if configured to do so
-        if self.seek_head_blob_first is True:
+        if self.seek_head_blob_first:
             peers = yield request_creator.get_new_peers_for_head_blob()
             peers = self.return_shuffled_peers_not_connected_to(peers, new_conns_needed)
         else:
@@ -190,7 +189,7 @@ class ConnectionManager(object):
 
         # we didn't find any new peers on the head blob,
         # we have to look for the first unavailable blob
-        if len(peers) == 0:
+        if not peers:
             peers = yield request_creator.get_new_peers_for_next_unavailable()
             peers = self.return_shuffled_peers_not_connected_to(peers, new_conns_needed)
 

--- a/lbrynet/core/client/ConnectionManager.py
+++ b/lbrynet/core/client/ConnectionManager.py
@@ -163,9 +163,6 @@ class ConnectionManager(object):
             self._next_manage_call = utils.call_later(self.MANAGE_CALL_INTERVAL_SEC, self.manage)
 
     def return_shuffled_peers_not_connected_to(self, peers, new_conns_needed):
-        if peers is None:
-            # can happen if there is some error in the lookup
-            return []
         out = [peer for peer in peers if peer not in self._peer_connections]
         random.shuffle(out)
         return out[0:new_conns_needed]
@@ -204,7 +201,7 @@ class ConnectionManager(object):
 
 
     def _connect_to_peer(self, peer):
-        if peer is None or self.stopped:
+        if self.stopped:
             return
 
         log.debug("%s Trying to connect to %s", self._get_log_name(), peer)

--- a/tests/unit/core/client/test_ConnectionManager.py
+++ b/tests/unit/core/client/test_ConnectionManager.py
@@ -136,8 +136,6 @@ class TestIntegrationConnectionManager(unittest.TestCase):
         from lbrynet.core.client.ConnectionManager import ConnectionManager
         self.connection_manager = ConnectionManager(self.downloader, self.rate_limiter,
                                                     [self.primary_request_creator], [])
-
-      
         self.connection_manager.seek_head_blob_first = seek_head_blob_first
         self.connection_manager._start()
 
@@ -242,14 +240,14 @@ class TestIntegrationConnectionManager(unittest.TestCase):
 
 
     """ test header first seeks """
-    @defer.inlineCallbacks  
+    @defer.inlineCallbacks
     def test_no_peer_for_head_blob(self):
-        # test that if we can't find blobs for the head blob, 
+        # test that if we can't find blobs for the head blob,
         # it looks at the next unavailable and makes connection
         self._init_connection_manager(seek_head_blob_first=True)
         self.server = MocServerProtocolFactory(self.clock)
         self.server_port = reactor.listenTCP(PEER_PORT, self.server, interface=LOCAL_HOST)
- 
+
         self.primary_request_creator.peers_to_return_head_blob = []
         self.primary_request_creator.peers_to_return = [self.TEST_PEER]
 


### PR DESCRIPTION
This adds an option in conf for clients to download by prioritizing the seeking of the "head blob" (the very first blob in the stream) before they seek the next unavailable blob. 

It is turned off by default in this PR so will not change how downloading works unless configured to be turned on manually.  Should be turned on when reflector switch to announcing head blob only. 
