### PR TITLE
--blocking support in abandon command

### DIFF
--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -2315,7 +2315,7 @@ class Daemon(AuthJSONRPCServer):
         )
 
     @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])
-    async def jsonrpc_claim_abandon(self, claim_id=None, txid=None, nout=None, account_id=None):
+    async def jsonrpc_claim_abandon(self, claim_id=None, txid=None, nout=None, account_id=None, blocking=True):
         """
         Abandon a name and reclaim credits from the claim
 
@@ -2323,12 +2323,14 @@ class Daemon(AuthJSONRPCServer):
             claim_abandon [<claim_id> | --claim_id=<claim_id>]
                           [<txid> | --txid=<txid>] [<nout> | --nout=<nout>]
                           [--account_id=<account_id>]
+                          [--blocking]
 
         Options:
             --claim_id=<claim_id>     : (str) claim_id of the claim to abandon
             --txid=<txid>             : (str) txid of the claim to abandon
             --nout=<nout>             : (int) nout of the claim to abandon
             --account_id=<account_id> : (str) id of the account to use
+            --blocking                : (bool) wait until abandon is in mempool
 
         Returns:
             (dict) Dictionary containing result of the claim
@@ -2348,6 +2350,8 @@ class Daemon(AuthJSONRPCServer):
 
         tx = await self.wallet_manager.abandon_claim(claim_id, txid, nout, account)
         self.analytics_manager.send_claim_action('abandon')
+        if blocking:
+            await self.ledger.wait(tx)
         return {"success": True, "tx": tx}
 
     @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])

--- a/tests/integration/wallet/test_commands.py
+++ b/tests/integration/wallet/test_commands.py
@@ -163,9 +163,9 @@ class CommandTestCase(IntegrationTestCase):
         self.manager.old_db = self.daemon.storage
 
     async def tearDown(self):
-        await super().tearDown()
         self.wallet_component._running = False
         await d2f(self.daemon._shutdown())
+        await super().tearDown()
 
     async def confirm_tx(self, txid):
         """ Wait for tx to be in mempool, then generate a block, wait for tx to be in a block. """
@@ -622,17 +622,11 @@ class AbandonCommand(CommandTestCase):
                 'hovercraft', '0.0001', file_path=file.name
             ))
             self.assertTrue(claim['success'])
-
-        await self.on_transaction_dict(claim['tx'])
-        await self.generate(1)
+            await self.on_transaction_dict(claim['tx'])
+            await self.generate(1)
 
         self.assertEqual('9.979793', await self.daemon.jsonrpc_account_balance())
-
-        abandon = await self.out(self.daemon.jsonrpc_claim_abandon(claim['claim_id']))
-
-        await self.on_transaction_dict(abandon['tx'])
-        await self.generate(1)
-
+        await self.out(self.daemon.jsonrpc_claim_abandon(claim['claim_id']))
         self.assertEqual('9.97968399', await self.daemon.jsonrpc_account_balance())
 
 


### PR DESCRIPTION
abandon RPC call will now block by default until abandon TX is in mempool