### PR TITLE
Expose abandon by txid/nout in Daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ at anytime.
   * Added `claim_send_tip`, a command to tip the owner of a claim via a support transaction
   * Added `reflector` keyword parameter to `file_reflect` command
   * Added configuration options for auto re-reflect
+  * Added option to abandon by txid/nout
 
 ### Fixed
   *

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -951,11 +951,12 @@ class Wallet(object):
         defer.returnValue(claim)
 
     @defer.inlineCallbacks
-    def abandon_claim(self, claim_id):
-        claim_out = yield self._abandon_claim(claim_id)
+    def abandon_claim(self, claim_id, txid, nout):
+        claim_out = yield self._abandon_claim(claim_id, txid, nout)
 
         if not claim_out['success']:
-            msg = 'Abandon of {} failed: {}'.format(claim_id, claim_out['reason'])
+            msg = 'Abandon of {}/{}:{} failed: {}'.format(
+                            claim_id, txid, nout, claim_out['reason'])
             raise Exception(msg)
 
         claim_out = self._process_claim_out(claim_out)
@@ -1088,7 +1089,7 @@ class Wallet(object):
                          change_address=None):
         return defer.fail(NotImplementedError())
 
-    def _abandon_claim(self, claim_id):
+    def _abandon_claim(self, claim_id, txid, nout):
         return defer.fail(NotImplementedError())
 
     def _support_claim(self, name, claim_id, amount):
@@ -1371,9 +1372,9 @@ class LBRYumWallet(Wallet):
         defer.returnValue(claim_out)
 
     @defer.inlineCallbacks
-    def _abandon_claim(self, claim_id):
+    def _abandon_claim(self, claim_id, txid, nout):
         log.debug("Abandon %s" % claim_id)
-        tx_out = yield self._run_cmd_as_defer_succeed('abandon', claim_id)
+        tx_out = yield self._run_cmd_as_defer_succeed('abandon', claim_id, txid, nout)
         defer.returnValue(tx_out)
 
     @defer.inlineCallbacks

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1880,18 +1880,9 @@ class Daemon(AuthJSONRPCServer):
         if nout is None and txid is not None:
             raise Exception('Must specify nout')
 
-        try:
-            abandon_claim_tx = yield self.session.wallet.abandon_claim(claim_id, txid, nout)
-            self.analytics_manager.send_claim_action('abandon')
-            response = yield self._render_response(abandon_claim_tx)
-        except BaseException as err:
-            log.warning(err)
-            # pylint: disable=unsubscriptable-object
-            if len(err.args) and err.args[0] == "txid was not found in wallet":
-                raise Exception("This transaction was not found in your wallet")
-            else:
-                response = yield self._render_response(err)
-        defer.returnValue(response)
+        result = yield self.session.wallet.abandon_claim(claim_id, txid, nout)
+        self.analytics_manager.send_claim_action('abandon')
+        defer.returnValue(result)
 
     @AuthJSONRPCServer.auth_required
     @defer.inlineCallbacks

--- a/tests/unit/core/test_Wallet.py
+++ b/tests/unit/core/test_Wallet.py
@@ -115,7 +115,7 @@ class WalletTest(unittest.TestCase):
             return threads.deferToThread(lambda: claim_out)
         MocLbryumWallet._abandon_claim = failed_abandon_claim
         wallet = MocLbryumWallet()
-        d = wallet.abandon_claim("f43dc06256a69988bdbea09a58c80493ba15dcfa")
+        d = wallet.abandon_claim("f43dc06256a69988bdbea09a58c80493ba15dcfa", None, None)
         self.assertFailure(d, Exception)
         return d
 
@@ -131,12 +131,12 @@ class WalletTest(unittest.TestCase):
             self.assertEqual(expected_abandon_out['fee'], claim_out['fee'])
             self.assertEqual(expected_abandon_out['txid'], claim_out['txid'])
 
-        def success_abandon_claim(self, claim_outpoint):
+        def success_abandon_claim(self, claim_outpoint, txid, nout):
             return threads.deferToThread(lambda: expected_abandon_out)
 
         MocLbryumWallet._abandon_claim = success_abandon_claim
         wallet = MocLbryumWallet()
-        d = wallet.abandon_claim("f43dc06256a69988bdbea09a58c80493ba15dcfa")
+        d = wallet.abandon_claim("f43dc06256a69988bdbea09a58c80493ba15dcfa", None, None)
         d.addCallback(lambda claim_out: check_out(claim_out))
         return d
 


### PR DESCRIPTION
Enable abandoning by txid/nout (feature already available in lbryum) , necessary for abandoning when you make supports for your own claim , since they share the same claim_id. Fixes https://github.com/lbryio/lbry/issues/795

Removed some unnecessary error handling for abandon in the Daemon. Exceptions are thrown in Wallet and will be propagated so the catching is unnecessary. 

 
