### PR TITLE
Delete blob hash from list when blob is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ at anytime.
   * Fixed external IP detection via jsonip.com (avoid detecting IPv6)
   * Fixed failing ConnectionManager unit test for parallel connections
   * Fixed race condition between `publish` and `channel_new`
+  * Fixed incorrect response on attempting to delete blob twice
 
 ### Deprecated
   *

--- a/lbrynet/core/BlobManager.py
+++ b/lbrynet/core/BlobManager.py
@@ -153,6 +153,7 @@ class DiskBlobManager(DHTHashSupplier):
                 blob = yield self.get_blob(blob_hash)
                 yield blob.delete()
                 bh_to_delete_from_db.append(blob_hash)
+                del self.blobs[blob_hash]
             except Exception as e:
                 log.warning("Failed to delete blob file. Reason: %s", e)
         yield self._delete_blobs_from_db(bh_to_delete_from_db)

--- a/lbrynet/tests/unit/core/test_BlobManager.py
+++ b/lbrynet/tests/unit/core/test_BlobManager.py
@@ -83,6 +83,10 @@ class BlobManagerTest(unittest.TestCase):
         self.assertEqual(len(blobs), 0)
         blobs = yield self.bm._get_all_blob_hashes()
         self.assertEqual(len(blobs), 0)
+        self.assertFalse(blob_hash in self.bm.blobs)
+
+        # delete blob that was already deleted once
+        out = yield self.bm.delete_blobs([blob_hash])
 
         # delete blob that does not exist, nothing will
         # happen


### PR DESCRIPTION
Addresses #786. The blob hash should be removed from the `BlobManager.blobs` dictionary when the blob is deleted. 