### PR TITLE
update channel balance checking to match claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ at anytime.
   * `blob_announce` error when announcing a single blob
   * `blob_list` error when looking up blobs by stream or sd hash
   * issue#1107 whereing claiming a channel with the exact amount present in wallet would give out proper error
-  *
+  * Fix channel creation to use same bid logic as claim ([1148])(https://github.com/lbryio/lbry/pull/1148)
 
 ### Deprecated
   * `report_bug` jsonrpc command

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1851,7 +1851,7 @@ class Daemon(AuthJSONRPCServer):
             raise Exception("Invalid channel name")
         if amount <= 0:
             raise Exception("Invalid amount")
-        
+
         yield self.session.wallet.update_balance()
         if amount >= self.session.wallet.get_balance():
             balance = yield self.session.wallet.get_max_usable_balance_for_claim(channel_name)

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1851,17 +1851,19 @@ class Daemon(AuthJSONRPCServer):
             raise Exception("Invalid channel name")
         if amount <= 0:
             raise Exception("Invalid amount")
-
-        balance = yield self.session.wallet.get_max_usable_balance_for_claim(channel_name)
-        max_bid_amount = balance - MAX_UPDATE_FEE_ESTIMATE
-        if balance <= MAX_UPDATE_FEE_ESTIMATE:
-            raise InsufficientFundsError(
-                "Insufficient funds, please deposit additional LBC. Minimum additional LBC needed {}"
-                .format(MAX_UPDATE_FEE_ESTIMATE - balance))
-        elif amount > max_bid_amount:
-            raise InsufficientFundsError(
-                "Please lower the bid value, the maximum amount you can specify for this claim is {}"
-                .format(max_bid_amount))
+        
+        yield self.session.wallet.update_balance()
+        if amount >= self.session.wallet.get_balance():
+            balance = yield self.session.wallet.get_max_usable_balance_for_claim(channel_name)
+            max_bid_amount = balance - MAX_UPDATE_FEE_ESTIMATE
+            if balance <= MAX_UPDATE_FEE_ESTIMATE:
+                raise InsufficientFundsError(
+                    "Insufficient funds, please deposit additional LBC. Minimum additional LBC needed {}"
+                .   format(MAX_UPDATE_FEE_ESTIMATE - balance))
+            elif amount > max_bid_amount:
+                raise InsufficientFundsError(
+                    "Please lower the bid value, the maximum amount you can specify for this channel is {}"
+                    .format(max_bid_amount))
 
         result = yield self.session.wallet.claim_new_channel(channel_name, amount)
         self.analytics_manager.send_new_channel()
@@ -2047,7 +2049,7 @@ class Daemon(AuthJSONRPCServer):
                     .format(MAX_UPDATE_FEE_ESTIMATE - balance))
             elif bid > max_bid_amount:
                 raise InsufficientFundsError(
-                    "Please lower the bid. After accounting for the estimated fee, you only have {} left."
+                    "Please lower the bid value, the maximum amount you can specify for this claim is {}."
                     .format(max_bid_amount))
 
         metadata = metadata or {}


### PR DESCRIPTION
Simple balance check before calling get_max_usable_balance_for_claim - matches what happens on the claim.

Also provide clearer error message about maximum amount