### PR TITLE
Remove unused Python modules in tests/unit/test_cli.py

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,4 @@
 import contextlib
-import json
 from io import StringIO
 from twisted.trial import unittest
 


### PR DESCRIPTION
Hello,

In my opinion, No json Python module are required.

Because it is not used.

What do you think of it?

Thanks.