### PR TITLE
remove download_directory from options

### DIFF
--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1594,7 +1594,6 @@ class Daemon(AuthJSONRPCServer):
         Options:
             <file_name>           : specified name for the downloaded file
             <timeout>             : download timeout in number of seconds
-            <download_directory>  : path to directory where file will be saved
 
         Returns:
             (dict) Dictionary containing information about the stream


### PR DESCRIPTION
We removed this from the parameters, but the CLI docs still show it as an option.