### PR TITLE
--conf option improvements

### DIFF
--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -112,11 +112,11 @@ class SettingsTest(unittest.TestCase):
 
         # nonexistent file
         conf.conf_file = 'monkey.yml'
-        with (self.assertRaises(FileNotFoundError)):
+        with self.assertRaises(FileNotFoundError):
             settings.load_conf_file_settings()
 
         # invalid extensions
         for filename in ('monkey.yymmll', 'monkey'):
             conf.conf_file = filename
-            with (self.assertRaises(ValueError)):
+            with self.assertRaises(ValueError):
                 settings.load_conf_file_settings()

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -107,3 +107,16 @@ class SettingsTest(unittest.TestCase):
             conf_decoded_new = decoder(conf_entry_new)
             self.assertEqual(conf_decoded, conf_decoded_new)
 
+    def test_load_file(self):
+        settings = self.get_mock_config_instance()
+
+        # nonexistent file
+        conf.conf_file = 'monkey.yml'
+        with (self.assertRaises(FileNotFoundError)):
+            settings.load_conf_file_settings()
+
+        # invalid extensions
+        for filename in ('monkey.yymmll', 'monkey'):
+            conf.conf_file = filename
+            with (self.assertRaises(ValueError)):
+                settings.load_conf_file_settings()


### PR DESCRIPTION
Fix for [#1302](https://github.com/lbryio/lbry/issues/1302)
Changes:
- if provided config file does not exist, throw descriptive error with absolute path of a file
- throw ValueError, not AssertionError if provided config file has unsupported extension
- simple test for loading file