### PR TITLE
DHT connectivity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ at anytime.
   * Retry announcing a blob up to three times if no peers store the announcement
   * Return storing peer information from the hash announcer after finishing an announce call
   * Convert `DHTHashAnnouncer` and `Node` manage functions to `LoopingCall`s.
+  * Restore previous dht contacts and node state on startup
 
 ### Added
   * Added `wallet_prefill_addresses` command, which distributes credits to multiple addresses
+  * Added `JSONFileDataStore` to persist dht node state and contacts
   *
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
   * Fixed lbryid length validation
   * Fixed an old print statement that polluted logs
   * Fixed rpc id length for dht requests
+  * Fixed a few old print statements that polluted logs
   * Fixed handling error from dht clients with old ping method
 
 ### Deprecated
@@ -36,11 +37,15 @@ at anytime.
   * Return storing peer information from the hash announcer after finishing an announce call
   * Convert `DHTHashAnnouncer` and `Node` manage functions to `LoopingCall`s.
   * Restore previous dht contacts and node state on startup
+  * Filter dht queries from unreachable peers
+  * Check dht peers requesting to store can be contacted before accepting
+  * Use `pingback` to check connectivity on startup, don't try to send `store` queries if this fails
+  * Improved logging of dht errors and non-typical behavior
 
 ### Added
   * Added `wallet_prefill_addresses` command, which distributes credits to multiple addresses
   * Added `JSONFileDataStore` to persist dht node state and contacts
-  *
+  * Added `pingback` dht method to test connectivity
 
 ### Removed
   *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
   * Fixed lbryid length validation
   * Fixed an old print statement that polluted logs
   * Fixed rpc id length for dht requests
+  * Fixed handling error from dht clients with old ping method
 
 ### Deprecated
   *
@@ -30,7 +31,11 @@ at anytime.
   * Detect a UPnP redirect that didn't get cleaned up on a previous run and use it
   * Bumped jsonschema requirement to 2.6.0
   * Refactor some assert statements to accommodate the PYTHONOPTIMIZE flag set for Android.
-  
+  * Refactor several dht internals to inlineCallbacks
+  * Retry announcing a blob up to three times if no peers store the announcement
+  * Return storing peer information from the hash announcer after finishing an announce call
+  * Convert `DHTHashAnnouncer` and `Node` manage functions to `LoopingCall`s.
+
 ### Added
   * Added `wallet_prefill_addresses` command, which distributes credits to multiple addresses
   *

--- a/lbrynet/core/Session.py
+++ b/lbrynet/core/Session.py
@@ -274,7 +274,8 @@ class Session(object):
         self.dht_node = self.dht_node_class(
             udpPort=self.dht_node_port,
             node_id=self.node_id,
-            externalIP=self.external_ip
+            externalIP=self.external_ip,
+            dataDirectory=self.db_dir
         )
         self.peer_finder = DHTPeerFinder(self.dht_node, self.peer_manager)
         if self.hash_announcer is None:

--- a/lbrynet/core/server/DHTHashAnnouncer.py
+++ b/lbrynet/core/server/DHTHashAnnouncer.py
@@ -2,8 +2,9 @@ import binascii
 import collections
 import logging
 import time
+import datetime
 
-from twisted.internet import defer
+from twisted.internet import defer, task
 from lbrynet.core import utils
 
 log = logging.getLogger(__name__)
@@ -14,6 +15,8 @@ class DHTHashAnnouncer(object):
     CONCURRENT_ANNOUNCERS = 5
 
     """This class announces to the DHT that this peer has certain blobs"""
+    STORE_RETRIES = 3
+
     def __init__(self, dht_node, peer_port):
         self.dht_node = dht_node
         self.peer_port = peer_port
@@ -21,17 +24,42 @@ class DHTHashAnnouncer(object):
         self.next_manage_call = None
         self.hash_queue = collections.deque()
         self._concurrent_announcers = 0
+        self._manage_call_lc = task.LoopingCall(self.manage_lc)
+        self._lock = utils.DeferredLockContextManager(defer.DeferredLock())
+        self._last_checked = time.time(), self.CONCURRENT_ANNOUNCERS
+        self._retries = {}
+        self._total = None
 
     def run_manage_loop(self):
+        log.info("Starting hash announcer")
+        if not self._manage_call_lc.running:
+            self._manage_call_lc.start(self.ANNOUNCE_CHECK_INTERVAL)
+
+    def manage_lc(self):
+        last_time, last_hashes = self._last_checked
+        hashes = len(self.hash_queue)
+        if hashes:
+            t, h = time.time() - last_time, last_hashes - hashes
+            blobs_per_second = float(h) / float(t)
+            if blobs_per_second > 0:
+                estimated_time_remaining = int(float(hashes) / blobs_per_second)
+                remaining = str(datetime.timedelta(seconds=estimated_time_remaining))
+            else:
+                remaining = "unknown"
+            log.info("Announcing blobs: %i blobs left to announce, %i%s complete, "
+                     "est time remaining: %s", hashes + self._concurrent_announcers,
+                     100 - int(100.0 * float(hashes + self._concurrent_announcers) /
+                               float(self._total)), "%", remaining)
+            self._last_checked = t + last_time, hashes
+        else:
+            self._total = 0
         if self.peer_port is not None:
