### PR TITLE
Add ability to control re-reflects through config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ at anytime.
   *
 
 ### Added
-  *
+  * Added configuration options for auto re-reflect
   *
 
 ### Removed

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -250,7 +250,12 @@ ADJUSTABLE_SETTINGS = {
     'peer_port': (int, 3333),
     'pointtrader_server': (str, 'http://127.0.0.1:2424'),
     'reflector_port': (int, 5566),
+    # if reflect_uploads is True, reflect files on publish
     'reflect_uploads': (bool, True),
+    # if auto_re_reflect is True, attempt to re-reflect files on startup and
+    # at every auto_re_reflect_interval seconds, useful if initial reflect is unreliable
+    'auto_re_reflect': (bool, True),
+    'auto_re_reflect_interval': (int, 3600),
     'reflector_servers': (list, [('reflector.lbry.io', 5566)], server_port),
     'run_reflector_server': (bool, False),
     'sd_download_timeout': (int, 3),

--- a/tests/unit/lbryfilemanager/test_EncryptedFileManager.py
+++ b/tests/unit/lbryfilemanager/test_EncryptedFileManager.py
@@ -1,10 +1,14 @@
 from twisted.internet import defer
 from twisted.trial import unittest
+from lbrynet import conf
 from lbrynet.file_manager.EncryptedFileDownloader import ManagedEncryptedFileDownloader
 from lbrynet.file_manager.EncryptedFileManager import EncryptedFileManager
 from tests.util import random_lbry_hash
 
 class TestEncryptedFileManager(unittest.TestCase):
+
+    def setUp(self):
+        conf.initialize_settings()
 
     @defer.inlineCallbacks
     def test_database_operations(self):


### PR DESCRIPTION
File manager will attempt to automatically re-reflect files on startup and every hour. 

Make this configurable through config file. "auto_re_reflect" will turn this feature on/off , "auto_re_reflect_interval" will control how often it attempts to re-reflect. Auto re-reflect is by default on, and interval is every hour (same as before)

Should solve some issues for speech https://github.com/lbryio/lbry/issues/817 by turning auto_re_reflect off. 