### PR TITLE
return error correctly when resolving invalid/expired url. fixes #1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ at anytime.
   * `use_auth_http` in a config file being overridden by the default command line argument to `lbrynet-daemon`, now the command line value will only override the config file value if it is provided
   * `lbrynet-cli` not automatically switching to the authenticated client if the server is detected to be using authentication. This resulted in `lbrynet-cli` failing to run when `lbrynet-daemon` was run with the `--http-auth` flag
   * fixed error when using `claim_show` with `txid` and `nout` arguments
+  * fixed resolving expired URLs
 
 ### Deprecated
   *

--- a/lbrynet/core/Wallet.py
+++ b/lbrynet/core/Wallet.py
@@ -366,9 +366,10 @@ class Wallet(object):
             claim['value'] = claim_dict
             claim['hex'] = decoded.serialized.encode('hex')
         except DecodeError:
-            claim['hex'] = claim['value']
-            claim['value'] = None
-            claim['error'] = "Failed to decode value"
+            raise UnknownURI(claim['permanent_url'] if 'permanent_url' in claim else "")
+            # claim['hex'] = claim['value']
+            # claim['value'] = None
+            # claim['error'] = "Failed to decode value"
         return claim
 
     def _handle_claim_result(self, results):


### PR DESCRIPTION
I don't know if this is the right solution. The whole thing is a mess of raising and reraising exceptions, and sometimes not raising but just setting an `error` value on a dict. This seems to work. If there's a better way to do this, please teach me.

The error was actually happening when `Wallet.save_claim()` was being called on a claim with a value of `None`. I see several other places where that's in danger of happening (does it actually happen there? idk). 

I think the REAL solution is for lbryschema to raise something more descriptive than `DecodeError` (is it really a decoding error when you successfully decode an expired url?) and for the daemon to catch that error and handle it correctly.