### PR TITLE
fix lbrynet --version

### DIFF
--- a/lbrynet/__init__.py
+++ b/lbrynet/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+__name__ = "lbrynet"
 __version__ = "0.30.0rc5"
 version = tuple(__version__.split('.'))
 

--- a/lbrynet/cli.py
+++ b/lbrynet/cli.py
@@ -19,6 +19,7 @@ from requests.exceptions import ConnectionError
 from docopt import docopt
 from textwrap import dedent
 
+from lbrynet import __name__ as lbrynet_name
 from lbrynet.daemon.Daemon import Daemon
 from lbrynet.daemon.DaemonControl import start as daemon_main
 from lbrynet.daemon.DaemonConsole import main as daemon_console
@@ -133,7 +134,7 @@ def main(argv=None):
         return 0
 
     elif method in ['version', '--version', '-v']:
-        print(json.dumps(get_platform(get_ip=False), sort_keys=True, indent=2, separators=(',', ': ')))
+        print(lbrynet_name + " " + get_platform(get_ip=False)["lbrynet_version"])
         return 0
 
     elif method == 'start':

--- a/lbrynet/cli.py
+++ b/lbrynet/cli.py
@@ -134,7 +134,9 @@ def main(argv=None):
         return 0
 
     elif method in ['version', '--version', '-v']:
-        print(lbrynet_name + " " + get_platform(get_ip=False)["lbrynet_version"])
+        print("{lbrynet_name} {lbrynet_version}".format(
+            lbrynet_name=lbrynet_name, **get_platform(get_ip=False)
+        ))
         return 0
 
     elif method == 'start':

--- a/lbrynet/core/system_info.py
+++ b/lbrynet/core/system_info.py
@@ -13,7 +13,7 @@ import logging.handlers
 log = logging.getLogger(__name__)
 
 
-def get_lbrynet_version():
+def get_lbrynet_version() -> str:
     if build_type.BUILD == "dev":
         try:
             with open(os.devnull, 'w') as devnull:
@@ -27,7 +27,7 @@ def get_lbrynet_version():
     return lbrynet_version
 
 
-def get_platform(get_ip=True):
+def get_platform(get_ip: bool = True) -> dict:
     p = {
         "processor": platform.processor(),
         "python_version": platform.python_version(),

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 import os
-from lbrynet import __version__
+from lbrynet import __name__, __version__
 from setuptools import setup, find_packages
 
 BASE = os.path.dirname(__file__)
 README_PATH = os.path.join(BASE, 'README.md')
 
 setup(
-    name="lbrynet",
+    name=__name__,
     version=__version__,
     author="LBRY Inc.",
     author_email="hello@lbry.io",


### PR DESCRIPTION
`lbrynet --version` should print 1-2 lines of version info, not a 20-line dict with extraneous stuff