### PR TITLE
[Testing] Turn head blob announce on for seeders and clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ at anytime.
   * Added option to announce head blob only if seeding
   * Added option to download by seeking head blob first
   * Added `include_tip_info` param to `transaction_list` API call
-  *
+  * Added ability for reflector to store stream information for head blob announce
 
 ### Fixed
   * Fixed uncaught error when shutting down after a failed daemon startup

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -251,11 +251,11 @@ ADJUSTABLE_SETTINGS = {
     'download_directory': (str, default_download_dir),
     'download_timeout': (int, 180),
     'is_generous_host': (bool, True),
-    'announce_head_blobs_only': (bool, False),
+    'announce_head_blobs_only': (bool, True),
     'known_dht_nodes': (list, DEFAULT_DHT_NODES, server_port),
     'lbryum_wallet_dir': (str, default_lbryum_dir),
     'max_connections_per_stream': (int, 5),
-    'seek_head_blob_first': (bool, False),
+    'seek_head_blob_first': (bool, True),
     # TODO: writing json on the cmd line is a pain, come up with a nicer
     # parser for this data structure. maybe 'USD:25'
     'max_key_fee': (json.loads, {'currency': 'USD', 'amount': 50.0}),

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -272,7 +272,7 @@ ADJUSTABLE_SETTINGS = {
     # at every auto_re_reflect_interval seconds, useful if initial reflect is unreliable
     'auto_re_reflect': (bool, True),
     'auto_re_reflect_interval': (int, 3600),
-    'reflector_servers': (list, [('reflector.lbry.io', 5566)], server_port),
+    'reflector_servers': (list, [('18.221.34.108', 5566)], server_port),
     'run_reflector_server': (bool, False),
     'sd_download_timeout': (int, 3),
     'share_usage_data': (bool, True),  # whether to share usage stats and diagnostic info with LBRY

--- a/lbrynet/core/BlobManager.py
+++ b/lbrynet/core/BlobManager.py
@@ -226,6 +226,14 @@ class DiskBlobManager(DHTHashSupplier):
         return d
 
     @rerun_if_locked
+    @defer.inlineCallbacks
+    def _get_all_should_announce_blob_hashes(self):
+        # return a list of blob hashes where should_announce is True
+        blob_hashes = yield self.db_conn.runQuery(
+            "select blob_hash from blobs where should_announce = 1")
+        defer.returnValue([d[0] for d in blob_hashes])
+
+    @rerun_if_locked
     def _get_all_verified_blob_hashes(self):
         d = self._get_all_blob_hashes()
 
@@ -255,5 +263,6 @@ class DiskBlobManager(DHTHashSupplier):
             "insert into upload values (null, ?, ?, ?, ?) ",
             (blob_hash, str(host), float(rate), ts))
         return d
+
 
 

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -317,7 +317,8 @@ class Daemon(AuthJSONRPCServer):
             if self.reflector_port is not None:
                 reflector_factory = reflector_server_factory(
                     self.session.peer_manager,
-                    self.session.blob_manager
+                    self.session.blob_manager,
+                    self.stream_info_manager
                 )
                 try:
                     self.reflector_server_port = reactor.listenTCP(self.reflector_port,


### PR DESCRIPTION
This changes the config file to turn head blob announce on for seeders and clients. Additionally it changes reflector to a test "head blob announce" prism instance. For testing only.

Also merges https://github.com/lbryio/lbry/pull/872