### PR TITLE
Fix blob reader closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ at anytime.
 ### Fixed
   * Fixed handling cancelled blob and availability requests
   * Fixed redundant blob requests to a peer
+  * Fixed https://github.com/lbryio/lbry/issues/923
 
 ### Deprecated
   * Deprecated `blob_announce_all` JSONRPC command. Use `blob_announce` instead.

--- a/lbrynet/blob/blob_file.py
+++ b/lbrynet/blob/blob_file.py
@@ -9,7 +9,7 @@ from lbrynet import conf
 from lbrynet.core.Error import DownloadCanceledError, InvalidDataError, InvalidBlobHashError
 from lbrynet.core.utils import is_valid_blobhash
 from lbrynet.blob.writer import HashBlobWriter
-from lbrynet.blob.reader import HashBlobReader
+from lbrynet.blob.reader import HashBlobReader, HashBlobReader_v0
 
 
 log = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ class BlobFile(object):
             return args[0]
 
         file_sender = FileSender()
-        reader = HashBlobReader(write_func)
+        reader = HashBlobReader_v0(write_func)
         file_handle = self.open_for_reading()
         if file_handle is not None:
             d = file_sender.beginFileTransfer(file_handle, reader)

--- a/lbrynet/blob/blob_file.py
+++ b/lbrynet/blob/blob_file.py
@@ -79,13 +79,9 @@ class BlobFile(object):
         finished
         """
         if self._verified is True:
-            try:
-                reader = HashBlobReader(self.file_path, self.reader_finished)
-                self.readers += 1
-                return reader
-            except IOError:
-                log.exception('Failed to open %s', self.file_path)
-                reader.close()
+            reader = HashBlobReader(self.file_path, self.reader_finished)
+            self.readers += 1
+            return reader
         return None
 
     def delete(self):

--- a/lbrynet/blob/blob_file.py
+++ b/lbrynet/blob/blob_file.py
@@ -144,6 +144,10 @@ class BlobFile(object):
         return False
 
     def read(self, write_func):
+        """
+        This function is only used in StreamBlobDecryptor
+        and should be deprecated in favor of open_for_reading()
+        """
         def close_self(*args):
             self.close_read_handle(file_handle)
             return args[0]
@@ -157,6 +161,15 @@ class BlobFile(object):
         else:
             d = defer.fail(IOError("Could not read the blob"))
         return d
+
+    def close_read_handle(self, file_handle):
+        """
+        This function is only used in StreamBlobDecryptor
+        and should be deprecated in favor of open_for_reading()
+        """
+        if file_handle is not None:
+            file_handle.close()
+            self.readers -= 1
 
     def reader_finished(self, reader):
         self.readers -= 1
@@ -205,11 +218,6 @@ class BlobFile(object):
             d = defer.succeed(True)
         d.addBoth(lambda _: writer.close_handle())
         return d
-
-    def close_read_handle(self, file_handle):
-        if file_handle is not None:
-            file_handle.close()
-            self.readers -= 1
 
     @defer.inlineCallbacks
     def _save_verified_blob(self, writer):

--- a/lbrynet/blob/reader.py
+++ b/lbrynet/blob/reader.py
@@ -6,6 +6,10 @@ log = logging.getLogger(__name__)
 
 
 class HashBlobReader_v0(object):
+    """
+    This is a class that is only used in StreamBlobDecryptor
+    and should be deprecated
+    """
     implements(interfaces.IConsumer)
 
     def __init__(self, write_func):
@@ -30,6 +34,10 @@ class HashBlobReader_v0(object):
             reactor.callLater(0, self.producer.resumeProducing)
 
 class HashBlobReader(object):
+    """
+    This is a file like reader class that supports
+    read(size) and close()
+    """
     def __init__(self, file_path, finished_cb):
         self.finished_cb = finished_cb
         self.finished_cb_d = None

--- a/lbrynet/blob/reader.py
+++ b/lbrynet/blob/reader.py
@@ -5,7 +5,7 @@ from zope.interface import implements
 log = logging.getLogger(__name__)
 
 
-class HashBlobReader(object):
+class HashBlobReader_v0(object):
     implements(interfaces.IConsumer)
 
     def __init__(self, write_func):
@@ -28,3 +28,24 @@ class HashBlobReader(object):
         self.write_func(data)
         if self.streaming is False:
             reactor.callLater(0, self.producer.resumeProducing)
+
+class HashBlobReader(object):
+    def __init__(self, file_path, finished_cb):
+        self.finished_cb = finished_cb
+        self.finished_cb_d = None
+        self.read_handle = open(file_path, 'rb')
+
+    def __del__(self):
+        self.close()
+
+    def read(self, size=-1):
+        return self.read_handle.read(size)
+
+    def close(self):
+        # if we've already closed and called finished_cb, do nothing
+        if self.finished_cb_d is not None:
+            return
+        self.read_handle.close()
+        self.finished_cb_d = self.finished_cb(self)
+
+

--- a/lbrynet/core/StreamDescriptor.py
+++ b/lbrynet/core/StreamDescriptor.py
@@ -55,7 +55,7 @@ class BlobStreamDescriptorReader(StreamDescriptorReader):
             f = self.blob.open_for_reading()
             if f is not None:
                 raw_data = f.read()
-                self.blob.close_read_handle(f)
+                f.close()
                 return raw_data
             else:
                 raise ValueError("Could not open the blob for reading")

--- a/lbrynet/core/server/BlobRequestHandler.py
+++ b/lbrynet/core/server/BlobRequestHandler.py
@@ -89,7 +89,7 @@ class BlobRequestHandler(object):
 
     def cancel_send(self, err):
         if self.currently_uploading is not None:
-            self.currently_uploading.close_read_handle(self.read_handle)
+            self.read_handle.close()
         self.read_handle = None
         self.currently_uploading = None
         return err
@@ -225,7 +225,7 @@ class BlobRequestHandler(object):
 
         def set_not_uploading(reason=None):
             if self.currently_uploading is not None:
-                self.currently_uploading.close_read_handle(self.read_handle)
+                self.read_handle.close()
                 self.read_handle = None
                 self.currently_uploading = None
             self.file_sender = None

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -2375,7 +2375,7 @@ class Daemon(AuthJSONRPCServer):
         if encoding and encoding in decoders:
             blob_file = blob.open_for_reading()
             result = decoders[encoding](blob_file.read())
-            blob.close_read_handle(blob_file)
+            blob_file.close()
         else:
             result = "Downloaded blob %s" % blob_hash
 
@@ -2624,7 +2624,7 @@ class Daemon(AuthJSONRPCServer):
         def read_sd_blob(sd_blob):
             sd_blob_file = sd_blob.open_for_reading()
             decoded_sd_blob = json.loads(sd_blob_file.read())
-            sd_blob.close_read_handle(sd_blob_file)
+            sd_blob_file.close()
             return decoded_sd_blob
 
         resolved_result = yield self.session.wallet.resolve(uri)

--- a/lbrynet/reflector/client/blob.py
+++ b/lbrynet/reflector/client/blob.py
@@ -94,7 +94,7 @@ class BlobReflectorClient(Protocol):
 
     def set_not_uploading(self):
         if self.next_blob_to_send is not None:
-            self.next_blob_to_send.close_read_handle(self.read_handle)
+            self.read_handle.close()
             self.read_handle = None
             self.next_blob_to_send = None
         self.file_sender = None
@@ -105,6 +105,7 @@ class BlobReflectorClient(Protocol):
         assert self.read_handle is not None, \
             "self.read_handle was None when trying to start the transfer"
         d = self.file_sender.beginFileTransfer(self.read_handle, self)
+        d.addCallback(lambda _: self.read_handle.close())
         return d
 
     def handle_handshake_response(self, response_dict):

--- a/lbrynet/reflector/client/client.py
+++ b/lbrynet/reflector/client/client.py
@@ -179,7 +179,7 @@ class EncryptedFileReflectorClient(Protocol):
     def set_not_uploading(self):
         if self.next_blob_to_send is not None:
             log.debug("Close %s", self.next_blob_to_send)
-            self.next_blob_to_send.close_read_handle(self.read_handle)
+            self.read_handle.close()
             self.read_handle = None
             self.next_blob_to_send = None
         if self.file_sender is not None:

--- a/lbrynet/reflector/client/client.py
+++ b/lbrynet/reflector/client/client.py
@@ -191,6 +191,7 @@ class EncryptedFileReflectorClient(Protocol):
         assert self.read_handle is not None, \
             "self.read_handle was None when trying to start the transfer"
         d = self.file_sender.beginFileTransfer(self.read_handle, self)
+        d.addCallback(lambda _: self.read_handle.close())
         return d
 
     def handle_handshake_response(self, response_dict):


### PR DESCRIPTION
Fix for https://github.com/lbryio/lbry/issues/923 and also some continuing work to improve the blob classes (https://github.com/lbryio/lbry/pull/898)

Blob file opened for reading ( BlobFile.open_for_reading() ) was not being closed after file transfer , thus during client reflection, too many blob files would be opened. Commit a4ea49c fixes this. 

This kind of mistake could be easily made since blob files opened for reading had to be closed by calling BlobFile.close_read_handle(handle) . We can now just call handle.close() to close the blob files. 







