### PR TITLE
Fixes Issues within naming conventions

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -367,7 +367,7 @@
             {
                 "is_required": false, 
                 "type": "int", 
-                "name": "amount<amount>", 
+                "name": "amount", 
                 "description": "Amount of credits to claim name for, defaults to the current amount on the claim"
             }
         ], 
@@ -478,7 +478,7 @@
             {
                 "is_required": false, 
                 "type": "str", 
-                "name": "file_name<file_name>", 
+                "name": "file_name", 
                 "description": "delete by file name in downloads folder"
             }, 
             {
@@ -1230,7 +1230,7 @@
         "arguments": [
             {
                 "is_required": true, 
-                "type": "Decimal", 
+                "type": "float", 
                 "name": "amount", 
                 "description": "amount of credit to send"
             }, 


### PR DESCRIPTION
There are a couple of names that use angle brackets which cause an issue when generating these functions from scratch. There was also a variable type "Decimal" which should be changed to "float" as all the others are. 