### PR TITLE
increase SINGLE_HASH_ANNONCE_DURATION from 1 to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ at anytime.
   * Renamed `channel_list_mine` to `channel_list`
   * Changed `channel_list` to include channels where the certificate info has been imported but the claim is not in the wallet
   * Changed `file_list`, `file_delete`, `file_set_status`, and `file_reflect` to no longer return claim related information.
+  * Increased assumption for time it takes to announce single hash from 1 second to 5 seconds
 
 ### Added
   * Added `channel_import` and `channel_export` commands

--- a/lbrynet/core/server/DHTHashAnnouncer.py
+++ b/lbrynet/core/server/DHTHashAnnouncer.py
@@ -96,7 +96,7 @@ class DHTHashSupplier(object):
     MIN_HASH_REANNOUNCE_TIME = 60*60
     # conservative assumption of the time it takes to announce
     # a single hash
-    SINGLE_HASH_ANNOUNCE_DURATION = 1
+    SINGLE_HASH_ANNOUNCE_DURATION = 5
 
     """Classes derived from this class give hashes to a hash announcer"""
     def __init__(self, announcer):


### PR DESCRIPTION
This will prevent pile up in the announce queue temporarily while we work on https://github.com/lbryio/lbry/pull/961