-            self._announce_available_hashes()
-        self.next_manage_call = utils.call_later(self.ANNOUNCE_CHECK_INTERVAL, self.run_manage_loop)
+            return self._announce_available_hashes()
 
     def stop(self):
         log.info("Stopping DHT hash announcer.")
-        if self.next_manage_call is not None:
-            self.next_manage_call.cancel()
-            self.next_manage_call = None
+        if self._manage_call_lc.running:
+            self._manage_call_lc.stop()
 
     def add_supplier(self, supplier):
         self.suppliers.append(supplier)
@@ -45,60 +73,102 @@ class DHTHashAnnouncer(object):
     def hash_queue_size(self):
         return len(self.hash_queue)
 
+    @defer.inlineCallbacks
     def _announce_available_hashes(self):
         log.debug('Announcing available hashes')
-        ds = []
         for supplier in self.suppliers:
-            d = supplier.hashes_to_announce()
-            d.addCallback(self._announce_hashes)
-            ds.append(d)
-        dl = defer.DeferredList(ds)
-        return dl
+            hashes = yield supplier.hashes_to_announce()
+            yield self._announce_hashes(hashes)
 
+    @defer.inlineCallbacks
     def _announce_hashes(self, hashes, immediate=False):
         if not hashes:
-            return
-        log.debug('Announcing %s hashes', len(hashes))
+            defer.returnValue(None)
+        if not self.dht_node.can_store:
+            log.warning("Client only DHT node cannot store, skipping announce")
+            defer.returnValue(None)
+        log.info('Announcing %s hashes', len(hashes))
         # TODO: add a timeit decorator
         start = time.time()
-        ds = []
 
-        for h in hashes:
-            announce_deferred = defer.Deferred()
-            ds.append(announce_deferred)
-            if immediate:
-                self.hash_queue.appendleft((h, announce_deferred))
-            else:
-                self.hash_queue.append((h, announce_deferred))
+        ds = []
+        with self._lock:
+            for h in hashes:
+                announce_deferred = defer.Deferred()
+                if immediate:
+                    self.hash_queue.appendleft((h, announce_deferred))
+                else:
+                    self.hash_queue.append((h, announce_deferred))
+            if not self._total:
+                self._total = len(hashes)
+
         log.debug('There are now %s hashes remaining to be announced', self.hash_queue_size())
 
-        def announce():
+        @defer.inlineCallbacks
+        def do_store(blob_hash, announce_d):
+            if announce_d.called:
+                defer.returnValue(announce_deferred.result)
+            try:
+                store_nodes = yield self.dht_node.announceHaveBlob(binascii.unhexlify(blob_hash),
+                                                                   self.peer_port)
+                if not store_nodes:
+                    retries = self._retries.get(blob_hash, 0)
+                    retries += 1
+                    self._retries[blob_hash] = retries
+                    if retries <= self.STORE_RETRIES:
+                        log.debug("No nodes stored %s, retrying", blob_hash)
+                        result = yield do_store(blob_hash, announce_d)
+                    else:
+                        log.warning("No nodes stored %s", blob_hash)
+                else:
+                    result = store_nodes
+                if not announce_d.called:
+                    announce_d.callback(result)
+                defer.returnValue(result)
+            except Exception as err:
+                if not announce_d.called:
+                    announce_d.errback(err)
+                raise err
+
+        @defer.inlineCallbacks
+        def announce(progress=None):
+            progress = progress or {}
             if len(self.hash_queue):
-                h, announce_deferred = self.hash_queue.popleft()
-                log.debug('Announcing blob %s to dht', h)
-                d = self.dht_node.announceHaveBlob(binascii.unhexlify(h), self.peer_port)
-                d.chainDeferred(announce_deferred)
-                d.addBoth(lambda _: utils.call_later(0, announce))
+                with self._lock:
+                    h, announce_deferred = self.hash_queue.popleft()
+                log.debug('Announcing blob %s to dht', h[:16])
+                stored_to_nodes = yield do_store(h, announce_deferred)
+                progress[h] = stored_to_nodes
+                log.debug("Stored %s to %i peers (hashes announced by this announcer: %i)",
+                          h.encode('hex')[:16],
+                          len(stored_to_nodes), len(progress))
+
+                yield announce(progress)
             else:
-                self._concurrent_announcers -= 1
+                with self._lock:
+                    self._concurrent_announcers -= 1
+            defer.returnValue(progress)
 
         for i in range(self._concurrent_announcers, self.CONCURRENT_ANNOUNCERS):
             self._concurrent_announcers += 1
