### PR TITLE
Quick Fix Google Finance BTC Feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ at anytime.
 
 ### Fixed
   * Fixed uncaught error when shutting down after a failed daemon startup
-  * Fixed Google Finance BTCUSD Feed Link
+  * Fixed Google Finance Feed Link
   *
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
 
 ### Fixed
   * Fixed uncaught error when shutting down after a failed daemon startup
+  * Fixed Google Finance BTCUSD Feed Link
   *
 
 ### Deprecated

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -135,7 +135,7 @@ class GoogleBTCFeed(MarketFeed):
             self,
             "USDBTC",
             "Coinbase via Google finance",
-            'http://finance.google.com/finance/info',
+            'http://finance.google.com/finance',
             {'client':'ig', 'q':'CURRENCY:USDBTC'},
             COINBASE_FEE
         )


### PR DESCRIPTION
fix for issue https://github.com/lbryio/lbry/issues/890
seems https://www.google.com/finance/info?q=CURRENCY:BTC doesnt exist anymore and instead dropped the /info from the link and the url works