### PR TITLE
Blobs mirroring (Look up blobs using HTTP in parallel with DHT lookup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ at anytime.
   * predictable result sorting for `claim_list` and `claim_list_mine`
 
 ### Added
+  * adds `blob_server_domains` to conf and the ability to use HTTP mirroring during p2p downloads, if possible
   * virtual kademlia network and mock udp transport for dht integration tests
   * integration tests for bootstrapping the dht
   * configurable `concurrent_announcers` and `s3_headers_depth` settings

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -290,6 +290,7 @@ ADJUSTABLE_SETTINGS = {
     'sd_download_timeout': (int, 3),
     'share_usage_data': (bool, True),  # whether to share usage stats and diagnostic info with LBRY
     'peer_search_timeout': (int, 3),
+    'blob_server_domains': (list, ['blobs.lbry.io']),  # blob HTTP mirrors for fallback
     'use_auth_http': (bool, False),
     'use_upnp': (bool, True),
     'use_keyring': (bool, False),

--- a/lbrynet/core/BlobMirror.py
+++ b/lbrynet/core/BlobMirror.py
@@ -1,0 +1,57 @@
+from random import choice
+import logging
+
+from twisted.internet import defer
+import treq
+
+from lbrynet import conf
+
+
+log = logging.getLogger(__name__)
+
+
+class BlobMirror(object):
+    def __init__(self, blob_manager, servers=None, client=None):
+        self.servers = list(servers or conf.settings['blob_server_domains'])
+        self.client = client or treq
+        self.blob_manager = blob_manager
+
+    @defer.inlineCallbacks
+    def get_all_missing_blobs(self):
+        blobs = self.blob_manager.blobs.itervalues()
+        needed = [blob for blob in blobs if not blob.get_is_verified()]
+        for success, (blob, we_have_it) in (yield defer.DeferredList(map(self.has_blob, needed))):
+            if we_have_it:
+                self._get_blob(blob)
+
+    @defer.inlineCallbacks
+    def has_blob(self, blob):
+        print(url_for(choice(self.servers), blob.blob_hash))
+        has_it = (yield self.client.head(url_for(choice(self.servers), blob.blob_hash))).code == 200
+        defer.returnValue((blob, has_it))
+
+    def get_blob(self, blob_hash):
+        if blob_hash in self.blob_manager.blobs:
+            return self._get_blob(self.blob_manager.blobs[blob_hash])
+
+    @defer.inlineCallbacks
+    def _get_blob(self, blob):
+        response = yield self.client.get(url_for(choice(self.servers), blob.blob_hash))
+        if response.code == 200 and not blob.is_downloading() and 'mirror' not in blob.writers:
+            blob.set_length(response.length)
+            writer, finished_deferred = blob.open_for_writing('mirror')
+            finished_deferred.addCallback(self._on_completed_blob)
+            finished_deferred.addErrback(self._on_failed)
+            d = treq.collect(response, writer.write)
+            d.addErrback(self._on_failed)
+            d.addBoth(lambda _: writer.close())
+
+    def _on_completed_blob(self, blob):
+        log.debug('Mirror completed download for %s', blob.blob_hash)
+
+    def _on_failed(self, err):
+        log.debug('Mirror failed downloading')
+
+
+def url_for(server, blob_hash=''):
+    return 'http://{}/{}'.format(server, blob_hash)

--- a/lbrynet/core/client/BlobRequester.py
+++ b/lbrynet/core/client/BlobRequester.py
@@ -7,6 +7,7 @@ from twisted.python.failure import Failure
 from twisted.internet.error import ConnectionAborted
 from zope.interface import implements
 
+from lbrynet.core.BlobMirror import BlobMirror
 from lbrynet.core.Error import ConnectionClosedBeforeResponseError
 from lbrynet.core.Error import InvalidResponseError, RequestCanceledError, NoResponseError
 from lbrynet.core.Error import PriceDisagreementError, DownloadCanceledError, InsufficientFundsError
@@ -57,6 +58,7 @@ class BlobRequester(object):
         self._protocol_tries = {}
         self._maxed_out_peers = []
         self._incompatible_peers = []
+        self.mirror = BlobMirror(blob_manager)
 
     ######## IRequestCreator #########
     def send_next_request(self, peer, protocol):
@@ -142,6 +144,8 @@ class BlobRequester(object):
             without_bad_peers = [p for p in peers if not p in bad_peers]
             without_maxed_out_peers = [
                 p for p in without_bad_peers if p not in self._maxed_out_peers]
+            if not without_bad_peers:
+                self.mirror.get_blob(h)
             return without_maxed_out_peers
 
         d.addCallback(choose_best_peers)

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -14,6 +14,7 @@ from twisted.internet import defer, threads, error, reactor
 from twisted.internet.task import LoopingCall
 from twisted.python.failure import Failure
 
+from lbrynet.core.BlobMirror import BlobMirror
 from lbryschema.claim import ClaimDict
 from lbryschema.uri import parse_lbry_uri
 from lbryschema.error import URIParseError, DecodeError
@@ -684,7 +685,8 @@ class Daemon(AuthJSONRPCServer):
             self.streams[sd_hash] = GetStream(self.sd_identifier, self.session,
                                               self.exchange_rate_manager, self.max_key_fee,
                                               self.disable_max_key_fee,
-                                              conf.settings['data_rate'], timeout)
+                                              conf.settings['data_rate'], timeout,
+                                              mirror=BlobMirror(self.session.blob_manager))
             try:
                 lbry_file, finished_deferred = yield self.streams[sd_hash].start(
                     claim_dict, name, txid, nout, file_name

--- a/lbrynet/daemon/Downloader.py
+++ b/lbrynet/daemon/Downloader.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 class GetStream(object):
     def __init__(self, sd_identifier, session, exchange_rate_manager,
-                 max_key_fee, disable_max_key_fee, data_rate=None, timeout=None):
+                 max_key_fee, disable_max_key_fee, data_rate=None, timeout=None, mirror=None):
 
         self.timeout = timeout or conf.settings['download_timeout']
         self.data_rate = data_rate or conf.settings['data_rate']
@@ -53,6 +53,7 @@ class GetStream(object):
         self.finished_deferred = None
         # fired after the metadata and the first data blob have been downloaded
         self.data_downloading_deferred = defer.Deferred(None)
+        self.mirror = mirror
 
     @property
     def download_path(self):
@@ -84,6 +85,8 @@ class GetStream(object):
             d.addCallback(self._check_status)
         else:
             log.debug("Waiting for stream descriptor (%i seconds)", self.timeout_counter)
+            if self.mirror:
+                self.mirror.get_blob(self.sd_hash)
 
     def convert_max_fee(self):
         currency, amount = self.max_key_fee['currency'], self.max_key_fee['amount']


### PR DESCRIPTION
For https://github.com/lbryio/lbry/issues/1212

Original title is "Look up blobs using HTTP in parallel with DHT lookup" and original idea was to do it as soon as possible. I tried my best to do it in a way that can be called anywhere in the codebase (as long as the caller has a way to get a blob_manager) and implemented in a middle ground between "when it fails" and "right on start". We can discuss where it's best to move it and I also tried to make it so it's easy to completely remove from our code (nobody really depends on it, they just ask help and ignore the result without even waiting for the deferred to fire).

One should notice that there is an unused method called `get_all_missing_blobs`. I added for the sake of having it so we can call during `blob_list --needed`, for instance, to fix all missing ones, however the reviewers are free to ask its removal if after discussing we find no usage for that.