### PR TITLE
Fix race condition between publish and channel_new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ at anytime.
 ### Fixed
   * Fixed amount of close nodes to add to list in case of extension to neighbouring k-buckets
   * Fixed external IP detection via jsonip.com (avoid detecting IPv6)
-  *
+  * Fixed race condition between `publish` and `channel_new`
 
 ### Deprecated
   *
@@ -23,7 +23,7 @@ at anytime.
 
 ### Changed
   * Moved BLOB_SIZE from conf.py to MAX_BLOB_SIZE in blob/blob_file.py
-  *
+  * Use shared deferredSemaphore for api methods decorated with `@AuthJSONRPCServer.queued`
 
 ### Added
   * Added `utxo_list` command to list unspent transaction outputs

--- a/lbrynet/daemon/auth/server.py
+++ b/lbrynet/daemon/auth/server.py
@@ -319,7 +319,7 @@ class AuthJSONRPCServer(AuthorizedBase):
                 reply_with_next_secret = True
 
         try:
-            function = self._get_jsonrpc_method(function_name)
+            fn = self._get_jsonrpc_method(function_name)
         except UnknownAPIMethodError as err:
             log.warning('Failed to get function %s: %s', function_name, err)
             self._render_error(
@@ -350,7 +350,7 @@ class AuthJSONRPCServer(AuthorizedBase):
             # d = defer.maybeDeferred(function, *args)  # if we want to support positional args too
             raise ValueError('Args must be a dict')
 
-        params_error, erroneous_params = self._check_params(function, args_dict)
+        params_error, erroneous_params = self._check_params(fn, args_dict)
         if params_error is not None:
             params_error_message = '{} for {} command: {}'.format(
                 params_error, function_name, ', '.join(erroneous_params)
@@ -363,9 +363,9 @@ class AuthJSONRPCServer(AuthorizedBase):
             return server.NOT_DONE_YET
 
         if is_queued:
-            d = self._queued_lock.run(function, self, **args_dict)
+            d = self._queued_lock.run(fn, self, **args_dict)
         else:
-            d = defer.maybeDeferred(function, self, **args_dict)
+            d = defer.maybeDeferred(fn, self, **args_dict)
 
         # finished_deferred will callback when the request is finished
         # and errback if something went wrong. If the errback is


### PR DESCRIPTION
`publish` and `channel_new` will both create a claim transaction - this can result in a race condition where the lbryum coin chooser selects the same utxo to spend for both claims, and only the first call to go through succeeds.

Currently, `publish` calls and `channel_new` calls are run sequentially (to avoid the same race condition between concurrent `publish`/`channel_new` calls), but on a per-function basis. This fixes the race condition by using a common deferredSemaphore for all methods decorated with `@AuthJSONRPCServer.queued`
