### PR TITLE
fixes for the --conf flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ at anytime.
   * Added abandon information (claim name, id, address, amount, balance_delta and nout) about claims, supports, and updates to `transaction_list` results under `abandon_info` key
   * Added `permanent_url` attribute to `channel_list_mine`, `claim_list`, `claim_show`, `resolve` and `resolve_name` API calls through lbryio/lbryum#203
   *
+  * Added `--conf` CLI flag to lbrynet-cli tool to specify an alternative config file
 
 ### Changed
   * claim_show API command no longer takes name as argument

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -509,6 +509,10 @@ class Config(object):
                 converted[k] = v
         return converted
 
+    def initialize_post_conf_load(self):
+        settings.installation_id = settings.get_installation_id()
+        settings.node_id = settings.get_node_id()
+
     def load_conf_file_settings(self):
         if conf_file:
             path = conf_file
@@ -527,6 +531,9 @@ class Config(object):
             self._data[TYPE_PERSISTED].update(self._convert_conf_file_lists(decoded))
         except (IOError, OSError) as err:
             log.info('%s: Failed to update settings from %s', err, path)
+
+        #initialize members depending on config file
+        self.initialize_post_conf_load()
 
     def _fix_old_conf_file_settings(self, settings_dict):
         if 'API_INTERFACE' in settings_dict:
@@ -628,7 +635,5 @@ def initialize_settings(load_conf_file=True):
     if settings is None:
         settings = Config(FIXED_SETTINGS, ADJUSTABLE_SETTINGS,
                           environment=get_default_env())
-        settings.installation_id = settings.get_installation_id()
-        settings.node_id = settings.get_node_id()
         if load_conf_file:
             settings.load_conf_file_settings()

--- a/lbrynet/daemon/DaemonCLI.py
+++ b/lbrynet/daemon/DaemonCLI.py
@@ -38,8 +38,22 @@ def set_flag_vals(flag_names, parsed_args):
 
 
 def main():
-    if len(sys.argv[1:]):
-        method, args = sys.argv[1], sys.argv[2:]
+    argv = sys.argv[1:]
+
+    # check if a config file has been specified. If so, shift
+    # all the arguments so that the parsing can continue without
+    # noticing
+    if len(argv) and argv[0] == "--conf":
+        if len(argv) < 2:
+            print_error("No config file specified for --conf option")
+            print_help()
+            return
+
+        conf.conf_file = argv[1]
+        argv = argv[2:]
+
+    if len(argv):
+        method, args = argv[0], argv[1:]
     else:
         print_help()
         return
@@ -176,13 +190,14 @@ def print_help():
         "   lbrynet-cli - LBRY command line client.",
         "",
         "USAGE",
-        "   lbrynet-cli <command> [<args>]",
+        "   lbrynet-cli [--conf <config file>] <command> [<args>]",
         "",
         "EXAMPLES",
-        "   lbrynet-cli commands            # list available commands",
-        "   lbrynet-cli status              # get daemon status",
-        "   lbrynet-cli resolve_name what   # resolve a name",
-        "   lbrynet-cli help resolve_name   # get help for a command",
+        "   lbrynet-cli commands                 # list available commands",
+        "   lbrynet-cli status                   # get daemon status",
+        "   lbrynet-cli --conf ~/l1.conf status  # like above but using ~/l1.conf as config file",
+        "   lbrynet-cli resolve_name what        # resolve a name",
+        "   lbrynet-cli help resolve_name        # get help for a command",
     ])
 
 


### PR DESCRIPTION
When starting a daemon with a different configuration,
the same should also be used by the cli tool.

Add the --conf flag to the cli command to allow using a
custom config file.

Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>