-            announce()
-        d = defer.DeferredList(ds)
-        d.addCallback(lambda _: log.debug('Took %s seconds to announce %s hashes',
-                                          time.time() - start, len(hashes)))
-        return d
+            ds.append(announce())
+        announcer_results = yield defer.DeferredList(ds)
+        stored_to = {}
+        for _, announced_to in announcer_results:
+            stored_to.update(announced_to)
+        log.info('Took %s seconds to announce %s hashes', time.time() - start, len(hashes))
+        defer.returnValue(stored_to)
 
 
 class DHTHashSupplier(object):
     # 1 hour is the min time hash will be reannounced
-    MIN_HASH_REANNOUNCE_TIME = 60*60
+    MIN_HASH_REANNOUNCE_TIME = 60 * 60
     # conservative assumption of the time it takes to announce
     # a single hash
     SINGLE_HASH_ANNOUNCE_DURATION = 1
 
     """Classes derived from this class give hashes to a hash announcer"""
+
     def __init__(self, announcer):
         if announcer is not None:
             announcer.add_supplier(self)
@@ -106,7 +176,6 @@ class DHTHashSupplier(object):
 
     def hashes_to_announce(self):
         pass
-
 
     def get_next_announce_time(self, num_hashes_to_announce=1):
         """
@@ -121,9 +190,7 @@ class DHTHashSupplier(object):
         Returns:
             timestamp for next announce time
         """
-        queue_size = self.hash_announcer.hash_queue_size()+num_hashes_to_announce
+        queue_size = self.hash_announcer.hash_queue_size() + num_hashes_to_announce
         reannounce = max(self.MIN_HASH_REANNOUNCE_TIME,
-                            queue_size*self.SINGLE_HASH_ANNOUNCE_DURATION)
+                         queue_size * self.SINGLE_HASH_ANNOUNCE_DURATION)
         return time.time() + reannounce
-
-

--- a/lbrynet/core/server/DHTHashAnnouncer.py
+++ b/lbrynet/core/server/DHTHashAnnouncer.py
@@ -11,10 +11,10 @@ log = logging.getLogger(__name__)
 
 
 class DHTHashAnnouncer(object):
+    """This class announces to the DHT that this peer has certain blobs"""
+
     ANNOUNCE_CHECK_INTERVAL = 60
     CONCURRENT_ANNOUNCERS = 5
-
-    """This class announces to the DHT that this peer has certain blobs"""
     STORE_RETRIES = 3
 
     def __init__(self, dht_node, peer_port):
@@ -95,13 +95,12 @@ class DHTHashAnnouncer(object):
         with self._lock:
             for h in hashes:
                 announce_deferred = defer.Deferred()
+
                 if immediate:
                     self.hash_queue.appendleft((h, announce_deferred))
                 else:
                     self.hash_queue.append((h, announce_deferred))
-            if not self._total:
-                self._total = len(hashes)
-
+            self._total = (self._total or 0) + len(hashes)
         log.debug('There are now %s hashes remaining to be announced', self.hash_queue_size())
 
         @defer.inlineCallbacks

--- a/lbrynet/core/utils.py
+++ b/lbrynet/core/utils.py
@@ -127,3 +127,14 @@ def get_sd_hash(stream_info):
 
 def json_dumps_pretty(obj, **kwargs):
     return json.dumps(obj, sort_keys=True, indent=2, separators=(',', ': '), **kwargs)
+
+
+class DeferredLockContextManager(object):
+    def __init__(self, lock):
+        self._lock = lock
+
+    def __enter__(self):
+        yield self._lock.aquire()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        yield self._lock.release()

--- a/lbrynet/dht/datastore.py
+++ b/lbrynet/dht/datastore.py
@@ -1,8 +1,17 @@
 import UserDict
 import time
+import os
+import json
 import constants
+from copy import deepcopy
 from interface import IDataStore
 from zope.interface import implements
+from lbrynet import conf
+
+NODE_ID = "node_id"
+CLOSEST_NODES = "closestNodes"
+NODE_STATE = "nodeState"
+DATA_STORE = "dataStore"
 
 
 class DictDataStore(UserDict.DictMixin):
@@ -13,10 +22,21 @@ class DictDataStore(UserDict.DictMixin):
         # Dictionary format:
         # { <key>: (<value>, <lastPublished>, <originallyPublished> <originalPublisherID>) }
         self._dict = {}
+        self._node_state = {}
+
+    def __getitem__(self, item):
+        return self._dict[item]
+
+    def __setitem__(self, key, value):
+        self._dict[key] = value
+        return
 
     def keys(self):
         """ Return a list of the keys in this data store """
         return self._dict.keys()
+
+    def getNodeState(self):
+        return self._node_state
 
     def removeExpiredPeers(self):
         now = int(time.time())
