### PR TITLE
Add exception for non-float bids when pubishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ can and probably will change functionality and break backwards compatability
 at anytime.
 
 ## [Unreleased]
+### Added
+  * Added new exception for non-float values being passed in the `bid` parameter for the `publish` method
 ### Security
   *
   *

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1966,6 +1966,9 @@ class Daemon(AuthJSONRPCServer):
         except (TypeError, URIParseError):
             raise Exception("Invalid name given to publish")
 
+        if not isinstance(bid, float):
+            raise Exception("Bid must be a float")
+
         if bid <= 0.0:
             raise Exception("Invalid bid")
 


### PR DESCRIPTION
When using the API, if you provide `"bid": .000001` you'll receive an exception for improperly formatted JSON, but if you use `"bid": ".000001"`you'll receive and exception stating "Insufficient funds. Make sure you have enough LBC to deposit". This is a (potentially) inaccurate message. The problem is that the API is comparing the bid,which was passed as a string, to the wallet balance, which is a float. This pull request changes that exception to give the developer more correct reasoning to why the API call failed.