### PR TITLE
Fix improper use of floats

### DIFF
--- a/lbrynet/daemon/auth/client.py
+++ b/lbrynet/daemon/auth/client.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import os
 import base64
-import json
+import simplejson
 
 from lbrynet.daemon.auth.util import load_api_keys, APIKey, API_KEY_NAME, get_auth_message
 from lbrynet import conf
@@ -52,7 +52,7 @@ class AuthAPIClient(object):
         to_auth = get_auth_message(pre_auth_post_data)
         token = self.__api_key.get_hmac(to_auth)
         pre_auth_post_data.update({'hmac': token})
-        post_data = json.dumps(pre_auth_post_data)
+        post_data = simplejson.dumps(pre_auth_post_data, use_decimal=True)
         service_url = self.__service_url
         auth_header = self.__auth_header
         cookies = self.__cookies

--- a/lbrynet/daemon/auth/server.py
+++ b/lbrynet/daemon/auth/server.py
@@ -8,7 +8,6 @@ from twisted.web import server, resource
 from twisted.internet import defer
 from twisted.python.failure import Failure
 from twisted.internet.error import ConnectionDone, ConnectionLost
-from txjsonrpc import jsonrpclib
 from traceback import format_exc
 
 from lbrynet import conf
@@ -101,7 +100,7 @@ def jsonrpc_dumps(obj, id_):
                       separators=(',', ': '), use_decimal=True) + "\n"
 
 def jsonrpc_loads(obj):
-    return jsonrpclib.loads(obj, parse_float=Decimal)
+    return simplejson.loads(obj, use_decimal=True)
 
 
 class JSONRPCServerType(type):

--- a/lbrynet/daemon/auth/server.py
+++ b/lbrynet/daemon/auth/server.py
@@ -1,9 +1,8 @@
 import logging
 import urlparse
-import json
+import simplejson
 import inspect
 
-from decimal import Decimal
 from zope.interface import implements
 from twisted.web import server, resource
 from twisted.internet import defer
@@ -77,10 +76,6 @@ class JSONRPCError(object):
     def create_from_exception(cls, exception, code=CODE_APPLICATION_ERROR, traceback=None):
         return cls(exception.message, code=code, traceback=traceback)
 
-def default_decimal(obj):
-    if isinstance(obj, Decimal):
-        return float(obj)
-
 class UnknownAPIMethodError(Exception):
     pass
 
@@ -102,8 +97,8 @@ def jsonrpc_dumps(obj, id_):
         data = {"jsonrpc": "2.0", "error": obj.to_dict(), "id": id_}
     else:
         data = {"jsonrpc": "2.0", "result": obj, "id": id_}
-    return json.dumps(data, cls=jsonrpclib.JSONRPCEncoder, sort_keys=True, indent=2,
-                      separators=(',', ': '), default=default_decimal) + "\n"
+    return simplejson.dumps(data, sort_keys=True, indent=2,
+                      separators=(',', ': '), use_decimal=True) + "\n"
 
 def jsonrpc_loads(obj):
     return jsonrpclib.loads(obj, parse_float=Decimal)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ requests==2.9.1
 txrequests==0.9.5
 seccure==0.3.1.3
 service_identity==16.0.0
+simplejson==3.11.1
 six>=1.9.0
 slowaes==0.1a1
 txJSON-RPC==0.5

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ requires = [
     'requests',
     'txrequests',
     'seccure',
+    'simplejson',
     'txJSON-RPC',
     'zope.interface',
     'docopt'


### PR DESCRIPTION
The daemon, when processing JSON RPC calls, needs to treat float fields as decimal.Decimal. 

It also needs to be able to return decimal.Decimal's as JSON without losing precision.

We switch to use simplejson library instead of json as it naively supports dumps() for Decimal types. 