### PR TITLE
Added redundant market feed (continued)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ at anytime.
   *
 
 ### Added
-  *
+  * Added redundant API server for currency conversion
   *
 
 ### Removed

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -71,7 +71,7 @@ class MarketFeed(object):
         return defer.succeed(from_amount / (1.0 - self.fee))
 
     def _save_price(self, price):
-        log.debug("Saving price update %f for %s" % (price, self.market))
+        log.debug("Saving price update %f for %s from %s" % (price, self.market, self.name))
         self.rate = ExchangeRate(self.market, price, int(time.time()))
 
     def _log_error(self, err):

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -46,11 +46,9 @@ class MarketFeed(object):
         self._updater = LoopingCall(self._update_price)
         self._online = True
 
-    @property
     def rate_is_initialized(self):
         return self.rate is not None
 
-    @property
     def is_online(self):
         return self._online
 
@@ -225,11 +223,11 @@ class ExchangeRateManager(object):
             return amount
 
         for market in self.market_feeds:
-            if (market.rate_is_initialized and market.is_online and
+            if (market.rate_is_initialized() and market.is_online() and
                 market.rate.currency_pair == (from_currency, to_currency)):
                 return amount * market.rate.spot
         for market in self.market_feeds:
-            if (market.rate_is_initialized and market.is_online and
+            if (market.rate_is_initialized() and market.is_online() and
                 market.rate.currency_pair[0] == from_currency):
                 return self.convert_currency(
                     market.rate.currency_pair[1], to_currency, amount * market.rate.spot)

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -5,7 +5,6 @@ import json
 from twisted.internet import defer, threads
 from twisted.internet.task import LoopingCall
 
-from lbrynet import conf
 from lbrynet.core.Error import InvalidExchangeRateResponse
 
 log = logging.getLogger(__name__)
@@ -102,7 +101,7 @@ class BittrexFeed(MarketFeed):
             self,
             "BTCLBC",
             "Bittrex",
-            conf.settings['bittrex_feed'],
+            "https://bittrex.com/api/v1.1/public/getmarkethistory",
             {'market': 'BTC-LBC', 'count': 50},
             BITTREX_FEE
         )
@@ -223,7 +222,7 @@ def get_default_market_feed(currency_pair):
 class ExchangeRateManager(object):
     def __init__(self):
         self.market_feeds = [
-           LBRYioBTCFeed(), LBRYioFeed(), CryptonatorBTCFeed(), CryptonatorFeed()]
+           LBRYioBTCFeed(), LBRYioFeed(), BittrexFeed(), CryptonatorBTCFeed(), CryptonatorFeed()]
 
     def start(self):
         log.info("Starting exchange rate manager")

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -203,20 +203,6 @@ class CryptonatorFeed(MarketFeed):
         return defer.succeed(float(json_response['ticker']['price']))
 
 
-def get_default_market_feed(currency_pair):
-    currencies = None
-    if isinstance(currency_pair, str):
-        currencies = (currency_pair[0:3], currency_pair[3:6])
-    elif isinstance(currency_pair, tuple):
-        currencies = currency_pair
-    assert currencies is not None
-
-    if currencies == ("USD", "BTC"):
-        return LBRYioBTCFeed()
-    elif currencies == ("BTC", "LBC"):
-        return LBRYioFeed()
-
-
 class ExchangeRateManager(object):
     def __init__(self):
         self.market_feeds = [

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -173,9 +173,12 @@ class CryptonatorBTCFeed(MarketFeed):
         )
 
     def _handle_response(self, response):
-        json_response = json.loads(response)
-        if 'ticker' not in json_response or 'success' not in json_response or \
-                        json_response['success'] is not True:
+        try:
+            json_response = json.loads(response)
+        except ValueError:
+            raise InvalidExchangeRateResponse(self.name, "invalid rate response : %s" % response)
+        if 'ticker' not in json_response or len(json_response['ticker']) == 0 or \
+                        'success' not in json_response or json_response['success'] is not True:
             raise InvalidExchangeRateResponse(self.name, 'result not found')
         return defer.succeed(float(json_response['ticker']['price']))
 
@@ -193,9 +196,12 @@ class CryptonatorFeed(MarketFeed):
         )
 
     def _handle_response(self, response):
