### PR TITLE
Update tip history for change in lbryum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ at anytime.
 
 ### Fixed
   * Fixed `transaction_list` doc string
+  * Fixed ([in lbryum](https://github.com/lbryio/lbryum/pull/156)) batched queries responsible for making transaction and tip histories slow
   *
 
 ### Deprecated

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -1457,7 +1457,9 @@ class LBRYumWallet(Wallet):
         return self._run_cmd_as_defer_to_thread('getclaimtrie')
 
     def _get_history(self, include_tip_info):
-        return self._run_cmd_as_defer_succeed('history', include_tip_info)
+        if include_tip_info:
+            return self._run_cmd_as_defer_succeed('tiphistory')
+        return self._run_cmd_as_defer_succeed('claimhistory')
 
     def _address_is_mine(self, address):
         return self._run_cmd_as_defer_succeed('ismine', address)


### PR DESCRIPTION
Fixed inefficient batch queries in lbryum responsible for making transaction and tip histories slow

goes with https://github.com/lbryio/lbryum/pull/156