### PR TITLE
Add more session info related to blob announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ at anytime.
   * Refactored and pruned blob related classes into `lbrynet.blobs`
   * Changed several `assert`s to raise more useful errors
   * Added ability for reflector to store stream information for head blob announce
+  * Added blob announcement information to API call status with session flag
 
 ### Removed
   * Removed `TempBlobFile`

--- a/lbrynet/core/BlobManager.py
+++ b/lbrynet/core/BlobManager.py
@@ -88,6 +88,9 @@ class DiskBlobManager(DHTHashSupplier):
     def hashes_to_announce(self):
         return self._get_blobs_to_announce()
 
+    def count_should_announce_blobs(self):
+        return self._count_should_announce_blobs()
+
     def set_should_announce(self, blob_hash, should_announce):
         if blob_hash in self.blobs:
             blob = self.blobs[blob_hash]
@@ -213,6 +216,12 @@ class DiskBlobManager(DHTHashSupplier):
     def _should_announce(self, blob_hash):
         result = yield self.db_conn.runQuery("select should_announce from blobs where blob_hash=?",
                                              (blob_hash,))
+        defer.returnValue(result[0][0])
+
+    @rerun_if_locked
+    @defer.inlineCallbacks
+    def _count_should_announce_blobs(self):
+        result = yield self.db_conn.runQuery("select count(*) from blobs where should_announce=1")
         defer.returnValue(result[0][0])
 
     @defer.inlineCallbacks

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1029,6 +1029,8 @@ class Daemon(AuthJSONRPCServer):
                     'session_status': {
                         'managed_blobs': count of blobs in the blob manager,
                         'managed_streams': count of streams in the file manager
+                        'announce_queue_size': number of blobs currently queued to be announced
+                        'should_announce_blobs': number of blobs that should be announced
                     }
 
                 If given the dht status option:
@@ -1077,9 +1079,13 @@ class Daemon(AuthJSONRPCServer):
         }
         if session_status:
             blobs = yield self.session.blob_manager.get_all_verified_blobs()
+            announce_queue_size = self.session.hash_announcer.hash_queue_size()
+            should_announce_blobs = yield self.session.blob_manager.count_should_announce_blobs()
             response['session_status'] = {
                 'managed_blobs': len(blobs),
                 'managed_streams': len(self.lbry_file_manager.lbry_files),
+                'announce_queue_size': announce_queue_size,
+                'should_announce_blobs': should_announce_blobs,
             }
         if dht_status:
             response['dht_status'] = self.session.dht_node.get_bandwidth_stats()


### PR DESCRIPTION
When calling jsonrpc_status() with session (-s) flag, add some additional information about blob announcements.

'announce_queue_size' shows the number of blobs currently queued to be announced
'should_announce_blobs" shows the number of blobs that are marked as should_announce (used in head blob announce)

This will be useful for quickly debugging nodes with a large amount of blobs on it (whether it has some backlog in announcement or not) 

Also added unit tests for should_announce function in blob manager