@@ -26,7 +46,7 @@ class DictDataStore(UserDict.DictMixin):
                 return False
             return True
 
-        for key in self._dict.keys():
+        for key in self.keys():
             unexpired_peers = filter(notExpired, self._dict[key])
             self._dict[key] = unexpired_peers
 
@@ -46,7 +66,64 @@ class DictDataStore(UserDict.DictMixin):
             return [val[0] for val in self._dict[key]]
 
     def removePeer(self, value):
-        for key in self._dict:
+        keys = self.keys()
+        for key in keys:
             self._dict[key] = [val for val in self._dict[key] if val[0] != value]
             if not self._dict[key]:
                 del self._dict[key]
+
+    def Load(self):
+        pass
+
+    def Save(self, contacts):
+        pass
+
+
+class JSONFileDataStore(DictDataStore):
+    def __init__(self, node, path, file_name=None):
+        DictDataStore.__init__(self)
+        self._node = node
+        self._path = os.path.join(path, file_name or "dht_datastore.json")
+
+    def Load(self):
+        nodeState = {}
+        encodedDataStore = {}
+        encodedNodeState = {}
+        if os.path.isfile(self._path):
+            with open(self._path, "r") as datastore_file:
+                try:
+                    encodedDataStore.update(json.loads(datastore_file.read()))
+                    encodedNodeState = encodedDataStore.pop(NODE_STATE, {})
+                except ValueError:
+                    pass
+        if NODE_ID in encodedNodeState:
+            nodeState[NODE_ID] = encodedNodeState.pop(NODE_ID).decode('hex')
+        else:
+            nodeState[NODE_ID] = conf.settings.node_id
+        if CLOSEST_NODES in encodedNodeState:
+            contacts = encodedNodeState[CLOSEST_NODES]
+            contact_triples = [(contact_id.decode('hex'), address, int(port))
+                                for (contact_id, address, port) in contacts]
+            nodeState[CLOSEST_NODES] = contact_triples
+        self._node_state.update(nodeState)
+        encodedDataStoreValues = encodedDataStore.pop(DATA_STORE, {})
+        for key in encodedDataStoreValues.keys():
+            items = encodedDataStoreValues.pop(key)
+            self[key.decode('hex')] = [(v.decode('hex'), int(l), int(o), p.decode('hex'))
+                                       for (v, l, o, p) in items]
+
+    def Save(self, contacts):
+        rawDataStore = deepcopy(self._dict)
+        encodedDataStore = {DATA_STORE: {}}
+        nodeState = self.getNodeState()
+        for k in rawDataStore.keys():
+            items = [(v.encode('hex'), int(l), int(o), p.encode('hex'))
+                     for (v, l, o, p) in rawDataStore[k]]
+            encodedDataStore[DATA_STORE][k.encode('hex')] = items
+        nodeState[NODE_ID] = conf.settings.node_id.encode('hex')
+        nodeState[CLOSEST_NODES] = [(contact.id.encode('hex'), str(contact.address),
+                                     int(contact.port))
+                                    for contact in contacts]
+        encodedDataStore[NODE_STATE] = nodeState
+        with open(self._path, "w") as datastore_file:
+            datastore_file.write(json.dumps(encodedDataStore, indent=2))

--- a/lbrynet/dht/distance.py
+++ b/lbrynet/dht/distance.py
@@ -1,0 +1,22 @@
+class Distance(object):
+    """Calculate the XOR result between two string variables.
+
+    Frequently we re-use one of the points so as an optimization
+    we pre-calculate the long value of that point.
+    """
+
+    def __init__(self, key):
+        self.key = key
+        self.val_key_one = long(key.encode('hex'), 16)
+
+    def __call__(self, key_two):
+        val_key_two = long(key_two.encode('hex'), 16)
+        return self.val_key_one ^ val_key_two
+
+    def is_closer(self, a, b):
+        """Returns true is `a` is closer to `key` than `b` is"""
+        return self(a) < self(b)
+
+    def to_contact(self, contact):
+        """A convenience function for calculating the distance to a contact"""
+        return self(contact.id)

--- a/lbrynet/dht/encoding.py
+++ b/lbrynet/dht/encoding.py
@@ -75,7 +75,6 @@ class Bencode(Encoding):
             # to the original Bencode algorithm
             return 'n'
         else:
-            print data
             raise TypeError("Cannot bencode '%s' object" % type(data))
 
     def decode(self, data):

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -477,6 +477,28 @@ class Node(object):
         """
         return 'pong'
 
+    @defer.inlineCallbacks
+    @rpcmethod
+    def pingback(self, contact=None):
+        """
+        A ping handshake used to verify contact between two Kademlia nodes
+
+        --------> pingback
+          <------ ping
+            ----> pong
+              <-- pong
+
+        @rtype: str
+        """
+
+        if not contact:
+            raise ValueError("pingback called without a contact")
+        result = yield contact.ping()
+        if result == "pong":
+            defer.returnValue("pong")
+        else:
+            raise ValueError("invalid ping response: %s" % result)
+
     @rpcmethod
     def store(self, key, value, originalPublisherID=None, self_store=False, **kwargs):
         """ Store the received data in this node's local hash table

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -295,7 +295,7 @@ class Node(object):
         return self.iterativeAnnounceHaveBlob(key, {'port': port, 'lbryid': self.node_id})
 
     @defer.inlineCallbacks
