### PR TITLE
Fix peer_ping command

### DIFF
--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -451,20 +451,10 @@ class Node(MockKademliaHelper):
         @rtype: twisted.internet.defer.Deferred
         """
         try:
-            contact = self._routingTable.getContact(contactID)
-            df = defer.Deferred()
-            df.callback(contact)
+            df = defer.succeed(self._routingTable.getContact(contactID))
         except (ValueError, IndexError):
-            def parseResults(nodes):
-                node_ids = [c.id for c in nodes]
-                if contactID in nodes:
-                    contact = nodes[node_ids.index(contactID)]
-                    return contact
-                else:
-                    return None
-
             df = self.iterativeFindNode(contactID)
-            df.addCallback(parseResults)
+            df.addCallback(lambda nodes: ([node for node in nodes if node.id == contactID] or (None,))[0])
         return df
 
     @rpcmethod

--- a/tests/functional/dht/test_contact_rpc.py
+++ b/tests/functional/dht/test_contact_rpc.py
@@ -269,3 +269,17 @@ class KademliaProtocolTest(unittest.TestCase):
         self.assertTrue(self.node._dataStore.hasPeersForBlob(fake_blob))
         self.assertEqual(len(self.node._dataStore.getStoringContacts()), 1)
         self.assertIs(self.node._dataStore.getStoringContacts()[0], self.remote_contact)
+
+    @defer.inlineCallbacks
+    def test_find_node(self):
+        self.node.addContact(self.node.contact_manager.make_contact(
+            self.remote_contact.id, self.remote_contact.address, self.remote_contact.port, self.node._protocol)
+        )
+        result = self.node.findContact(b'0'*48)
+        for _ in range(6):
+            self._reactor.advance(1)
+        self.assertEqual((yield result), None)
+        result = self.node.findContact(self.remote_contact.id)
+        for _ in range(6):
+            self._reactor.advance(1)
+        self.assertEqual((yield result).id, self.remote_contact.id)


### PR DESCRIPTION
"peer_ping" for inexistent ids currently raises:
`builtins.TypeError: invalid type to compare with Contact: <class 'bytes'>`
Fixed and added a test for it.