### PR TITLE
Stop conditions on find value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ at anytime.
   *
 
 ### Changed
+  * change iterative find stop condition on find value to allow it to continue until a value is found (or it times out)
   * include all of our own blobs in the local dht datastore (as if we had announced them to ourselves)
   * ignore dht `store` token validation errors for the first expiration-time after startup (fixes failed `store` requests after a restart)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ at anytime.
   *
 
 ### Changed
+  * default for `peer_search_timeout` raised from 3 to 30 and being logged on console
   * change iterative find stop condition on find value to allow it to continue until a value is found (or it times out)
   * include all of our own blobs in the local dht datastore (as if we had announced them to ourselves)
   * ignore dht `store` token validation errors for the first expiration-time after startup (fixes failed `store` requests after a restart)

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -291,7 +291,7 @@ ADJUSTABLE_SETTINGS = {
     'run_reflector_server': (bool, False),
     'sd_download_timeout': (int, 3),
     'share_usage_data': (bool, True),  # whether to share usage stats and diagnostic info with LBRY
-    'peer_search_timeout': (int, 3),
+    'peer_search_timeout': (int, 30),
     'use_auth_http': (bool, False),
     'use_upnp': (bool, True),
     'use_keyring': (bool, False),

--- a/lbrynet/dht/iterativefind.py
+++ b/lbrynet/dht/iterativefind.py
@@ -134,6 +134,9 @@ class _IterativeFind(object):
             defer.returnValue(contact.id)
 
     def should_stop(self):
+        if self.is_find_value_request:
+            # search stops when it finds a value, let it run
+            return False
         if self.prev_closest_node and self.closest_node and self.distance.is_closer(self.prev_closest_node.id,
                                                                                     self.closest_node.id):
             # we're getting further away

--- a/lbrynet/dht/peerfinder.py
+++ b/lbrynet/dht/peerfinder.py
@@ -48,6 +48,7 @@ class DHTPeerFinder(DummyPeerFinder):
         try:
             peer_list = yield finished_deferred
         except defer.TimeoutError:
+            log.warning("DHT timed out while looking peers for blob {}".format(blob_hash))
             peer_list = []
 
         peers = set(peer_list)

--- a/lbrynet/dht/peerfinder.py
+++ b/lbrynet/dht/peerfinder.py
@@ -4,6 +4,7 @@ import logging
 from zope.interface import implements
 from twisted.internet import defer
 from lbrynet.interfaces import IPeerFinder
+from lbrynet import conf
 
 
 log = logging.getLogger(__name__)
@@ -43,12 +44,14 @@ class DHTPeerFinder(DummyPeerFinder):
         """
         bin_hash = binascii.unhexlify(blob_hash)
         finished_deferred = self.dht_node.iterativeFindValue(bin_hash)
+        timeout = timeout or conf.settings['peer_search_timeout']
         if timeout:
             finished_deferred.addTimeout(timeout, self.dht_node.clock)
         try:
             peer_list = yield finished_deferred
         except defer.TimeoutError:
-            log.warning("DHT timed out while looking peers for blob {}".format(blob_hash))
+            log.warning("DHT timed out while looking peers for blob"
+                        " %s after %s seconds.", blob_hash, timeout)
             peer_list = []
 
         peers = set(peer_list)


### PR DESCRIPTION
It already stops when it finds a value, so the other stop conditions only makes sense when collecting nearest nodes around a value and not while navigating the network looking for values.