### PR TITLE
fixes bug when saving server list to conf file (issues #1109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ at anytime.
   * `use_auth_http` in a config file being overridden by the default command line argument to `lbrynet-daemon`, now the command line value will only override the config file value if it is provided
   * `lbrynet-cli` not automatically switching to the authenticated client if the server is detected to be using authentication. This resulted in `lbrynet-cli` failing to run when `lbrynet-daemon` was run with the `--http-auth` flag
   * fixed error when using `claim_show` with `txid` and `nout` arguments
+  * fixed error when saving server list to conf file (issue #1109)
 
 ### Deprecated
   *


### PR DESCRIPTION
When server lists (e.g. lbryum_servers) are loaded from the configuration file, the format address:port is converted to a tuple (address, port). When settings are changed and the configuration file gets overwritten, this conversion must be reversed. 