-    def getPeersForBlob(self, blob_hash):
+    def getPeersForBlob(self, blob_hash, include_node_ids=False):
         result = yield self.iterativeFindValue(blob_hash)
         expanded_peers = []
         if result:
@@ -307,8 +307,11 @@ class Node(object):
                                 and result["from_peer"] != "self":
                             host = result["from_peer"]
                         port, = struct.unpack('>H', peer[4:6])
-                        if (host, port) not in expanded_peers:
-                            expanded_peers.append((host, port))
+                        if (host, port) not in [(x[0], x[1]) for x in expanded_peers]:
+                            if not include_node_ids:
+                                expanded_peers.append((host, port))
+                            else:
+                                expanded_peers.append((host, port, peer[6:].encode('hex')))
         defer.returnValue(expanded_peers)
 
     def get_most_popular_hashes(self, num_to_return):

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -21,8 +21,9 @@ import protocol
 
 from contact import Contact
 from hashwatcher import HashWatcher
-import logging
+from distance import Distance
 
+import logging
 from lbrynet.core.utils import generate_id
 
 log = logging.getLogger(__name__)
@@ -850,30 +851,6 @@ class _IterativeFindHelper(object):
                 len(self.active_probes) == self.slow_node_count[0]
             )
         )
-
-
-class Distance(object):
-    """Calculate the XOR result between two string variables.
-
-    Frequently we re-use one of the points so as an optimization
-    we pre-calculate the long value of that point.
-    """
-
-    def __init__(self, key):
-        self.key = key
-        self.val_key_one = long(key.encode('hex'), 16)
-
-    def __call__(self, key_two):
-        val_key_two = long(key_two.encode('hex'), 16)
-        return self.val_key_one ^ val_key_two
-
-    def is_closer(self, a, b):
-        """Returns true is `a` is closer to `key` than `b` is"""
-        return self(a) < self(b)
-
-    def to_contact(self, contact):
-        """A convenience function for calculating the distance to a contact"""
-        return self(contact.id)
 
 
 class ExpensiveSort(object):

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -114,9 +114,16 @@ class Node(object):
         self.externalIP = externalIP
         self.hash_watcher = HashWatcher()
 
+        # will be used later
+        self._can_store = True
+
     def __del__(self):
         if self._listeningPort is not None:
             self._listeningPort.stopListening()
+
+    @property
+    def can_store(self):
+        return self._can_store is True
 
     def stop(self):
         # stop LoopingCalls:
@@ -232,20 +239,7 @@ class Node(object):
     def iterativeAnnounceHaveBlob(self, blob_hash, value):
         known_nodes = {}
 
-        def log_error(err, n):
-            if err.check(protocol.TimeoutError):
-                log.debug(
-                    "Timeout while storing blob_hash %s at %s",
-                    binascii.hexlify(blob_hash), n)
-            else:
-                log.error(
-                    "Unexpected error while storing blob_hash %s at %s: %s",
-                    binascii.hexlify(blob_hash), n, err.getErrorMessage())
-
-        def log_success(res):
-            log.debug("Response to store request: %s", str(res))
-            return res
-
+        @defer.inlineCallbacks
         def announce_to_peer(responseTuple):
             """ @type responseMsg: kademlia.msgtypes.ResponseMessage """
             # The "raw response" tuple contains the response message,
@@ -254,40 +248,65 @@ class Node(object):
             originAddress = responseTuple[1]  # tuple: (ip adress, udp port)
             # Make sure the responding node is valid, and abort the operation if it isn't
             if not responseMsg.nodeID in known_nodes:
-                return responseMsg.nodeID
-
+                log.warning("Responding node was not expected")
+                defer.returnValue(responseMsg.nodeID)
             n = known_nodes[responseMsg.nodeID]
 
             result = responseMsg.response
+            announced = False
             if 'token' in result:
                 value['token'] = result['token']
-                d = n.store(blob_hash, value, self.node_id, 0)
-                d.addCallback(log_success)
-                d.addErrback(log_error, n)
+                try:
+                    res = yield n.store(blob_hash, value, self.node_id)
+                    log.debug("Response to store request: %s", str(res))
+                    announced = True
+                except protocol.TimeoutError:
+                    log.debug("Timeout while storing blob_hash %s at %s",
+                                blob_hash.encode('hex')[:16], n.id.encode('hex'))
+                except Exception as err:
+                    log.error("Unexpected error while storing blob_hash %s at %s: %s",
+                              blob_hash.encode('hex')[:16], n.id.encode('hex'), err)
             else:
