### PR TITLE
Don't filter out local node ID when returning peer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
   * Fixed lbryid length validation
   * Fixed an old print statement that polluted logs
   * Fixed rpc id length for dht requests
+  * Fixed local node ID reporting in peer list
 
 ### Deprecated
   *

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -216,14 +216,13 @@ class Node(object):
         if result:
             if blob_hash in result:
                 for peer in result[blob_hash]:
-                    if self.node_id != peer[6:]:
-                        host = ".".join([str(ord(d)) for d in peer[:4]])
-                        if host == "127.0.0.1" and "from_peer" in result \
-                                and result["from_peer"] != "self":
-                            host = result["from_peer"]
-                        port, = struct.unpack('>H', peer[4:6])
-                        if (host, port) not in expanded_peers:
-                            expanded_peers.append((host, port))
+                    host = ".".join([str(ord(d)) for d in peer[:4]])
+                    if host == "127.0.0.1" and "from_peer" in result \
+                            and result["from_peer"] != "self":
+                        host = result["from_peer"]
+                    port, = struct.unpack('>H', peer[4:6])
+                    if (host, port) not in expanded_peers:
+                        expanded_peers.append((host, port))
         defer.returnValue(expanded_peers)
 
     def get_most_popular_hashes(self, num_to_return):


### PR DESCRIPTION
If a node is returning a peer list for a given blob hash
(being this been requested via CLI or via DHT) and it is
part of the resulting peer list, it will filter itself out
before returning the list.

This makes the results across the DHT inconsistent as
different nodes won't include themselves when
responding a findValue/findNode query.

Remove such filtering so that the local node ID is always
included when needed.

Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>