### PR TITLE
Extend close nodes list by right amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ at anytime.
   * Fixed lbryid length validation
   * Fixed an old print statement that polluted logs
   * Fixed rpc id length for dht requests
+  * Fixed amount of closed nodes to add to list in case of extension to neighbouring k-buckets
 
 ### Deprecated
   *

--- a/lbrynet/dht/routingtable.py
+++ b/lbrynet/dht/routingtable.py
@@ -138,15 +138,14 @@ class TreeRoutingTable(object):
         # Fill up the node list to k nodes, starting with the closest neighbouring nodes known
         while len(closestNodes) < min(count, constants.k) and (canGoLower or canGoHigher):
             # TODO: this may need to be optimized
+            remain = min(count, constants.k) - len(closestNodes)
             if canGoLower:
                 closestNodes.extend(
-                    self._buckets[bucketIndex - i].getContacts(
-                        constants.k - len(closestNodes), _rpcNodeID))
+                    self._buckets[bucketIndex - i].getContacts(remain, _rpcNodeID))
                 canGoLower = bucketIndex - (i + 1) >= 0
             if canGoHigher:
                 closestNodes.extend(
-                    self._buckets[bucketIndex + i].getContacts(constants.k - len(closestNodes),
-                                                               _rpcNodeID))
+                    self._buckets[bucketIndex + i].getContacts(remain, _rpcNodeID))
                 canGoHigher = bucketIndex + (i + 1) < len(self._buckets)
             i += 1
         return closestNodes


### PR DESCRIPTION
When a k-bucket does not contain enough close nodes, the
DHT will look into neighbouring k-buckets in order to entend
the list of returned nodes.

However, the list should not be extended beyond its maximum size.

Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>