### PR TITLE
Reflector client bug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ at anytime.
   * Fixed redundant blob requests to a peer
   * Fixed https://github.com/lbryio/lbry/issues/923
   * Fixed concurrent reflects opening too many files
+  * Fixed cases when reflecting would fail on error conditions
 
 ### Deprecated
   * Deprecated `blob_announce_all` JSONRPC command. Use `blob_announce` instead.

--- a/lbrynet/reflector/client/client.py
+++ b/lbrynet/reflector/client/client.py
@@ -124,8 +124,8 @@ class EncryptedFileReflectorClient(Protocol):
 
     def set_blobs_to_send(self, blobs_to_send):
         for blob in blobs_to_send:
-            if blob not in self.blob_hashes_to_send:
-                self.blob_hashes_to_send.append(blob)
+            if blob.blob_hash not in self.blob_hashes_to_send:
+                self.blob_hashes_to_send.append(blob.blob_hash)
 
     def get_blobs_to_send(self):
         def _show_missing_blobs(filtered):
@@ -308,9 +308,10 @@ class EncryptedFileReflectorClient(Protocol):
             return d
         elif self.blob_hashes_to_send:
             # open the next blob to send
-            blob = self.blob_hashes_to_send[0]
+            blob_hash = self.blob_hashes_to_send[0]
             self.blob_hashes_to_send = self.blob_hashes_to_send[1:]
-            d = self.open_blob_for_reading(blob)
+            d = self.blob_manager.get_blob(blob_hash)
+            d.addCallback(self.open_blob_for_reading)
             d.addCallbacks(lambda _: self.send_blob_info(),
                            lambda err: self.skip_missing_blob(err, blob.blob_hash))
             return d


### PR DESCRIPTION
Fix inconsistency in how EncryptedFileReflectorClient.blob_hashes_to_send is used, preventing proper reflecting.

Some functions put blob hashes in EncryptedFileReflectorClient.blob_hahes_to_send , others put BlobFile's in them. EncryptedFileReflectorClient.open_blob_for_reading() expected BlobFiles so if it received blob hashes, it errored out. 

I fixed it so that EncryptedFileReflectorClient.blob_hashes_to_send always contains blob hashes. And EncryptedFileReflectorClient.open_blob_for_reading() would always be fed BlobFiles.

This looks like a bug that's been here forever.. It looks like it should have prevented any partial reflects from working out properly. 