-                d = defer.succeed(False)
-            return d
+                log.warning("missing token")
+            defer.returnValue(announced)
 
+        @defer.inlineCallbacks
         def requestPeers(contacts):
             if self.externalIP is not None and len(contacts) >= constants.k:
                 is_closer = Distance(blob_hash).is_closer(self.node_id, contacts[-1].id)
                 if is_closer:
                     contacts.pop()
-                    self.store(blob_hash, value, self_store=True, originalPublisherID=self.node_id)
+                    yield self.store(blob_hash, value, originalPublisherID=self.node_id,
+                                     self_store=True)
             elif self.externalIP is not None:
-                self.store(blob_hash, value, self_store=True, originalPublisherID=self.node_id)
-            ds = []
+                yield self.store(blob_hash, value, originalPublisherID=self.node_id,
+                                 self_store=True)
+            else:
+                raise Exception("Cannot determine external IP: %s" % self.externalIP)
+
+            contacted = []
             for contact in contacts:
                 known_nodes[contact.id] = contact
                 rpcMethod = getattr(contact, "findValue")
-                df = rpcMethod(blob_hash, rawResponse=True)
-                df.addCallback(announce_to_peer)
-                df.addErrback(log_error, contact)
-                ds.append(df)
-            return defer.DeferredList(ds)
+                try:
+                    response = yield rpcMethod(blob_hash, rawResponse=True)
+                    stored = yield announce_to_peer(response)
+                    if stored:
+                        contacted.append(contact)
+                except protocol.TimeoutError:
+                    log.debug("Timeout while storing blob_hash %s at %s",
+                              binascii.hexlify(blob_hash), contact)
+                except Exception as err:
+                    log.error("Unexpected error while storing blob_hash %s at %s: %s",
+                              binascii.hexlify(blob_hash), contact, err)
+            log.debug("Stored %s to %i of %i attempted peers", blob_hash.encode('hex')[:16],
+                     len(contacted), len(contacts))
+
+            contacted_node_ids = [c.id.encode('hex') for c in contacts]
+            defer.returnValue(contacted_node_ids)
 
         d = self.iterativeFindNode(blob_hash)
-        d.addCallbacks(requestPeers)
+        d.addCallback(requestPeers)
         return d
 
     def change_token(self):
@@ -618,28 +637,13 @@ class Node(object):
         self._dataStore.removeExpiredPeers()
         defer.returnValue(None)
 
+    @defer.inlineCallbacks
     def _refreshRoutingTable(self):
         nodeIDs = self._routingTable.getRefreshList(0, False)
-        outerDf = defer.Deferred()
-
-        def searchForNextNodeID(dfResult=None):
-            if len(nodeIDs) > 0:
-                searchID = nodeIDs.pop()
-                df = self.iterativeFindNode(searchID)
-                df.addCallback(searchForNextNodeID)
-            else:
-                # If this is reached, we have finished refreshing the routing table
-                outerDf.callback(None)
-
-        # Start the refreshing cycle
-        searchForNextNodeID()
-        return outerDf
-
-
-    # args put here because _refreshRoutingTable does outerDF.callback(None)
-    def _removeExpiredPeers(self, *args):
-        df = threads.deferToThread(self._dataStore.removeExpiredPeers)
-        return df
+        while nodeIDs:
+            searchID = nodeIDs.pop()
+            yield self.iterativeFindNode(searchID)
+        defer.returnValue(None)
 
 
 # This was originally a set of nested methods in _iterativeFind

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -11,8 +11,7 @@ import hashlib
 import operator
 import struct
 import time
-
-from twisted.internet import defer, error, reactor, threads, task
+from twisted.internet import defer, error, reactor, task
 
 import constants
 import routingtable
@@ -84,8 +83,8 @@ class Node(object):
         # network (add callbacks to this deferred if scheduling such
         # operations before the node has finished joining the network)
         self._joinDeferred = None
-        self.next_refresh_call = None
         self.change_token_lc = task.LoopingCall(self.change_token)
+        self.refresh_node_lc = task.LoopingCall(self._refreshNode)
         # Create k-buckets (for storing contacts)
         if routingTableClass is None:
             self._routingTable = routingtable.OptimizedTreeRoutingTable(self.node_id)
@@ -120,10 +119,9 @@ class Node(object):
             self._listeningPort.stopListening()
 
     def stop(self):
-        # cancel callLaters:
-        if self.next_refresh_call is not None:
-            self.next_refresh_call.cancel()
-            self.next_refresh_call = None
+        # stop LoopingCalls:
+        if self.refresh_node_lc.running:
+            self.refresh_node_lc.stop()
         if self.change_token_lc.running:
             self.change_token_lc.stop()
         if self._listeningPort is not None:
