### PR TITLE
Session: simplify UPnP setup and avoid race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Fixed race condition during UPnP setup between 'check' and 'set' of the new mapping
   *
 
 ### Deprecated
@@ -25,7 +25,8 @@ at anytime.
   *
 
 ### Added
-  *
+  * Added error detection in UPnP setup
+  * Updated miniupnpc from 1.9 to 2.0.2 (provides upnp.addanyportmapping)
   *
 
 ### Removed

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jsonrpclib==0.1.7
 jsonschema==2.6.0
 git+https://github.com/lbryio/lbryum.git@v3.1.10#egg=lbryum
 git+https://github.com/lbryio/lbryschema.git@v0.0.13#egg=lbryschema
-miniupnpc==1.9
+miniupnpc==2.0.2
 pbkdf2==1.3
 pycrypto==2.6.1
 pyyaml==3.12


### PR DESCRIPTION
Checking for a mapping availability and setting it up in two
different moments may lead to race conditions as other procsses may
register the same mapping before lbrynet does.

Moreover, the return value of upnp.addportmapping() was not checked,
thus leading lbrynet to believe that the mapping was succesful even if
it was not.

Starting with miniupnpc 2.0.x, we have support for the
upnp.addanyportmapping() primitive which instructs the server to reserve
the first available external port if the requested one is already taken.

If no port is avaialable the upnp call will fail.

This new primitive therefore avoids the need to "test and set" the
mapping thus eliminating the racy behaviour.

Simplify the UPnP setup by using upnp.addanyportmapping() and check
its return value to ensure everything went fine.

Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>