### PR TITLE
Treq and cryptography instead of txrequests and pycrypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ at anytime.
   * 
   
 ### Changed
+  * changed cryptography version to 2.2.2
+  * removed pycrypto dependency, replacing all calls to cryptography
   * several internal dht functions to use inlineCallbacks
   * `DHTHashAnnouncer` and `Node` manage functions to use `LoopingCall`s instead of scheduling with `callLater`.
   * `store` kademlia rpc method to block on the call finishing and to return storing peer information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ at anytime.
   * 
   
 ### Changed
+  * changed txrequests for treq
   * changed cryptography version to 2.2.2
   * removed pycrypto dependency, replacing all calls to cryptography
   * several internal dht functions to use inlineCallbacks

--- a/lbrynet/core/system_info.py
+++ b/lbrynet/core/system_info.py
@@ -37,7 +37,7 @@ def get_platform(get_ip=True):
         "build": build_type.BUILD,  # CI server sets this during build step
     }
 
-    # TODO: remove this from get_platform and add a get_external_ip function using txrequests
+    # TODO: remove this from get_platform and add a get_external_ip function using treq
     if get_ip:
         try:
             response = json.loads(urlopen("https://api.lbry.io/ip").read())

--- a/lbrynet/cryptstream/CryptStreamCreator.py
+++ b/lbrynet/cryptstream/CryptStreamCreator.py
@@ -1,12 +1,12 @@
 """
 Utility for creating Crypt Streams, which are encrypted blobs and associated metadata.
 """
-
+import os
 import logging
+
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from twisted.internet import interfaces, defer
 from zope.interface import implements
-from Crypto import Random
-from Crypto.Cipher import AES
 from lbrynet.cryptstream.CryptBlob import CryptStreamBlobMaker
 
 
@@ -101,13 +101,13 @@ class CryptStreamCreator(object):
     @staticmethod
     def random_iv_generator():
         while 1:
-            yield Random.new().read(AES.block_size)
+            yield os.urandom(AES.block_size / 8)
 
     def setup(self):
         """Create the symmetric key if it wasn't provided"""
 
         if self.key is None:
-            self.key = Random.new().read(AES.block_size)
+            self.key = os.urandom(AES.block_size / 8)
 
         return defer.succeed(True)
 

--- a/lbrynet/tests/functional/test_misc.py
+++ b/lbrynet/tests/functional/test_misc.py
@@ -7,8 +7,7 @@ import sys
 import random
 import unittest
 
-from Crypto import Random
-from Crypto.Hash import MD5
+from hashlib import md5
 from lbrynet import conf
 from lbrynet.file_manager.EncryptedFileManager import EncryptedFileManager
 from lbrynet.core.Session import Session
@@ -98,9 +97,6 @@ class LbryUploader(object):
         from twisted.internet import reactor
         self.reactor = reactor
         logging.debug("Starting the uploader")
-        Random.atfork()
-        r = random.Random()
-        r.seed("start_lbry_uploader")
         wallet = FakeWallet()
         peer_manager = PeerManager()
         peer_finder = FakePeerFinder(5553, peer_manager, 1)