@@ -166,11 +164,9 @@ class Node(object):
         self._joinDeferred = self._iterativeFind(self.node_id, bootstrapContacts)
         #        #TODO: Refresh all k-buckets further away than this node's closest neighbour
         # Start refreshing k-buckets periodically, if necessary
-        self.next_refresh_call = reactor.callLater(constants.checkRefreshInterval,
-                                                   self._refreshNode)
-
         self.hash_watcher.tick()
         yield self._joinDeferred
+        self.refresh_node_lc.start(constants.checkRefreshInterval)
 
     @property
     def contacts(self):
@@ -613,13 +609,14 @@ class Node(object):
         result = yield outerDf
         defer.returnValue(result)
 
+    @defer.inlineCallbacks
     def _refreshNode(self):
         """ Periodically called to perform k-bucket refreshes and data
         replication/republishing as necessary """
 
-        df = self._refreshRoutingTable()
-        df.addCallback(self._removeExpiredPeers)
-        df.addCallback(self._scheduleNextNodeRefresh)
+        yield self._refreshRoutingTable()
+        self._dataStore.removeExpiredPeers()
+        defer.returnValue(None)
 
     def _refreshRoutingTable(self):
         nodeIDs = self._routingTable.getRefreshList(0, False)
@@ -638,9 +635,6 @@ class Node(object):
         searchForNextNodeID()
         return outerDf
 
-    def _scheduleNextNodeRefresh(self, *args):
-        self.next_refresh_call = reactor.callLater(constants.checkRefreshInterval,
-                                                   self._refreshNode)
 
     # args put here because _refreshRoutingTable does outerDF.callback(None)
     def _removeExpiredPeers(self, *args):

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -592,7 +592,7 @@ class Node(object):
                 raise TypeError, 'No NodeID given. Therefore we can\'t store this node'
 
         if self_store is True and self.externalIP:
-            contact = Contact(self.node_id, self.externalIP, self.port, None, None)
+            contact = Contact(self.node_id, self.externalIP, self.port, self._protocol)
             compact_ip = contact.compact_ip()
         elif '_rpcNodeContact' in kwargs:
             contact = kwargs['_rpcNodeContact']

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -367,6 +367,13 @@ class Node(object):
 
             contacted = []
             for contact in contacts:
+                try:
+                    yield contact.ping()
+                except protocol.TimeoutError:
+                    log.debug("Skip %s after ping timeout", contact.address)
+                    self.removeContact(contact.id)
+                    continue
+
                 known_nodes[contact.id] = contact
                 rpcMethod = getattr(contact, "findValue")
                 try:

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -492,6 +492,7 @@ class Node(object):
         @type contactID: str
         """
         self._routingTable.removeContact(contactID)
+        self._dataStore.removePeer(contactID)
 
     def findContact(self, contactID):
         """ Find a entangled.kademlia.contact.Contact object for the specified

--- a/lbrynet/dht/protocol.py
+++ b/lbrynet/dht/protocol.py
@@ -253,8 +253,18 @@ class KademliaProtocol(protocol.DatagramProtocol):
                     else:
                         exception_type = UnknownRemoteException
                     remoteException = exception_type(message.response)
-                    log.error("Remote exception (%s): %s", address, remoteException)
-                    df.errback(remoteException)
+                    # this error is returned by nodes that can be contacted but have an old
+                    # and broken version of the ping command, if they return it the node can
+                    # be contacted, so we'll treat it as a successful ping
+                    old_ping_error = "ping() got an unexpected keyword argument '_rpcNodeContact'"
+                    if isinstance(remoteException, TypeError) and \
+                                    remoteException.message == old_ping_error:
+                        log.debug("old pong error")
+                        df.callback('pong')
+                    else:
+                        log.error("DHT RECV REMOTE EXCEPTION FROM %s:%i: %s", address[0],
+                                  address[1], remoteException)
+                        df.errback(remoteException)
                 else:
                     # We got a result from the RPC
                     df.callback(message.response)

--- a/lbrynet/dht/protocol.py
+++ b/lbrynet/dht/protocol.py
@@ -396,7 +396,9 @@ class KademliaProtocol(protocol.DatagramProtocol):
                 log.debug("DHT RECV CALL %s %s:%i", method, senderContact.address,
                           senderContact.port)
             try:
-                if method == 'ping':
+                if method == 'pingback':
+                    df = defer.maybeDeferred(func, contact=senderContact)
+                elif method == 'ping':
                     df = defer.maybeDeferred(func)
                 else:
                     kwargs = {'_rpcNodeID': senderContact.id, '_rpcNodeContact': senderContact}

--- a/lbrynet/tests/dht/test_routing_table.py
+++ b/lbrynet/tests/dht/test_routing_table.py
@@ -11,6 +11,7 @@ import lbrynet.dht.constants
 import lbrynet.dht.routingtable
 import lbrynet.dht.contact
 import lbrynet.dht.node
