### PR TITLE
Reflector rework (for head blob announce)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ at anytime.
   *
 
 ### Changed
-  *
+  * Announcing by head blob is turned on by default
   *
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ at anytime.
   *
   *
 
+### Added
+  * Added ability for reflector to store stream information for head blob announce
+  *
+
 ### Fixed
   * Fixed handling cancelled blob and availability requests
   * Fixed redundant blob requests to a peer

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -251,7 +251,7 @@ ADJUSTABLE_SETTINGS = {
     'download_directory': (str, default_download_dir),
     'download_timeout': (int, 180),
     'is_generous_host': (bool, True),
-    'announce_head_blobs_only': (bool, False),
+    'announce_head_blobs_only': (bool, True),
     'known_dht_nodes': (list, DEFAULT_DHT_NODES, server_port),
     'lbryum_wallet_dir': (str, default_lbryum_dir),
     'max_connections_per_stream': (int, 5),

--- a/lbrynet/core/BlobManager.py
+++ b/lbrynet/core/BlobManager.py
@@ -231,6 +231,14 @@ class DiskBlobManager(DHTHashSupplier):
         return d
 
     @rerun_if_locked
+    @defer.inlineCallbacks
+    def _get_all_should_announce_blob_hashes(self):
+        # return a list of blob hashes where should_announce is True
+        blob_hashes = yield self.db_conn.runQuery(
+            "select blob_hash from blobs where should_announce = 1")
+        defer.returnValue([d[0] for d in blob_hashes])
+
+    @rerun_if_locked
     def _get_all_verified_blob_hashes(self):
         d = self._get_all_blob_hashes()
 

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -316,7 +316,8 @@ class Daemon(AuthJSONRPCServer):
             if self.reflector_port is not None:
                 reflector_factory = reflector_server_factory(
                     self.session.peer_manager,
-                    self.session.blob_manager
+                    self.session.blob_manager,
+                    self.stream_info_manager
                 )
                 try:
                     self.reflector_server_port = reactor.listenTCP(self.reflector_port,

--- a/lbrynet/reflector/server/server.py
+++ b/lbrynet/reflector/server/server.py
@@ -4,7 +4,7 @@ from twisted.python import failure
 from twisted.internet import error, defer
 from twisted.internet.protocol import Protocol, ServerFactory
 from lbrynet.core.utils import is_valid_blobhash
-from lbrynet.core.Error import DownloadCanceledError, InvalidBlobHashError
+from lbrynet.core.Error import DownloadCanceledError, InvalidBlobHashError, NoSuchSDHash
 from lbrynet.core.StreamDescriptor import BlobStreamDescriptorReader
 from lbrynet.lbry_file.StreamDescriptor import save_sd_info
 from lbrynet.reflector.common import REFLECTOR_V1, REFLECTOR_V2
@@ -65,6 +65,41 @@ class ReflectorServer(Protocol):
             log.exception(err)
 
     @defer.inlineCallbacks
+    def check_head_blob_announce(self, stream_hash):
+        blob_infos = yield self.stream_info_manager.get_blobs_for_stream(stream_hash)
+        blob_hash, blob_num, blob_iv, blob_length = blob_infos[0]
+        if blob_hash in self.blob_manager.blobs:
+            head_blob = self.blob_manager.blobs[blob_hash]
+            if head_blob.get_is_verified():
+                should_announce = yield self.blob_manager.get_should_announce(blob_hash)
+                if should_announce == 0:
+                    yield self.blob_manager.set_should_announce(blob_hash, 1)
+                    log.info("Discovered previously completed head blob (%s), "
+                             "setting it to be announced", blob_hash[:8])
+        defer.returnValue(None)
+
+    @defer.inlineCallbacks
+    def check_sd_blob_announce(self, sd_hash):
+        if sd_hash in self.blob_manager.blobs:
+            sd_blob = self.blob_manager.blobs[sd_hash]
+            if sd_blob.get_is_verified():
+                should_announce = yield self.blob_manager.get_should_announce(sd_hash)
+                if should_announce == 0:
+                    yield self.blob_manager.set_should_announce(sd_hash, 1)
+                    log.info("Discovered previously completed sd blob (%s), "
+                             "setting it to be announced", sd_hash[:8])
+                    try:
+                        yield self.stream_info_manager.get_stream_hash_for_sd_hash(sd_hash)
+                    except NoSuchSDHash:
+                        log.info("Adding blobs to stream")
+                        sd_info = yield BlobStreamDescriptorReader(sd_blob).get_info()
+                        yield save_sd_info(self.stream_info_manager, sd_info)
+                        yield self.stream_info_manager.save_sd_blob_hash_to_stream(
+                            sd_info['stream_hash'],
+                            sd_hash)
+        defer.returnValue(None)
+
+    @defer.inlineCallbacks
     def _on_completed_blob(self, blob, response_key):
         should_announce = False
         if response_key == RECEIVED_SD_BLOB:
@@ -74,16 +109,29 @@ class ReflectorServer(Protocol):
                                                                        blob.blob_hash)
             should_announce = True
 
+            # if we already have the head blob, set it to be announced now that we know it's
+            # a head blob
+            d = self.check_head_blob_announce(sd_info['stream_hash'])
+
         else:
+            d = defer.succeed(None)
             stream_hash = yield self.stream_info_manager.get_stream_of_blob(blob.blob_hash)
             if stream_hash is not None:
                 blob_num = yield self.stream_info_manager._get_blob_num_by_hash(stream_hash,
                                                                                 blob.blob_hash)
                 if blob_num == 0:
                     should_announce = True
+                    sd_hashes = yield self.stream_info_manager.get_sd_blob_hashes_for_stream(
+                        stream_hash)
+
+                    # if we already have the sd blob, set it to be announced now that we know it's
+                    # a sd blob
+                    for sd_hash in sd_hashes:
+                        d.addCallback(lambda _: self.check_sd_blob_announce(sd_hash))
 
         yield self.blob_manager.blob_completed(blob, should_announce=should_announce)
         yield self.close_blob()
+        yield d
         log.info("Received %s", blob)
         yield self.send_response({response_key: True})
 
@@ -249,16 +297,29 @@ class ReflectorServer(Protocol):
             d = self.blob_finished_d
         return d
 
+    @defer.inlineCallbacks
     def get_descriptor_response(self, sd_blob):
         if sd_blob.get_is_verified():
-            d = defer.succeed({SEND_SD_BLOB: False})
-            d.addCallback(self.request_needed_blobs, sd_blob)
+            # if we already have the sd blob being offered, make sure we have it and the head blob
+            # marked as such for announcement now that we know it's an sd blob that we have.
+            yield self.check_sd_blob_announce(sd_blob.blob_hash)
+            try:
+                stream_hash = yield self.stream_info_manager.get_stream_hash_for_sd_hash(
+                    sd_blob.blob_hash)
+            except NoSuchSDHash:
+                sd_info = yield BlobStreamDescriptorReader(sd_blob).get_info()
+                stream_hash = sd_info['stream_hash']
+                yield save_sd_info(self.stream_info_manager, sd_info)
+                yield self.stream_info_manager.save_sd_blob_hash_to_stream(stream_hash,
+                                                                           sd_blob.blob_hash)
+            yield self.check_head_blob_announce(stream_hash)
+            response = yield self.request_needed_blobs({SEND_SD_BLOB: False}, sd_blob)
         else:
             self.incoming_blob = sd_blob
             self.receiving_blob = True
             self.handle_incoming_blob(RECEIVED_SD_BLOB)
-            d = defer.succeed({SEND_SD_BLOB: True})
-        return d
+            response = {SEND_SD_BLOB: True}
+        defer.returnValue(response)
 
     def request_needed_blobs(self, response, sd_blob):
         def _add_needed_blobs_to_response(needed_blobs):

--- a/tests/functional/test_reflector.py
+++ b/tests/functional/test_reflector.py
@@ -287,6 +287,78 @@ class TestReflector(unittest.TestCase):
         d.addCallback(lambda _: verify_data_on_reflector())
         return d
 
+    # test case when we reflect blob, and than that same blob
+    # is reflected as stream
+    def test_blob_reflect_and_stream(self):
+
+        def verify_blob_on_reflector():
+            check_blob_ds = []
+            for blob_hash, blob_size in self.expected_blobs:
+                check_blob_ds.append(verify_have_blob(blob_hash, blob_size))
+            return defer.DeferredList(check_blob_ds)
+
+        @defer.inlineCallbacks
+        def verify_stream_on_reflector():
+            # check stream_info_manager has all the right information
+
+            streams = yield self.server_stream_info_manager.get_all_streams()
+            self.assertEqual(1, len(streams))
+            self.assertEqual(self.stream_hash, streams[0])
+
+            blobs = yield self.server_stream_info_manager.get_blobs_for_stream(self.stream_hash)
+            blob_hashes = [b[0] for b in blobs if b[0] is not None]
+            expected_blob_hashes = [b[0] for b in self.expected_blobs[:-1] if b[0] is not None]
+            self.assertEqual(expected_blob_hashes, blob_hashes)
+            sd_hashes = yield self.server_stream_info_manager.get_sd_blob_hashes_for_stream(self.stream_hash)
+            self.assertEqual(1, len(sd_hashes))
+            expected_sd_hash = self.expected_blobs[-1][0]
+            self.assertEqual(self.sd_hash, sd_hashes[0])
+
+            # check should_announce blobs on blob_manager
+            blob_hashes = yield self.server_blob_manager._get_all_should_announce_blob_hashes()
+            self.assertEqual(2, len(blob_hashes))
+            self.assertTrue(self.sd_hash in blob_hashes)
+            self.assertTrue(expected_blob_hashes[0] in blob_hashes)
+
+        def verify_have_blob(blob_hash, blob_size):
+            d = self.server_blob_manager.get_blob(blob_hash)
+            d.addCallback(lambda blob: verify_blob_completed(blob, blob_size))
+            return d
+
+        def send_to_server_as_blobs(blob_hashes_to_send):
+            factory = reflector.BlobClientFactory(
+                self.session.blob_manager,
+                blob_hashes_to_send
+            )
+            factory.protocol_version = 0
+
+            from twisted.internet import reactor
+            reactor.connectTCP('localhost', self.port, factory)
+            return factory.finished_deferred
+
+        def send_to_server_as_stream(result):
+            fake_lbry_file = mocks.FakeLBRYFile(self.session.blob_manager,
+                                                self.stream_info_manager,
+                                                self.stream_hash)
+            factory = reflector.ClientFactory(fake_lbry_file)
+
+            from twisted.internet import reactor
+            reactor.connectTCP('localhost', self.port, factory)
+            return factory.finished_deferred
+
+
+        def verify_blob_completed(blob, blob_size):
+            self.assertTrue(blob.get_is_verified())
+            self.assertEqual(blob_size, blob.length)
+
+        # Modify this to change which blobs to send
+        blobs_to_send = self.expected_blobs
+
+        d = send_to_server_as_blobs([x[0] for x in self.expected_blobs])
+        d.addCallback(send_to_server_as_stream)
+        d.addCallback(lambda _: verify_blob_on_reflector())
+        d.addCallback(lambda _: verify_stream_on_reflector())
+        return d
 
 def iv_generator():
     iv = 0

--- a/tests/functional/test_reflector.py
+++ b/tests/functional/test_reflector.py
@@ -248,6 +248,15 @@ class TestReflector(unittest.TestCase):
         return d
 
     def test_blob_reflector_v1(self):
+        @defer.inlineCallbacks
+        def verify_stream_on_reflector():
+            # this protocol should not have any impact on stream info manager
+            streams = yield self.server_stream_info_manager.get_all_streams()
+            self.assertEqual(0, len(streams))
+            # there should be no should announce blobs here
+            blob_hashes = yield self.server_blob_manager._get_all_should_announce_blob_hashes()
+            self.assertEqual(0, len(blob_hashes))
+
         def verify_data_on_reflector():
             check_blob_ds = []
             for blob_hash, blob_size in self.expected_blobs:


### PR DESCRIPTION
When running lbrynet as a reflector cluster, it previously did not use the stream info manager at all when receiving streams from clients. Thus a reflector cluster had no knowledge of streams and would  not be able to use head blob announce. 

This adds stream info manager to the reflector server, and uses this to mark blobs as "should_announce" or not. test_reflectory.py has been modified to check if the stream info is handled properly and blobs are marked as "should_announce" if appropriate.


