### PR TITLE
Remove claim information from files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ at anytime.
 ### Fixed
   * Fixed unnecessarily verbose exchange rate error (https://github.com/lbryio/lbry/issues/984)
   * Merged two sepereate dht test folders into one
-  *
 
 ### Deprecated
   * `channel_list_mine`, replaced with `channel_list`
@@ -25,15 +24,14 @@ at anytime.
   * Check claim schema in `publish` before trying to make the claim, return better error messages
   * Renamed `channel_list_mine` to `channel_list`
   * Changed `channel_list` to include channels where the certificate info has been imported but the claim is not in the wallet
-  * API commands file_list, file_delete, and file_reflect no longer deals with claim information
-  *
+  * Changed `file_list`, `file_delete`, `file_set_status`, and `file_reflect` to no longer return claim related information.
 
 ### Added
   * Added `channel_import` and `channel_export` commands
   * Added `is_mine` field to `channel_list` results
 
 ### Removed
-  *
+  * Removed claim related filter arguments `name`, `claim_id`, and `outpoint` from `file_list`, `file_delete`, `file_set_status`, and `file_reflect`
   *
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ at anytime.
   * Check claim schema in `publish` before trying to make the claim, return better error messages
   * Renamed `channel_list_mine` to `channel_list`
   * Changed `channel_list` to include channels where the certificate info has been imported but the claim is not in the wallet
+  * API commands file_list, file_delete, and file_reflect no longer deals with claim information
+  *
 
 ### Added
   * Added `channel_import` and `channel_export` commands
@@ -56,7 +58,6 @@ at anytime.
 ### Removed
  * Removed some alternate methods of reading from blob files
  * Removed `@AuthJSONRPCServer.queued` decorator
-
 
 ## [0.17.1] - 2017-10-25
 ### Fixed

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -649,7 +649,6 @@ class Daemon(AuthJSONRPCServer):
         def _download_finished(download_id, name, claim_dict):
             report = yield self._get_stream_analytics_report(claim_dict)
             self.analytics_manager.send_download_finished(download_id, name, report, claim_dict)
-
         @defer.inlineCallbacks
         def _download_failed(error, download_id, name, claim_dict):
             report = yield self._get_stream_analytics_report(claim_dict)
@@ -1509,12 +1508,13 @@ class Daemon(AuthJSONRPCServer):
         name = resolved['name']
         claim_id = resolved['claim_id']
         claim_dict = ClaimDict.load_dict(resolved['value'])
+        sd_hash = claim_dict.source_hash
 
         if claim_id in self.streams:
             log.info("Already waiting on lbry://%s to start downloading", name)
             yield self.streams[claim_id].data_downloading_deferred
 
-        lbry_file = yield self._get_lbry_file(FileID.CLAIM_ID, claim_id, return_json=False)
+        lbry_file = yield self._get_lbry_file(FileID.SD_HASH, sd_hash, return_json=False)
 
         if lbry_file:
             if not os.path.isfile(os.path.join(lbry_file.download_directory, lbry_file.file_name)):

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -112,12 +112,9 @@ class Checker(object):
 
 class _FileID(IterableContainer):
     """The different ways a file can be identified"""
-    NAME = 'name'
     SD_HASH = 'sd_hash'
     FILE_NAME = 'file_name'
     STREAM_HASH = 'stream_hash'
-    CLAIM_ID = "claim_id"
-    OUTPOINT = "outpoint"
     ROWID = "rowid"
 
 
@@ -880,32 +877,6 @@ class Daemon(AuthJSONRPCServer):
             size = None
             message = None
 
-        claim = yield self.session.wallet.get_claim_by_claim_id(lbry_file.claim_id,
-                                                                check_expire=False)
-
-        if claim and 'value' in claim:
-            metadata = claim['value']
-        else:
-            metadata = None
-
-        if claim and 'channel_name' in claim:
-            channel_name = claim['channel_name']
-        else:
-            channel_name = None
-
-        if lbry_file.txid and lbry_file.nout is not None:
-            outpoint = repr(ClaimOutpoint(lbry_file.txid, lbry_file.nout))
-        else:
-            outpoint = None
-
-        if claim and 'has_signature' in claim:
-            has_signature = claim['has_signature']
-        else:
-            has_signature = None
-        if claim and 'signature_is_valid' in claim:
-            signature_is_valid = claim['signature_is_valid']
-        else:
-            signature_is_valid = None
 
         result = {
             'completed': lbry_file.completed,
@@ -917,23 +888,13 @@ class Daemon(AuthJSONRPCServer):
             'stream_name': lbry_file.stream_name,
             'suggested_file_name': lbry_file.suggested_file_name,
             'sd_hash': lbry_file.sd_hash,
-            'name': lbry_file.name,
-            'outpoint': outpoint,
-            'claim_id': lbry_file.claim_id,
             'download_path': full_path,
             'mime_type': mime_type,
             'key': key,
             'total_bytes': size,
             'written_bytes': written_bytes,
             'message': message,
-            'metadata': metadata
         }
-        if channel_name is not None:
-            result['channel_name'] = channel_name
-        if has_signature is not None:
-            result['has_signature'] = has_signature
-        if signature_is_valid is not None:
-            result['signature_is_valid'] = signature_is_valid
         defer.returnValue(result)
 
     @defer.inlineCallbacks
@@ -1292,8 +1253,7 @@ class Daemon(AuthJSONRPCServer):
 
         Usage:
             file_list [--sd_hash=<sd_hash>] [--file_name=<file_name>] [--stream_hash=<stream_hash>]
-                      [--claim_id=<claim_id>] [--outpoint=<outpoint>] [--rowid=<rowid>]
-                      [--name=<name>]
+                      [--rowid=<rowid>]
                       [-f]
 
         Options:
@@ -1301,10 +1261,7 @@ class Daemon(AuthJSONRPCServer):
             --file_name=<file_name>      : get file with matching file name in the
                                            downloads folder
             --stream_hash=<stream_hash>  : get file with matching stream hash
-            --claim_id=<claim_id>        : get file with matching claim id
-            --outpoint=<outpoint>        : get file with matching claim outpoint
             --rowid=<rowid>              : get file with matching row id
-            --name=<name>                : get file with matching associated name claim
             -f                           : full status, populate the 'message' and 'size' fields
 
         Returns:
@@ -1321,16 +1278,12 @@ class Daemon(AuthJSONRPCServer):
                     'stream_name': (str) stream name ,
                     'suggested_file_name': (str) suggested file name,
                     'sd_hash': (str) sd hash of file,
-                    'name': (str) name claim attached to file
-                    'outpoint': (str) claim outpoint attached to file
-                    'claim_id': (str) claim ID attached to file,
                     'download_path': (str) download path of file,
                     'mime_type': (str) mime type of file,
                     'key': (str) key attached to file,
                     'total_bytes': (int) file size in bytes, None if full_status is false
                     'written_bytes': (int) written size in bytes
                     'message': (str), None if full_status is false
-                    'metadata': (dict) Metadata dictionary
                 },
             ]
         """
@@ -1644,10 +1597,7 @@ class Daemon(AuthJSONRPCServer):
             --sd_hash=<sd_hash>             : delete by file sd hash
             --file_name<file_name>          : delete by file name in downloads folder
             --stream_hash=<stream_hash>     : delete by file stream hash
-            --claim_id=<claim_id>           : delete by file claim id
-            --outpoint=<outpoint>           : delete by file claim outpoint
             --rowid=<rowid>                 : delete by file row id
-            --name=<name>                   : delete by associated name claim of file
 
         Returns:
             (bool) true if deletion was successful
@@ -2699,10 +2649,7 @@ class Daemon(AuthJSONRPCServer):
             --file_name=<file_name>      : get file with matching file name in the
                                            downloads folder
             --stream_hash=<stream_hash>  : get file with matching stream hash
-            --claim_id=<claim_id>        : get file with matching claim id
-            --outpoint=<outpoint>        : get file with matching claim outpoint
             --rowid=<rowid>              : get file with matching row id
-            --name=<name>                : get file with matching associated name claim
             --reflector=<reflector>      : reflector server, ip address or url
                                            by default choose a server from the config
 

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1537,19 +1537,14 @@ class Daemon(AuthJSONRPCServer):
 
         Usage:
             file_set_status <status> [--sd_hash=<sd_hash>] [--file_name=<file_name>]
-                      [--stream_hash=<stream_hash>] [--claim_id=<claim_id>]
-                      [--outpoint=<outpoint>] [--rowid=<rowid>]
-                      [--name=<name>]
+                      [--stream_hash=<stream_hash>] [--rowid=<rowid>]
 
         Options:
             --sd_hash=<sd_hash>          : set status of file with matching sd hash
             --file_name=<file_name>      : set status of file with matching file name in the
                                            downloads folder
             --stream_hash=<stream_hash>  : set status of file with matching stream hash
-            --claim_id=<claim_id>        : set status of file with matching claim id
-            --outpoint=<outpoint>        : set status of file with matching claim outpoint
             --rowid=<rowid>              : set status of file with matching row id
-            --name=<name>                : set status of file with matching associated name claim
 
         Returns:
             (str) Confirmation message
@@ -1583,9 +1578,7 @@ class Daemon(AuthJSONRPCServer):
 
         Usage:
             file_delete [-f] [--delete_all] [--sd_hash=<sd_hash>] [--file_name=<file_name>]
-                        [--stream_hash=<stream_hash>] [--claim_id=<claim_id>]
-                        [--outpoint=<outpoint>] [--rowid=<rowid>]
-                        [--name=<name>]
+                        [--stream_hash=<stream_hash>] [--rowid=<rowid>]
 
         Options:
             -f, --delete_from_download_dir  : delete file from download directory,
@@ -2639,8 +2632,7 @@ class Daemon(AuthJSONRPCServer):
 
         Usage:
             file_reflect [--sd_hash=<sd_hash>] [--file_name=<file_name>]
-                         [--stream_hash=<stream_hash>] [--claim_id=<claim_id>]
-                         [--outpoint=<outpoint>] [--rowid=<rowid>] [--name=<name>]
+                         [--stream_hash=<stream_hash>] [--rowid=<rowid>]
                          [--reflector=<reflector>]
 
         Options:

--- a/lbrynet/tests/mocks.py
+++ b/lbrynet/tests/mocks.py
@@ -16,8 +16,7 @@ class FakeLBRYFile(object):
         self.blob_manager = blob_manager
         self.stream_info_manager = stream_info_manager
         self.stream_hash = stream_hash
-        self.name = "fake_uri"
-
+        self.file_name = 'fake_lbry_file'
 
 class Node(object):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This removes claim information attached to files, and implements the fix for https://github.com/lbryio/lbry/issues/981


9502b29 - remove the claim information from file related API daemon commands

4aa3cf7 - reflector would use lbry_file.name, for logging purposes, use lbry_file.file_name

1527304 - fix test for above change

d17d410 -when calling API command get, it would check to see if it had the file by looking up the claim_id. Instead, look up by the sd_hash, also fixes https://github.com/lbryio/lbry/issues/951

1bd620a - when calling API command get, it would check to see if there was an ongoing download by looking up the claim_id, also look up by sd_hash, also fixes https://github.com/lbryio/lbry/issues/951


I assigned @kauffj as a reviewer here, he does not have to review this but he needs to give the OK to merge when the app-side work is complete.


NOTE: This PR changes the API  (should  I run the api script in the PR?) , and will break the app.
 