### PR TITLE
Fix high cpu usage on incomplete streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ at anytime.
 
 ### Fixed
   * daemon cli spelling fixes
-  *
+  * high CPU usage when a stream is incomplete and the peers we're requesting from have no more blobs to send us
 
 ### Deprecated
   *

--- a/lbrynet/core/client/BlobRequester.py
+++ b/lbrynet/core/client/BlobRequester.py
@@ -354,6 +354,10 @@ class AvailabilityRequest(RequestHelper):
         log.debug("Received a response to the availability request")
         # save available blobs
         blob_hashes = response_dict['available_blobs']
+        if not blob_hashes:
+            # should not send any more requests as it doesnt have any blob we need
+            self.peer.update_score(-10.0)
+            return True
         for blob_hash in blob_hashes:
             if blob_hash in request.request_dict['requested_blobs']:
                 self.process_available_blob_hash(blob_hash, request)


### PR DESCRIPTION
If the connected peer doesnt have a blob we need we would trigger the same request in a loop, causing a high CPU usage for the time the download is stuck.