-        json_response = json.loads(response)
-        if 'ticker' not in json_response or 'success' not in json_response or \
-                        json_response['success'] is not True:
+        try:
+            json_response = json.loads(response)
+        except ValueError:
+            raise InvalidExchangeRateResponse(self.name, "invalid rate response : %s" % response)
+        if 'ticker' not in json_response or len(json_response['ticker']) == 0 or \
+                        'success' not in json_response or json_response['success'] is not True:
             raise InvalidExchangeRateResponse(self.name, 'result not found')
         return defer.succeed(float(json_response['ticker']['price']))
 

--- a/lbrynet/daemon/ExchangeRateManager.py
+++ b/lbrynet/daemon/ExchangeRateManager.py
@@ -45,14 +45,23 @@ class MarketFeed(object):
         self.fee = fee
         self.rate = None
         self._updater = LoopingCall(self._update_price)
+        self._online = True
 
     @property
     def rate_is_initialized(self):
         return self.rate is not None
 
+    @property
+    def is_online(self):
+        return self._online
+
     def _make_request(self):
         r = requests.get(self.url, self.params, timeout=self.REQUESTS_TIMEOUT)
-        return r.text
+        if r.status_code == 200:
+            self._online = True
+            return r.text
+        self._online = False
+        return ""
 
     def _handle_response(self, response):
         return NotImplementedError
@@ -66,7 +75,8 @@ class MarketFeed(object):
         self.rate = ExchangeRate(self.market, price, int(time.time()))
 
     def _log_error(self, err):
-        log.warning("There was a problem updating %s exchange rate information from %s\n%s",
+        log.warning(
+            "There was a problem updating %s exchange rate information from %s: %s",
             self.market, self.name, err)
 
     def _update_price(self):
@@ -151,6 +161,45 @@ class LBRYioBTCFeed(MarketFeed):
         return defer.succeed(1.0 / json_response['data']['btc_usd'])
 
 
+class CryptonatorBTCFeed(MarketFeed):
+    def __init__(self):
+        MarketFeed.__init__(
+            self,
+            "USDBTC",
+            "cryptonator.com",
+            "https://api.cryptonator.com/api/ticker/usd-btc",
+            {},
+            0.0,
+        )
+
+    def _handle_response(self, response):
+        json_response = json.loads(response)
+        if 'ticker' not in json_response or 'success' not in json_response or \
+                        json_response['success'] is not True:
+            raise InvalidExchangeRateResponse(self.name, 'result not found')
+        return defer.succeed(float(json_response['ticker']['price']))
+
+
+
+class CryptonatorFeed(MarketFeed):
+    def __init__(self):
+        MarketFeed.__init__(
+            self,
+            "BTCLBC",
+            "cryptonator.com",
+            "https://api.cryptonator.com/api/ticker/btc-lbc",
+            {},
+            0.0,
+        )
+
+    def _handle_response(self, response):
+        json_response = json.loads(response)
+        if 'ticker' not in json_response or 'success' not in json_response or \
+                        json_response['success'] is not True:
+            raise InvalidExchangeRateResponse(self.name, 'result not found')
+        return defer.succeed(float(json_response['ticker']['price']))
+
+
 def get_default_market_feed(currency_pair):
     currencies = None
     if isinstance(currency_pair, str):
@@ -168,7 +217,7 @@ def get_default_market_feed(currency_pair):
 class ExchangeRateManager(object):
     def __init__(self):
         self.market_feeds = [
-            get_default_market_feed(currency_pair) for currency_pair in CURRENCY_PAIRS]
+           LBRYioBTCFeed(), LBRYioFeed(), CryptonatorBTCFeed(), CryptonatorFeed()]
 
     def start(self):
         log.info("Starting exchange rate manager")
@@ -185,12 +234,13 @@ class ExchangeRateManager(object):
         log.info("Converting %f %s to %s, rates: %s" % (amount, from_currency, to_currency, rates))
         if from_currency == to_currency:
             return amount
+
         for market in self.market_feeds:
