### PR TITLE
platform ip: ensure daemon retrieves IPv4 address only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Fixed external IP detection via jsonip.com (avoid detecting IPv6)
   *
 
 ### Deprecated

--- a/lbrynet/core/system_info.py
+++ b/lbrynet/core/system_info.py
@@ -39,7 +39,7 @@ def get_platform(get_ip=True):
 
     if get_ip:
         try:
-            p['ip'] = json.load(urlopen('http://jsonip.com'))['ip']
+            p['ip'] = json.load(urlopen('http://ipv4.jsonip.com'))['ip']
         except:
             p['ip'] = "Could not determine IP"
 


### PR DESCRIPTION
When contacting jsonip.com to retrieve the node external IP,
the connection might be established with IPv6 and thus return
an address belonging to that family.

This address is then used to initialize the external_ip member of
Daemon session, but unfortunately IPv6 is not yet handled well.

Using an IPv6 as external IP is currently breaking parts of the
Daemon resulting in no peer connectivity at all.

We should stick to IPv4 for time being.

http://jsonip.com/about says "ipv4-only":"https://ipv4.jsonip.com"

therefore, change the IP retrieval URL to ipv4.jsonip.com to
make sure the connection is established only using an IPv4 address.

Closes: https://github.com/lbryio/lbry/issues/971
Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>