### PR TITLE
Support lists of address:port in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ at anytime.
   * Added `wallet_unlock`, a command available during startup to unlock an encrypted wallet
   * Added support for wallet encryption via new commands `wallet_decrypt` and `wallet_encrypt`
   * Added `blob_availability` and `stream_availability` commands for debugging download issues
+  * Changed config file format of `known_dht_nodes`, `lbryum_servers`, and `reflector_servers` to lists of `hostname:port` strings
 
 ### Removed
   * Removed claim related filter arguments `name`, `claim_id`, and `outpoint` from `file_list`, `file_delete`, `file_set_status`, and `file_reflect`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ at anytime.
   * Removed unused files
   * Removed old and unused UI related code
   * Removed claim information from lbry file internals
+  * Removed `auto_re_reflect` setting from the conf file, use the `reflect_uploads` setting instead
 
 
 ## [0.18.0] - 2017-11-08

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -277,11 +277,9 @@ ADJUSTABLE_SETTINGS = {
     'peer_port': (int, 3333),
     'pointtrader_server': (str, 'http://127.0.0.1:2424'),
     'reflector_port': (int, 5566),
-    # if reflect_uploads is True, reflect files on publish
+    # if reflect_uploads is True, send files to reflector (after publishing as well as a
+    # periodic check in the event the initial upload failed or was disconnected part way through
     'reflect_uploads': (bool, True),
-    # if auto_re_reflect is True, attempt to re-reflect files on startup and
-    # at every auto_re_reflect_interval seconds, useful if initial reflect is unreliable
-    'auto_re_reflect': (bool, True),
     'auto_re_reflect_interval': (int, 3600),
     'reflector_servers': (list, [('reflector2.lbry.io', 5566)], server_list),
     'run_reflector_server': (bool, False),

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -546,8 +546,8 @@ class Daemon(AuthJSONRPCServer):
 
                 log.info("Using lbryum wallet")
 
-                lbryum_servers = {address.split(":")[0]: {'t': str(address.split(":")[1])}
-                                  for address in conf.settings['lbryum_servers']}
+                lbryum_servers = {address: {'t': str(port)}
+                                  for address, port in conf.settings['lbryum_servers']}
 
                 config = {
                     'auto_connect': True,

--- a/lbrynet/file_manager/EncryptedFileManager.py
+++ b/lbrynet/file_manager/EncryptedFileManager.py
@@ -32,7 +32,7 @@ class EncryptedFileManager(object):
 
     def __init__(self, session, stream_info_manager, sd_identifier, download_directory=None):
 
-        self.auto_re_reflect = conf.settings['auto_re_reflect']
+        self.auto_re_reflect = conf.settings['reflect_uploads']
         self.auto_re_reflect_interval = conf.settings['auto_re_reflect_interval']
         self.session = session
         self.stream_info_manager = stream_info_manager


### PR DESCRIPTION
This allows easily specifying the `reflector_servers`, `lbryum_servers`, and `known_dht_nodes` in the config file