### PR TITLE
Faster reflector server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ at anytime.
   * Added configuration options for auto re-reflect
 
 ### Fixed
-  *
+  * Fixed reflector server blocking the `received_blob` reply on the server announcing the blob to the dht
   *
   * Fixed incorrect formatting of "amount" fields
   * Fixed handling of SIGINT, SIGTERM.


### PR DESCRIPTION
-don't block `BlobManager.blob_completed` on the blob being announced  (this considerably slows down the rate at which reflector server can receive blobs)