### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ package_name = "lbrynet"
 base_dir = os.path.abspath(os.path.dirname(__file__))
 # Get the long description from the README file
 with open(os.path.join(base_dir, 'README.md')) as f:
-    long_description = f.read().decode('utf-8')
+    long_description = f.read()
 
 setup(
     name=package_name,

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ def package_files(directory):
 package_name = "lbrynet"
 base_dir = os.path.abspath(os.path.dirname(__file__))
 # Get the long description from the README file
-with open(os.path.join(base_dir, 'README.md')) as f:
-    long_description = f.read()
+with open(os.path.join(base_dir, 'README.md'), 'rb') as f:
+    long_description = f.read().decode('utf-8')
 
 setup(
     name=package_name,


### PR DESCRIPTION
`.decode('utf-8')` is unnecessary and breaks on Python 3