### PR TITLE
Bump jsonschema version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ at anytime.
   *
 
 ### Changed
-  *
+  * Bumped jsonschema requirement to 2.6.0
   *
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ GitPython==2.1.3
 gmpy==1.17
 jsonrpc==1.2
 jsonrpclib==0.1.7
-jsonschema==2.5.1
+jsonschema==2.6.0
 git+https://github.com/lbryio/lbryschema.git@v0.0.12#egg=lbryschema
 git+https://github.com/lbryio/lbryum.git@v3.1.9#egg=lbryum
 miniupnpc==1.9


### PR DESCRIPTION
latest jsonschema version is 2.6.0 https://pypi.python.org/pypi/jsonschema, 
Chanelog: https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst

Also for lbryschema and lbryum: 

https://github.com/lbryio/lbryschema/pull/30
https://github.com/lbryio/lbryum/pull/163

Note: the travis integration test here fails because it tries to start up the daemon but can't because lbryschema and lbryum has set requirements to tagged jsonschema version 2.5.1 , once above two is merged, test should pass