### PR TITLE
Turn on head blob seek for clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ at anytime.
 ### Added
   * Added option to announce head blob only if seeding
   * Added option to download by seeking head blob first
+  * By default, option to download seeking head blob first is turned on
   * Added `include_tip_info` param to `transaction_list` API call
   *
 

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -255,7 +255,7 @@ ADJUSTABLE_SETTINGS = {
     'known_dht_nodes': (list, DEFAULT_DHT_NODES, server_port),
     'lbryum_wallet_dir': (str, default_lbryum_dir),
     'max_connections_per_stream': (int, 5),
-    'seek_head_blob_first': (bool, False),
+    'seek_head_blob_first': (bool, True),
     # TODO: writing json on the cmd line is a pain, come up with a nicer
     # parser for this data structure. maybe 'USD:25'
     'max_key_fee': (json.loads, {'currency': 'USD', 'amount': 50.0}),


### PR DESCRIPTION
This turns on "head blob seek" for clients downloading from the lbry network. 

Since "head blob announce" is not enabled for reflector, or any other seeders, this should not affect clients since they can fallback to downloading by blobs. 