### PR TITLE
reduce routing table ping flood

### DIFF
--- a/lbrynet/dht/contact.py
+++ b/lbrynet/dht/contact.py
@@ -67,7 +67,7 @@ class _Contact:
 
     @property
     def lastFailed(self):
-        return self._contactManager._rpc_failures.get((self.address, self.port), [None])[-1]
+        return (self.failures or [None])[-1]
 
     @property
     def failures(self):

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -220,7 +220,7 @@ class Node(MockKademliaHelper):
             if not bootstrap_contacts:
                 log.warning("no bootstrap contacts to ping")
             ping_result = yield _ping_contacts(bootstrap_contacts)
-            shortlist = ping_result.keys()
+            shortlist = list(ping_result.keys())
             if not shortlist:
                 log.warning("failed to ping %i bootstrap contacts", len(bootstrap_contacts))
                 defer.returnValue(None)


### PR DESCRIPTION
This PR filters out nodes that are already being contacted from replacement candidates list, giving them time to reply and avoid race conditions that can cause floods.