### PR TITLE
Dht shortlist without ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ at anytime.
 ### Changed
   * keep track of failures for DHT peers for up to ten minutes instead of indefinitely
   * skip ignored peers from iterative lookups instead of blocking the peer who returned them to us too
+  * if a node becomes ignored during an iterative find cycle remove it from the shortlist so that we can't return it as a result nor try to probe it anyway
 
 ### Added
   *

--- a/lbrynet/dht/iterativefind.py
+++ b/lbrynet/dht/iterativefind.py
@@ -160,6 +160,9 @@ class _IterativeFind(object):
         already_contacted_addresses = {(c.address, c.port) for c in self.already_contacted}
         to_remove = []
         for contact in self.shortlist:
+            if self.node.contact_manager.is_ignored((contact.address, contact.port)):
+                to_remove.append(contact)  # a contact became bad during iteration
+                continue
             if (contact.address, contact.port) not in already_contacted_addresses:
                 self.already_contacted.append(contact)
                 to_remove.append(contact)


### PR DESCRIPTION
During iterative find a peer can go ignored. It will occupy the search querying something that will be discarded, so this PR removes it from the shortlist so its not even considered on probing.