### PR TITLE
track successful reflector uploads in sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ at anytime.
   * support both positional and keyword args for api calls
   * `peer_list` to return a list of dictionaries instead of a list of lists, added peer node ids to the results
   * download blockchain headers from s3 before starting the wallet when the local height is more than `s3_headers_depth` (a config setting) blocks behind
+  * track successful reflector uploads in sqlite to minimize how many streams are attempted by auto re-reflect
+  * increase the default `auto_re_reflect_interval` to a day
 
 ### Added
   * virtual kademlia network and mock udp transport for dht integration tests

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -280,10 +280,10 @@ ADJUSTABLE_SETTINGS = {
     'peer_port': (int, 3333),
     'pointtrader_server': (str, 'http://127.0.0.1:2424'),
     'reflector_port': (int, 5566),
-    # if reflect_uploads is True, send files to reflector (after publishing as well as a
-    # periodic check in the event the initial upload failed or was disconnected part way through
+    # if reflect_uploads is True, send files to reflector after publishing (as well as a periodic check in the
+    # event the initial upload failed or was disconnected part way through, provided the auto_re_reflect_interval > 0)
     'reflect_uploads': (bool, True),
-    'auto_re_reflect_interval': (int, 3600),
+    'auto_re_reflect_interval': (int, 86400),  # set to 0 to disable
     'reflector_servers': (list, [('reflector2.lbry.io', 5566)], server_list),
     'run_reflector_server': (bool, False),
     'sd_download_timeout': (int, 3),

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -199,7 +199,7 @@ class Daemon(AuthJSONRPCServer):
         self.connected_to_internet = True
         self.connection_status_code = None
         self.platform = None
-        self.current_db_revision = 7
+        self.current_db_revision = 8
         self.db_revision_file = conf.settings.get_db_revision_filename()
         self.session = None
         self._session_id = conf.settings.get_session_id()

--- a/lbrynet/database/migrator/dbmigrator.py
+++ b/lbrynet/database/migrator/dbmigrator.py
@@ -16,6 +16,8 @@ def migrate_db(db_dir, start, end):
             from lbrynet.database.migrator.migrate5to6 import do_migration
         elif current == 6:
             from lbrynet.database.migrator.migrate6to7 import do_migration
+        elif current == 7:
+            from lbrynet.database.migrator.migrate7to8 import do_migration
         else:
             raise Exception("DB migration of version {} to {} is not available".format(current,
                                                                                        current+1))

--- a/lbrynet/database/migrator/migrate7to8.py
+++ b/lbrynet/database/migrator/migrate7to8.py
@@ -1,0 +1,21 @@
+import sqlite3
+import os
+
+
+def do_migration(db_dir):
+    db_path = os.path.join(db_dir, "lbrynet.sqlite")
+    connection = sqlite3.connect(db_path)
+    cursor = connection.cursor()
+
+    cursor.executescript(
+        """
+        create table reflected_stream (
+            sd_hash text not null,
+            reflector_address text not null,
+            timestamp integer,
+            primary key (sd_hash, reflector_address)
+        );
+        """
+    )
+    connection.commit()
+    connection.close()


### PR DESCRIPTION
-add `reflected_stream` table to the database to track reflector uploads so we don't check reflector server unnecessarily 
-increase the default `auto_re_reflect_interval` to a day