### PR TITLE
Fix stop raising `NoneType' object has no attribute 'finished_deferred'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ at anytime.
   *
 
 ### Fixed
-  *
+  * Fixed a scenario where stopping downloads raises `NoneType object has no attribute finished_deferred`.
   *
 
 ### Deprecated

--- a/lbrynet/core/client/ClientProtocol.py
+++ b/lbrynet/core/client/ClientProtocol.py
@@ -116,8 +116,8 @@ class ClientProtocol(Protocol, TimeoutMixin):
             d.errback(err)
             ds.append(d)
         if self._blob_download_request is not None:
-            self._blob_download_request.cancel(err)
             ds.append(self._blob_download_request.finished_deferred)
+            self._blob_download_request.cancel(err)
             self._blob_download_request = None
         self._downloading_blob = False
         return defer.DeferredList(ds)


### PR DESCRIPTION
`cancel` call can trigger error handlers, which in turns makes the object None, which makes the next line fail. Reordering lines ensures we collect the deferred before the object attribute becomes None by error handlers.

Steps to reproduce:
Option 1:
1. Download with a very tight impossible timeout, like 4 or 5. (adjust at will, maybe my connection is _that_ bad)

Option 2 (easier):
1. Cancel (file_set_status stop) an ongoing download.