### PR TITLE
change stream_cost_estimate "name" param to "uri"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -633,7 +633,7 @@ Returns:
 Get estimated cost for a lbry stream
 
 Args:
-    'name': (str) lbry name
+    'uri': (str) lbry uri
     'size' (optional): (int) stream size, in bytes. if provided an sd blob
                         won't be downloaded.
 Returns:


### PR DESCRIPTION
When making a request with the stream_cost_estimate method, an error is thrown if "name" is provided instead of "uri" as a parameter.