### PR TITLE
fix windows encoding issue in old directories

### DIFF
--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -71,6 +71,7 @@ def _get_old_directories(platform):
     dirs = {}
     if platform == WINDOWS:
         appdata = get_path(FOLDERID.RoamingAppData, UserHandle.current)
+        appdata = _win_path_to_bytes(appdata)
         dirs['data'] = os.path.join(appdata, 'lbrynet')
         dirs['lbryum'] = os.path.join(appdata, 'lbryum')
         dirs['download'] = get_path(FOLDERID.Downloads, UserHandle.current)


### PR DESCRIPTION
potential fix for https://github.com/lbryio/lbry/issues/794
need to convert the directory to bytes before joining , otherwise join will be screwed up