### PR TITLE
Add lbry file manager to reflector server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ at anytime.
   * Removed claim related filter arguments `name`, `claim_id`, and `outpoint` from `file_list`, `file_delete`, `file_set_status`, and `file_reflect`
   * Removed unused files
   * Removed old and unused UI related code
+  * Removed claim information from lbry file internals
 
 
 ## [0.18.0] - 2017-11-08

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -314,7 +314,8 @@ class Daemon(AuthJSONRPCServer):
                 reflector_factory = reflector_server_factory(
                     self.session.peer_manager,
                     self.session.blob_manager,
-                    self.stream_info_manager
+                    self.stream_info_manager,
+                    self.lbry_file_manager
                 )
                 try:
                     self.reflector_server_port = reactor.listenTCP(self.reflector_port,

--- a/lbrynet/daemon/Publisher.py
+++ b/lbrynet/daemon/Publisher.py
@@ -35,9 +35,9 @@ class Publisher(object):
             stream_hash = yield create_lbry_file(self.session, self.lbry_file_manager, file_name,
                                                  read_handle)
         prm = self.session.payment_rate_manager
-        self.lbry_file = yield self.lbry_file_manager.add_lbry_file(stream_hash, prm)
         sd_hash = yield publish_sd_blob(self.lbry_file_manager.stream_info_manager,
-                            self.session.blob_manager, self.lbry_file.stream_hash)
+                            self.session.blob_manager, stream_hash)
+        self.lbry_file = yield self.lbry_file_manager.add_lbry_file(stream_hash, prm)
         if 'source' not in claim_dict['stream']:
             claim_dict['stream']['source'] = {}
         claim_dict['stream']['source']['source'] = sd_hash
@@ -47,7 +47,6 @@ class Publisher(object):
 
         claim_out = yield self.make_claim(name, bid, claim_dict, claim_address, change_address)
         self.lbry_file.completed = True
-        yield self.lbry_file.load_file_attributes(sd_hash)
         yield self.lbry_file.save_status()
         defer.returnValue(claim_out)
 

--- a/lbrynet/daemon/Publisher.py
+++ b/lbrynet/daemon/Publisher.py
@@ -34,10 +34,9 @@ class Publisher(object):
         with file_utils.get_read_handle(file_path) as read_handle:
             stream_hash = yield create_lbry_file(self.session, self.lbry_file_manager, file_name,
                                                  read_handle)
-        prm = self.session.payment_rate_manager
         sd_hash = yield publish_sd_blob(self.lbry_file_manager.stream_info_manager,
                             self.session.blob_manager, stream_hash)
-        self.lbry_file = yield self.lbry_file_manager.add_lbry_file(stream_hash, prm)
+        self.lbry_file = yield self.lbry_file_manager.add_lbry_file(stream_hash)
         if 'source' not in claim_dict['stream']:
             claim_dict['stream']['source'] = {}
         claim_dict['stream']['source']['source'] = sd_hash

--- a/lbrynet/file_manager/EncryptedFileDownloader.py
+++ b/lbrynet/file_manager/EncryptedFileDownloader.py
@@ -7,7 +7,6 @@ from zope.interface import implements
 from twisted.internet import defer
 
 from lbrynet.core.client.StreamProgressManager import FullStreamProgressManager
-from lbrynet.core.Error import NoSuchStreamHash
 from lbrynet.core.utils import short_hash
 from lbrynet.core.StreamDescriptor import StreamMetadata
 from lbrynet.lbry_file.client.EncryptedFileDownloader import EncryptedFileSaver
@@ -35,18 +34,21 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
     STATUS_RUNNING = "running"
     STATUS_STOPPED = "stopped"
     STATUS_FINISHED = "finished"
-
+    """
+    These are started by EncryptedFileManager, aka, file_manager
+    """
     def __init__(self, rowid, stream_hash, peer_finder, rate_limiter,
                  blob_manager, stream_info_manager, lbry_file_manager,
                  payment_rate_manager, wallet, download_directory,
                  file_name=None):
+
         EncryptedFileSaver.__init__(self, stream_hash, peer_finder,
                                     rate_limiter, blob_manager,
                                     stream_info_manager,
                                     payment_rate_manager, wallet,
                                     download_directory,
                                     file_name)
-        self.sd_hash = None
+
         self.rowid = rowid
         self.lbry_file_manager = lbry_file_manager
         self._saving_status = False
@@ -57,7 +59,6 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
 
     @defer.inlineCallbacks
     def restore(self):
-        yield self.load_file_attributes()
 
         status = yield self.lbry_file_manager.get_lbry_file_status(self)
         log_status(self.file_name, self.sd_hash, status)
