### PR TITLE
Fix failing ConnectionManager unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ at anytime.
 ### Fixed
   * Fixed amount of close nodes to add to list in case of extension to neighbouring k-buckets
   * Fixed external IP detection via jsonip.com (avoid detecting IPv6)
+  * Fixed failing ConnectionManager unit test for parallel connections
   *
 
 ### Deprecated


### PR DESCRIPTION
Addresses #511. Previously, the test yielded to obtain the result of `connection_was_made`, but the assertions were made in sequential order. Sometimes the result of both connections would be returned before resuming the test, failing the assertions. Instead, this adds a callback to verify the result of each connection, then yields to get both Deferred results.