### PR TITLE
use smart_decode on transaction parsing to support legacy claims

### DIFF
--- a/lbrynet/wallet/transaction.py
+++ b/lbrynet/wallet/transaction.py
@@ -2,6 +2,7 @@ import struct
 from binascii import hexlify, unhexlify
 from typing import List, Iterable, Optional
 
+from lbryschema.decode import smart_decode
 from .account import Account
 from torba.basetransaction import BaseTransaction, BaseInput, BaseOutput
 from torba.hash import hash160
@@ -58,7 +59,7 @@ class Output(BaseOutput):
     @property
     def claim(self) -> ClaimDict:
         if self.script.is_claim_name or self.script.is_update_claim:
-            return ClaimDict.deserialize(self.script.values['claim'])
+            return smart_decode(self.script.values['claim'])
         raise ValueError('Only claim name and claim update have the claim payload.')
 
     @property


### PR DESCRIPTION
@tzarebczan has a wallet with legacy JSON claims
part of, but not yet solves #1530 
It solves the case but something else must ensure decode errors doesn't stop the history sync.