### PR TITLE
API call to blob_list with uri parameter now succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ at anytime.
   * Fixed handling decryption error for blobs encrypted with an invalid key
   * Fixed handling stream with no data blob (https://github.com/lbryio/lbry/issues/905)
   * Fixed fetching the external ip
+  * Fixed API call to blob_list with --uri parameter (https://github.com/lbryio/lbry/issues/895)
 
 ### Deprecated
   * `channel_list_mine`, replaced with `channel_list`

--- a/lbrynet/core/utils.py
+++ b/lbrynet/core/utils.py
@@ -134,31 +134,15 @@ def get_sd_hash(stream_info):
         return None
     if isinstance(stream_info, ClaimDict):
         return stream_info.source_hash
-    path = ['claim', 'value', 'stream', 'source', 'source']
-    result = safe_dict_descend(stream_info, *path)
+    result = stream_info.get('claim', {}).\
+        get('value', {}).\
+        get('stream', {}).\
+        get('source', {}).\
+        get('source')
     if not result:
-        log.warn("Unable to get sd_hash via path %s" % path)
+        log.warn("Unable to get sd_hash")
     return result
 
 
 def json_dumps_pretty(obj, **kwargs):
     return json.dumps(obj, sort_keys=True, indent=2, separators=(',', ': '), **kwargs)
-
-
-def safe_dict_descend(source, *path):
-    """
-    For when you want to do something like
-    stream_info['claim']['value']['stream']['source']['source']"
-    but don't trust that every last one of those keys exists
-    """
-    cur_source = source
-    for path_entry in path:
-        try:
-            if path_entry not in cur_source:
-                return None
-        except TypeError:
-            # This happens if we try to keep going along a path that isn't
-            # a dictionary (see e.g. test_safe_dict_descend_typeerror)
-            return None
-        cur_source = cur_source[path_entry]
-    return cur_source

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -2881,7 +2881,10 @@ class Daemon(AuthJSONRPCServer):
         if uri:
             metadata = yield self._resolve_name(uri)
             sd_hash = utils.get_sd_hash(metadata)
-            blobs = yield self.get_blobs_for_sd_hash(sd_hash)
+            try:
+                blobs = yield self.get_blobs_for_sd_hash(sd_hash)
+            except NoSuchSDHash:
+                blobs = []
         elif stream_hash:
             try:
                 blobs = yield self.get_blobs_for_stream_hash(stream_hash)

--- a/lbrynet/tests/unit/core/test_utils.py
+++ b/lbrynet/tests/unit/core/test_utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from lbrynet.core import utils
-from lbryschema.claim import ClaimDict
 
 from twisted.trial import unittest
 

--- a/lbrynet/tests/unit/core/test_utils.py
+++ b/lbrynet/tests/unit/core/test_utils.py
@@ -31,3 +31,47 @@ class ObfuscationTest(unittest.TestCase):
         plain = '☃'
         obf = utils.obfuscate(plain)
         self.assertEqual(plain, utils.deobfuscate(obf))
+
+
+class SafeDictDescendTest(unittest.TestCase):
+
+    def test_safe_dict_descend_happy(self):
+        nested = {
+            'foo': {
+                'bar': {
+                    'baz': 3
+                }
+            }
+        }
+        self.assertEqual(
+            utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'),
+            3
+        )
+
+    def test_safe_dict_descend_typeerror(self):
+        nested = {
+            'foo': {
+                'bar': 7
+            }
+        }
+        self.assertIsNone(utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'))
+
+    def test_safe_dict_descend_missing(self):
+        nested = {
+            'foo': {
+                'barn': 7
+            }
+        }
+        self.assertIsNone(utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'))
+
+    def test_empty_dict_doesnt_explode(self):
+        nested = {}
+        self.assertIsNone(utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'))
+
+    def test_identity(self):
+        nested = {
+            'foo': {
+                'bar': 7
+            }
+        }
+        self.assertIs(nested, utils.safe_dict_descend(nested))

--- a/lbrynet/tests/unit/core/test_utils.py
+++ b/lbrynet/tests/unit/core/test_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from lbrynet.core import utils
+from lbryschema.claim import ClaimDict
 
 from twisted.trial import unittest
 
@@ -33,45 +34,31 @@ class ObfuscationTest(unittest.TestCase):
         self.assertEqual(plain, utils.deobfuscate(obf))
 
 
-class SafeDictDescendTest(unittest.TestCase):
+class SdHashTests(unittest.TestCase):
 
-    def test_safe_dict_descend_happy(self):
-        nested = {
-            'foo': {
-                'bar': {
-                    'baz': 3
+    def test_none_in_none_out(self):
+        self.assertIsNone(utils.get_sd_hash(None))
+
+    def test_ordinary_dict(self):
+        claim = {
+            "claim": {
+                "value": {
+                    "stream": {
+                        "source": {
+                            "source": "0123456789ABCDEF"
+                        }
+                    }
                 }
             }
         }
-        self.assertEqual(
-            utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'),
-            3
-        )
+        self.assertEqual("0123456789ABCDEF", utils.get_sd_hash(claim))
 
-    def test_safe_dict_descend_typeerror(self):
-        nested = {
-            'foo': {
-                'bar': 7
+    def test_old_shape_fails(self):
+        claim = {
+            "stream": {
+                "source": {
+                    "source": "0123456789ABCDEF"
+                }
             }
         }
-        self.assertIsNone(utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'))
-
-    def test_safe_dict_descend_missing(self):
-        nested = {
-            'foo': {
-                'barn': 7
-            }
-        }
-        self.assertIsNone(utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'))
-
-    def test_empty_dict_doesnt_explode(self):
-        nested = {}
-        self.assertIsNone(utils.safe_dict_descend(nested, 'foo', 'bar', 'baz'))
-
-    def test_identity(self):
-        nested = {
-            'foo': {
-                'bar': 7
-            }
-        }
-        self.assertIs(nested, utils.safe_dict_descend(nested))
+        self.assertIsNone(utils.get_sd_hash(claim))


### PR DESCRIPTION
This is a fix for Issue #895 :

The shape of the claim data appears to have changed, from `['stream']['source']['source']`
to `['claim']['value']['stream']['source']['source']`.  I changed the path, and also wrote a utility function to safely delve along the path and return None if it doesn't work.  If that
happens, I log a warning so that if the shape changes again we know exactly where to look
and can easily see what the problem is from the logs.

I also found that attempting to get the blob_list via URI of an item that hadn't been downloaded
resulted in an error:

```
lbrynet.core.Error.NoSuchSDHash: 92b8aae7a901c56901fd5602c1f1acc0e63fb5492ef2a3cd5b9c631d92cab2e060e2a908baa922c24dee6c5229a98136

```

Whereas attempting to search via the `sd_hash` param performed normally; I've added the same
error handling functionality to the URI search that the hash search currently has.