### PR TITLE
unset mirror for tests, but let it be read on normal usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ at anytime.
   *
 
 ### Fixed
+  * mirroring being set on tests, making unrelated tests fail
   * loggly error reporting not following `share_usage_data`
   * improper error handling when data is not valid JSON
   * edge cases of http mirrored download of blobs

--- a/lbrynet/file_manager/EncryptedFileDownloader.py
+++ b/lbrynet/file_manager/EncryptedFileDownloader.py
@@ -57,7 +57,7 @@ class ManagedEncryptedFileDownloader(EncryptedFileSaver):
         self.channel_name = None
         self.metadata = None
         self.mirror = None
-        if download_mirrors:
+        if download_mirrors or conf.settings['download_mirrors']:
             self.mirror = HTTPBlobDownloader(
                 self.blob_manager, servers=download_mirrors or conf.settings['download_mirrors']
             )

--- a/lbrynet/tests/mocks.py
+++ b/lbrynet/tests/mocks.py
@@ -495,6 +495,7 @@ create_stream_sd_file = {
 
 
 def mock_conf_settings(obj, settings={}):
+    settings.setdefault('download_mirrors', [])
     conf.initialize_settings(False)
     original_settings = conf.settings
     conf.settings = conf.Config(conf.FIXED_SETTINGS, conf.ADJUSTABLE_SETTINGS)


### PR DESCRIPTION
fixes #1346 