+import lbrynet.dht.distance
 
 
 class FakeRPCProtocol(object):
@@ -47,15 +48,15 @@ class TreeRoutingTableTest(unittest.TestCase):
         basicTestList = [('123456789', '123456789', 0L), ('12345', '98765', 34527773184L)]
 
         for test in basicTestList:
-            result = lbrynet.dht.node.Distance(test[0])(test[1])
+            result = lbrynet.dht.distance.Distance(test[0])(test[1])
             self.failIf(result != test[2], 'Result of _distance() should be %s but %s returned' %
                         (test[2], result))
 
         baseIp = '146.64.19.111'
         ipTestList = ['146.64.29.222', '192.68.19.333']
 
-        distanceOne = lbrynet.dht.node.Distance(baseIp)(ipTestList[0])
-        distanceTwo = lbrynet.dht.node.Distance(baseIp)(ipTestList[1])
+        distanceOne = lbrynet.dht.distance.Distance(baseIp)(ipTestList[0])
+        distanceTwo = lbrynet.dht.distance.Distance(baseIp)(ipTestList[1])
 
         self.failIf(distanceOne > distanceTwo, '%s should be closer to the base ip %s than %s' %
                     (ipTestList[0], baseIp, ipTestList[1]))

--- a/lbrynet/tests/unit/core/server/test_DHTHashAnnouncer.py
+++ b/lbrynet/tests/unit/core/server/test_DHTHashAnnouncer.py
@@ -1,21 +1,30 @@
 from twisted.trial import unittest
-from twisted.internet import defer, task
+from twisted.internet import defer, task, reactor
 
 from lbrynet.core import utils
 from lbrynet.tests.util import random_lbry_hash
+from lbrynet.core.server.DHTHashAnnouncer import DHTHashAnnouncer
+
 
 class MocDHTNode(object):
     def __init__(self):
+        self.can_store = True
         self.blobs_announced = 0
 
+    @defer.inlineCallbacks
     def announceHaveBlob(self, blob, port):
         self.blobs_announced += 1
-        return defer.succeed(True)
+        d = defer.Deferred(None)
+        reactor.callLater(1, d.callback, {blob: ["ab" * 48]})
+        result = yield d
+        defer.returnValue(result)
+
 
 class MocSupplier(object):
     def __init__(self, blobs_to_announce):
         self.blobs_to_announce = blobs_to_announce
         self.announced = False
+
     def hashes_to_announce(self):
         if not self.announced:
             self.announced = True
@@ -23,8 +32,8 @@ class MocSupplier(object):
         else:
             return defer.succeed([])
 
-class DHTHashAnnouncerTest(unittest.TestCase):
 
+class DHTHashAnnouncerTest(unittest.TestCase):
     def setUp(self):
         self.num_blobs = 10
         self.blobs_to_announce = []
@@ -33,23 +42,26 @@ class DHTHashAnnouncerTest(unittest.TestCase):
         self.clock = task.Clock()
         self.dht_node = MocDHTNode()
         utils.call_later = self.clock.callLater
-        from lbrynet.core.server.DHTHashAnnouncer import DHTHashAnnouncer
         self.announcer = DHTHashAnnouncer(self.dht_node, peer_port=3333)
         self.supplier = MocSupplier(self.blobs_to_announce)
         self.announcer.add_supplier(self.supplier)
 
+    @defer.inlineCallbacks
     def test_basic(self):
-        self.announcer._announce_available_hashes()
+        d = self.announcer._announce_available_hashes()
         self.assertEqual(self.announcer.hash_queue_size(), self.announcer.CONCURRENT_ANNOUNCERS)
         self.clock.advance(1)
+        yield d
         self.assertEqual(self.dht_node.blobs_announced, self.num_blobs)
         self.assertEqual(self.announcer.hash_queue_size(), 0)
 
+    @defer.inlineCallbacks
     def test_immediate_announce(self):
         # Test that immediate announce puts a hash at the front of the queue
-        self.announcer._announce_available_hashes()
+        d = self.announcer._announce_available_hashes()
+        self.assertEqual(self.announcer.hash_queue_size(), self.announcer.CONCURRENT_ANNOUNCERS)
         blob_hash = random_lbry_hash()
         self.announcer.immediate_announce([blob_hash])
         self.assertEqual(self.announcer.hash_queue_size(), self.announcer.CONCURRENT_ANNOUNCERS+1)
         self.assertEqual(blob_hash, self.announcer.hash_queue[0][0])
-
+        yield d


### PR DESCRIPTION
  * Added `pingback` dht method to test connectivity
  * Filter dht queries from unreachable peers
  * Check dht peers requesting to store can be contacted before accepting
  * Use `pingback` to check connectivity on startup, don't try to send `store` queries if this fails
  * Improved logging of dht errors and non-typical behavior