@@ -191,10 +187,6 @@ def start_lbry_reuploader(sd_hash, kill_event, dead_event,
 
     logging.debug("Starting the uploader")
 
-    Random.atfork()
-
-    r = random.Random()
-    r.seed("start_lbry_reuploader")
 
     wallet = FakeWallet()
     peer_port = 5553 + n
@@ -297,7 +289,6 @@ def start_blob_uploader(blob_hash_queue, kill_event, dead_event, slow, is_genero
 
     logging.debug("Starting the uploader")
 
-    Random.atfork()
 
     wallet = FakeWallet()
     peer_manager = PeerManager()
@@ -515,7 +506,7 @@ class TestTransfer(TestCase):
 
         def check_md5_sum():
             f = open(os.path.join(db_dir, 'test_file'))
-            hashsum = MD5.new()
+            hashsum = md5()
             hashsum.update(f.read())
             self.assertEqual(hashsum.hexdigest(), "4ca2aafb4101c1e42235aad24fbb83be")
 
@@ -688,7 +679,7 @@ class TestTransfer(TestCase):
 
         def check_md5_sum():
             f = open(os.path.join(db_dir, 'test_file'))
-            hashsum = MD5.new()
+            hashsum = md5()
             hashsum.update(f.read())
             self.assertEqual(hashsum.hexdigest(), "4ca2aafb4101c1e42235aad24fbb83be")
 
@@ -811,7 +802,7 @@ class TestTransfer(TestCase):
 
         def check_md5_sum():
             f = open('test_file')
-            hashsum = MD5.new()
+            hashsum = md5()
             hashsum.update(f.read())
             self.assertEqual(hashsum.hexdigest(), "e5941d615f53312fd66638239c1f90d5")
 

--- a/lbrynet/tests/functional/test_streamify.py
+++ b/lbrynet/tests/functional/test_streamify.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 
-from Crypto.Hash import MD5
+from hashlib import md5
 from twisted.trial.unittest import TestCase
 from twisted.internet import defer, threads
 
@@ -127,7 +127,7 @@ class TestStreamify(TestCase):
             self.assertTrue(lbry_file.sd_hash, sd_hash)
             yield lbry_file.start()
             f = open('test_file')
-            hashsum = MD5.new()
+            hashsum = md5()
             hashsum.update(f.read())
             self.assertEqual(hashsum.hexdigest(), "68959747edc73df45e45db6379dd7b3b")
 

--- a/lbrynet/tests/unit/lbryfilemanager/test_EncryptedFileCreator.py
+++ b/lbrynet/tests/unit/lbryfilemanager/test_EncryptedFileCreator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
 import mock
 from twisted.trial import unittest
 from twisted.internet import defer
@@ -18,7 +18,7 @@ MB = 2**20
 
 def iv_generator():
     while True:
-        yield '3' * AES.block_size
+        yield '3' * (AES.block_size / 8)
 
 
 class CreateEncryptedFileTest(unittest.TestCase):
@@ -47,7 +47,7 @@ class CreateEncryptedFileTest(unittest.TestCase):
     @defer.inlineCallbacks
     def create_file(self, filename):
         handle = mocks.GenFile(3*MB, '1')
-        key = '2'*AES.block_size
+        key = '2' * (AES.block_size / 8)
         out = yield EncryptedFileCreator.create_lbry_file(self.session, self.file_manager, filename, handle,
                                                           key, iv_generator())
         defer.returnValue(out)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ git+https://github.com/lbryio/lbryschema.git@v0.0.15#egg=lbryschema
 git+https://github.com/lbryio/lbryum.git@v3.2.1#egg=lbryum
 miniupnpc==1.9
 pbkdf2==1.3
-pycrypto==2.6.1
 pyyaml==3.12
 PyGithub==1.34
 qrcode==5.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Twisted==16.6.0
-cryptography==2.0.3
+cryptography==2.2.2
 appdirs==1.4.3
 argparse==1.2.1
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ pyyaml==3.12
 PyGithub==1.34
 qrcode==5.2.2
 requests==2.9.1
-txrequests==0.9.5
 service_identity==16.0.0
 six>=1.9.0
 slowaes==0.1a1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ requires = [
     'miniupnpc',
     'pyyaml',
     'requests',
-    'txrequests',
     'txJSON-RPC',
     'zope.interface',
     'docopt'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ requires = [
     'lbryschema==0.0.15',
     'lbryum==3.2.1',
     'miniupnpc',
-    'pycrypto',
     'pyyaml',
     'requests',
     'txrequests',


### PR DESCRIPTION
Changes:
* change pycrypto to cryptography (we were mixing them)
* change txrequests to treq (avoids some thread pools)
* change requests to treq on Exchange Manager

Optional changes included here (easy to drop):
* change wallet download to support resuming downloads from s3 (download the missing part of the header file instead of everything)

Probably to change (maybe in another PR):
* add a method to check headers integrity on start up. This way we can automate the remove and download, avoiding the user to get frustrated solving it.