### PR TITLE
Fixes for inexistent URIs error format and implementation of get_best_block_hash

### DIFF
--- a/lbrynet/wallet/manager.py
+++ b/lbrynet/wallet/manager.py
@@ -181,7 +181,7 @@ class LbryWalletManager(BaseWalletManager):
         return manager
 
     def get_best_blockhash(self):
-        return defer.succeed('')
+        return self.ledger.headers.hash(self.ledger.headers.height).decode()
 
     def get_unused_address(self):
         return self.default_account.receiving.get_or_create_usable_address()

--- a/lbrynet/wallet/resolve.py
+++ b/lbrynet/wallet/resolve.py
@@ -36,7 +36,9 @@ class Resolver:
                         (yield self._handle_resolve_uri_response(uri, resolution, page, page_size))
                     )
                 except (UnknownNameError, UnknownClaimID, UnknownURI) as err:
-                    results[uri] = {'error': err.message}
+                    results[uri] = {'error': str(err)}
+            else:
+                results[uri] = {'error': "URI lbry://{} cannot be resolved".format(uri.replace("lbry://", ""))}
         defer.returnValue(results)
 
     @defer.inlineCallbacks

--- a/tests/integration/wallet/test_transactions.py
+++ b/tests/integration/wallet/test_transactions.py
@@ -89,3 +89,8 @@ class BasicTransactionTest(IntegrationTestCase):
 
         response = await d2f(self.ledger.resolve(0, 10, 'lbry://@bar/foo'))
         self.assertNotIn('claim', response['lbry://@bar/foo'])
+
+        # checks for expected format in inexistent URIs
+        response = await d2f(self.ledger.resolve(0, 10, 'lbry://404', 'lbry://@404'))
+        self.assertEqual('URI lbry://404 cannot be resolved', response['lbry://404']['error'])
+        self.assertEqual('URI lbry://@404 cannot be resolved', response['lbry://@404']['error'])


### PR DESCRIPTION
closes: #1485 
closes: #1486 