### PR TITLE
A More Informative Error Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ can and probably will change functionality and break backwards compatability
 at anytime.
 
 ## [Unreleased]
+
+## [0.20.3] - 2018-07-20
+### Changed
+* Additional information added to the balance error message when editing a claim.
+(https://github.com/lbryio/lbry/pull/1309)
+
 ### Security
   *
   *

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1873,8 +1873,10 @@ class Daemon(AuthJSONRPCServer):
                 .   format(MAX_UPDATE_FEE_ESTIMATE - balance))
             elif amount > max_bid_amount:
                 raise InsufficientFundsError(
-                    "Please wait for any pending bids to resolve or lower the bid value. Currently the maximum amount you can specify for this channel is {}"
-                    .format(max_bid_amount))
+                    "Please wait for any pending bids to resolve or lower the bid value. "
+                    "Currently the maximum amount you can specify for this channel is {}"
+                    .format(max_bid_amount)
+                )
 
         result = yield self.session.wallet.claim_new_channel(channel_name, amount)
         self.analytics_manager.send_new_channel()

--- a/lbrynet/daemon/Daemon.py
+++ b/lbrynet/daemon/Daemon.py
@@ -1873,7 +1873,7 @@ class Daemon(AuthJSONRPCServer):
                 .   format(MAX_UPDATE_FEE_ESTIMATE - balance))
             elif amount > max_bid_amount:
                 raise InsufficientFundsError(
-                    "Please lower the bid value, the maximum amount you can specify for this channel is {}"
+                    "Please wait for any pending bids to resolve or lower the bid value. Currently the maximum amount you can specify for this channel is {}"
                     .format(max_bid_amount))
 
         result = yield self.session.wallet.claim_new_channel(channel_name, amount)


### PR DESCRIPTION
## A More Informative Error Message

Currently, when a bid is **pending**, you can not increase another bid unless you have the **total amount** in your **balance**. You have to **wait** for any **pending** claims to **resolve** before you can do this.

The current error message, in this case, can give the **impression** that the app is **broken**.

This new error message **amendment** will prevent **angry** users from launching vigilante attacks on the LBRY HQ and mass riots!

### When Pending:
![image](https://user-images.githubusercontent.com/29914179/42949417-0fafa14c-8bb5-11e8-836c-4587c978c4ae.png)

### When Resolved

![image](https://user-images.githubusercontent.com/29914179/42949426-159626e4-8bb5-11e8-835c-b43a4df9ebca.png)