-            if (market.rate_is_initialized and
+            if (market.rate_is_initialized and market.is_online and
                 market.rate.currency_pair == (from_currency, to_currency)):
                 return amount * market.rate.spot
         for market in self.market_feeds:
-            if (market.rate_is_initialized and
+            if (market.rate_is_initialized and market.is_online and
                 market.rate.currency_pair[0] == from_currency):
                 return self.convert_currency(
                     market.rate.currency_pair[1], to_currency, amount * market.rate.spot)

--- a/lbrynet/tests/unit/lbrynet_daemon/test_ExchangeRateManager.py
+++ b/lbrynet/tests/unit/lbrynet_daemon/test_ExchangeRateManager.py
@@ -119,3 +119,43 @@ class LBRYioBTCFeedTest(unittest.TestCase):
         response = '{"success":true,"result":[]}'
         with self.assertRaises(InvalidExchangeRateResponse):
             out = yield feed._handle_response(response)
+
+class CryptonatorFeedTest(unittest.TestCase):
+    @defer.inlineCallbacks
+    def test_handle_response(self):
+        feed = ExchangeRateManager.CryptonatorFeed()
+
+        response = '{\"ticker\":{\"base\":\"BTC\",\"target\":\"LBC\",\"price\":\"23657.44026496\"' \
+                   ',\"volume\":\"\",\"change\":\"-5.59806916\"},\"timestamp\":1507470422' \
+                   ',\"success\":true,\"error\":\"\"}'
+        out = yield feed._handle_response(response)
+        expected = 23657.44026496
+        self.assertEqual(expected, out)
+
+        response = '{}'
+        with self.assertRaises(InvalidExchangeRateResponse):
+            out = yield feed._handle_response(response)
+
+        response = '{"success":true,"ticker":{}}'
+        with self.assertRaises(InvalidExchangeRateResponse):
+            out = yield feed._handle_response(response)
+
+class CryptonatorBTCFeedTest(unittest.TestCase):
+    @defer.inlineCallbacks
+    def test_handle_response(self):
+        feed = ExchangeRateManager.CryptonatorBTCFeed()
+
+        response = '{\"ticker\":{\"base\":\"USD\",\"target\":\"BTC\",\"price\":\"0.00022123\",' \
+                   '\"volume\":\"\",\"change\":\"-0.00000259\"},\"timestamp\":1507471141,' \
+                   '\"success\":true,\"error\":\"\"}'
+        out = yield feed._handle_response(response)
+        expected = 0.00022123
+        self.assertEqual(expected, out)
+
+        response = '{}'
+        with self.assertRaises(InvalidExchangeRateResponse):
+            out = yield feed._handle_response(response)
+
+        response = '{"success":true,"ticker":{}}'
+        with self.assertRaises(InvalidExchangeRateResponse):
+            out = yield feed._handle_response(response)

--- a/lbrynet/tests/unit/lbrynet_daemon/test_ExchangeRateManager.py
+++ b/lbrynet/tests/unit/lbrynet_daemon/test_ExchangeRateManager.py
@@ -159,3 +159,28 @@ class CryptonatorBTCFeedTest(unittest.TestCase):
         response = '{"success":true,"ticker":{}}'
         with self.assertRaises(InvalidExchangeRateResponse):
             out = yield feed._handle_response(response)
+
+
+class BittrexFeedTest(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def test_handle_response(self):
+        feed = ExchangeRateManager.BittrexFeed()
+
+        response = '{"success":true,"message":"","result":[{"Id":6902471,"TimeStamp":"2017-02-2'\
+        '7T23:41:52.213","Quantity":56.12611239,"Price":0.00001621,"Total":0.00090980,"FillType":"'\
+        'PARTIAL_FILL","OrderType":"SELL"},{"Id":6902403,"TimeStamp":"2017-02-27T23:31:40.463","Qu'\
+        'antity":430.99988180,"Price":0.00001592,"Total":0.00686151,"FillType":"PARTIAL_FILL","Ord'\
+        'erType":"SELL"}]}'
+        out = yield feed._handle_response(response)
+        expected = 1.0 / ((0.00090980+0.00686151) / (56.12611239+430.99988180))
+        self.assertEqual(expected, out)
+
+        response = '{}'
+        with self.assertRaises(InvalidExchangeRateResponse):
+            out = yield feed._handle_response(response)
+
+        response = '{"success":true,"result":[]}'
+        with self.assertRaises(InvalidExchangeRateResponse):
+            out = yield feed._handle_response(response)
+


### PR DESCRIPTION
Reviewed and made some changes on top of https://github.com/lbryio/lbry/pull/915 by mirgee , which adds ExchangeRateManager capability to have fail over feeds so if one feed fails it can use another. Cryptonator was added as a back up feed.

I added also BittrexFeed as a back up feed, and re-added the unit test for it which was removed some patches ago. 

I also adjusted the detection of if a feed is detected to be online or not. mirgee set this variable in the _make_request function when requests.get() returned a response with status code that is not a success. However this doesn't handle the case when requests.get() throws an exception due to the end point not being available, or if parsing of the requests fail because they changed the API. We now set a feed to be offline in the errback so any exception while trying to get the feed will set the feed to be offline.

fixes https://github.com/lbryio/lbry/issues/892