### PR TITLE
Fix to not reflect all the files at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
   * Fixed handling cancelled blob and availability requests
   * Fixed redundant blob requests to a peer
   * Fixed https://github.com/lbryio/lbry/issues/923
+  * Fixed concurrent reflects opening too many files
 
 ### Deprecated
   * Deprecated `blob_announce_all` JSONRPC command. Use `blob_announce` instead.

--- a/lbrynet/reflector/client/client.py
+++ b/lbrynet/reflector/client/client.py
@@ -71,6 +71,9 @@ class EncryptedFileReflectorClient(Protocol):
             d.addErrback(self.response_failure_handler)
 
     def connectionLost(self, reason):
+        # make sure blob file readers get closed
+        self.set_not_uploading()
+
         if reason.check(error.ConnectionDone):
             if not self.needed_blobs:
                 log.info("Reflector has all blobs for %s (%s)",


### PR DESCRIPTION
If you have a lot of files, EncryptedFileManager tries to reflect all the files at once, which will likely cause you to hit your open file limit (default on ubuntu is 1024, so if you have 1000 files, you will likely hit the limit), and will also open up a lot of connections to the reflector server.  This uses DeferredSemaphore, see: https://patrickmn.com/software/using-twisteds-deferred-semaphore/ so that only 5 files are reflected at a time. 

Also it was found the reflector client would not always close an open read handle when connection was closed. Also resulting in a lot of open files. Make sure to do this. 