@@ -102,22 +103,8 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
                                                     num_blobs_known, status))
 
     @defer.inlineCallbacks
-    def load_file_attributes(self, sd_hash=None):
-        if not sd_hash:
-            sd_hash = yield self.stream_info_manager.get_sd_blob_hashes_for_stream(self.stream_hash)
-            if sd_hash:
-                self.sd_hash = sd_hash[0]
-            else:
-                raise NoSuchStreamHash(self.stream_hash)
-        else:
-            self.sd_hash = sd_hash
-
-        defer.returnValue(None)
-
-    @defer.inlineCallbacks
     def _start(self):
         yield EncryptedFileSaver._start(self)
-        yield self.load_file_attributes()
         status = yield self._save_status()
         log_status(self.file_name, self.sd_hash, status)
         defer.returnValue(status)

--- a/lbrynet/file_manager/EncryptedFileManager.py
+++ b/lbrynet/file_manager/EncryptedFileManager.py
@@ -183,8 +183,10 @@ class EncryptedFileManager(object):
             yield self._stop_lbry_file(lbry_file)
 
     @defer.inlineCallbacks
-    def add_lbry_file(self, stream_hash, payment_rate_manager, blob_data_rate=None,
+    def add_lbry_file(self, stream_hash, payment_rate_manager=None, blob_data_rate=None,
                       download_directory=None, file_name=None):
+        if not payment_rate_manager:
+            payment_rate_manager = self.sesion.payment_rate_manager
         rowid = yield self._save_lbry_file(stream_hash, blob_data_rate)
         lbry_file = yield self.start_lbry_file(rowid, stream_hash, payment_rate_manager,
                                                blob_data_rate, download_directory,

--- a/lbrynet/file_manager/EncryptedFileManager.py
+++ b/lbrynet/file_manager/EncryptedFileManager.py
@@ -186,7 +186,7 @@ class EncryptedFileManager(object):
     def add_lbry_file(self, stream_hash, payment_rate_manager=None, blob_data_rate=None,
                       download_directory=None, file_name=None):
         if not payment_rate_manager:
-            payment_rate_manager = self.sesion.payment_rate_manager
+            payment_rate_manager = self.session.payment_rate_manager
         rowid = yield self._save_lbry_file(stream_hash, blob_data_rate)
         lbry_file = yield self.start_lbry_file(rowid, stream_hash, payment_rate_manager,
                                                blob_data_rate, download_directory,

--- a/lbrynet/reflector/server/server.py
+++ b/lbrynet/reflector/server/server.py
@@ -33,6 +33,7 @@ class ReflectorServer(Protocol):
         self.peer = self.factory.peer_manager.get_peer(peer_info.host, peer_info.port)
         self.blob_manager = self.factory.blob_manager
         self.stream_info_manager = self.factory.stream_info_manager
+        self.lbry_file_manager = self.factory.lbry_file_manager
         self.protocol_version = self.factory.protocol_version
         self.received_handshake = False
         self.peer_version = None
@@ -107,6 +108,7 @@ class ReflectorServer(Protocol):
             yield save_sd_info(self.stream_info_manager, sd_info)
             yield self.stream_info_manager.save_sd_blob_hash_to_stream(sd_info['stream_hash'],
                                                                        blob.blob_hash)
+            yield self.lbry_file_manager.add_lbry_file(sd_info['stream_hash'])
             should_announce = True
 
             # if we already have the head blob, set it to be announced now that we know it's
@@ -399,10 +401,11 @@ class ReflectorServer(Protocol):
 class ReflectorServerFactory(ServerFactory):
     protocol = ReflectorServer
 
-    def __init__(self, peer_manager, blob_manager, stream_info_manager):
+    def __init__(self, peer_manager, blob_manager, stream_info_manager, lbry_file_manager):
         self.peer_manager = peer_manager
         self.blob_manager = blob_manager
         self.stream_info_manager = stream_info_manager
+        self.lbry_file_manager = lbry_file_manager
         self.protocol_version = REFLECTOR_V2
 
     def buildProtocol(self, addr):

--- a/lbrynet/reflector/server/server.py
+++ b/lbrynet/reflector/server/server.py
@@ -108,7 +108,7 @@ class ReflectorServer(Protocol):
             yield save_sd_info(self.stream_info_manager, sd_info)
             yield self.stream_info_manager.save_sd_blob_hash_to_stream(sd_info['stream_hash'],
                                                                        blob.blob_hash)
-            yield self.lbry_file_manager.add_lbry_file(sd_info['stream_hash'])
+            self.lbry_file_manager.add_lbry_file(sd_info['stream_hash'])
             should_announce = True
 
             # if we already have the head blob, set it to be announced now that we know it's

--- a/lbrynet/tests/functional/test_reflector.py
+++ b/lbrynet/tests/functional/test_reflector.py
@@ -162,25 +162,17 @@ class TestReflector(unittest.TestCase):
     def take_down_env(self):
         d = defer.succeed(True)
         ## Close client classes ##
-        if self.lbry_file_manager is not None:
-            d.addCallback(lambda _: self.lbry_file_manager.stop())
-        if self.session is not None:
-            d.addCallback(lambda _: self.session.shut_down())
-        if self.stream_info_manager is not None:
-            d.addCallback(lambda _: self.stream_info_manager.stop())
+        d.addCallback(lambda _: self.lbry_file_manager.stop())
+        d.addCallback(lambda _: self.session.shut_down())
+        d.addCallback(lambda _: self.stream_info_manager.stop())
 
         ## Close server classes ##
-        if self.server_blob_manager is not None:
-            d.addCallback(lambda _: self.server_blob_manager.stop())
-        if self.server_lbry_file_manager is not None:
-            d.addCallback(lambda _: self.server_lbry_file_manager.stop())
-        if self.server_session is not None:
-            d.addCallback(lambda _: self.server_session.shut_down())
-        if self.server_stream_info_manager is not None:
-            d.addCallback(lambda _: self.server_stream_info_manager.stop())
+        d.addCallback(lambda _: self.server_blob_manager.stop())
+        d.addCallback(lambda _: self.server_lbry_file_manager.stop())
+        d.addCallback(lambda _: self.server_session.shut_down())
+        d.addCallback(lambda _: self.server_stream_info_manager.stop())
 
-        if self.reflector_port is not None:
-            d.addCallback(lambda _: self.reflector_port.stopListening())
+        d.addCallback(lambda _: self.reflector_port.stopListening())
 
         def delete_test_env():
             try:

--- a/lbrynet/tests/functional/test_reflector.py
+++ b/lbrynet/tests/functional/test_reflector.py
@@ -212,6 +212,12 @@ class TestReflector(unittest.TestCase):
             self.assertEqual(self.sd_hash, files[0].sd_hash)
             self.assertEqual('test_file', files[0].file_name)
 
+            status = yield files[0].status()
+            self.assertEqual('stopped', status.running_status)
+            num_blobs = len(self.expected_blobs) -1 # subtract sd hash
+            self.assertEqual(num_blobs, status.num_completed)
+            self.assertEqual(num_blobs, status.num_known)
+
             # check should_announce blobs on blob_manager
             blob_hashes = yield self.server_blob_manager._get_all_should_announce_blob_hashes()
             self.assertEqual(2, len(blob_hashes))

--- a/lbrynet/tests/functional/test_reflector.py
+++ b/lbrynet/tests/functional/test_reflector.py
@@ -6,7 +6,6 @@ from lbrynet import lbry_file
 from lbrynet import reflector
 from lbrynet.core import BlobManager
 from lbrynet.core import PeerManager
-from lbrynet.core import RateLimiter
 from lbrynet.core import Session
 from lbrynet.core import StreamDescriptor
 from lbrynet.lbry_file import EncryptedFileMetadataManager
@@ -32,7 +31,6 @@ class TestReflector(unittest.TestCase):
         peer_manager = PeerManager.PeerManager()
         peer_finder = mocks.PeerFinder(5553, peer_manager, 2)
         hash_announcer = mocks.Announcer()
-        rate_limiter = RateLimiter.DummyRateLimiter()
         sd_identifier = StreamDescriptor.StreamDescriptorIdentifier()
 
         self.expected_blobs = [
@@ -63,7 +61,6 @@ class TestReflector(unittest.TestCase):
             blob_dir=self.blob_dir,
             peer_port=5553,
             use_upnp=False,
-            rate_limiter=rate_limiter,
             wallet=wallet,
             blob_tracker_class=mocks.BlobAvailabilityTracker,
             external_ip="127.0.0.1"


### PR DESCRIPTION
depends on https://github.com/lbryio/lbry/pull/983 . Reflector server now adds file to file manager. Needed to make a few structural changes to make this happen.

ManagedEncryptedFileDownloader had a function load_file_attribute() which is used to load claim information along with the sd_hash. Since #983 removes claim information from files, now all this function does is load the sd_hash. Move this task to the base class EncryptedFileDownloader in function set_stream_info() where it gets stream information (cleaner since we have less setup functions that needs to be run in order to load file information). 

EncryptedFileManager.add_lbry_file() has a mandatory payment_rate_manager argument which is annoying for users to specify (they need to have access to Session class, which EncryptedFileManager has already) Make it optional and use Session.payment_rate_manager.

Changes reflector tests to use file manager and check if files are loaded into file manager.


