### PR TITLE
Better initialization of routing table buckets

### DIFF
--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -216,10 +216,10 @@ class Node(MockKademliaHelper):
                 # find the closest peers to us
                 closest = yield self._iterativeFind(self.node_id, shortlist if not self.contacts else None)
                 yield _ping_contacts(closest)
-                # # query random hashes in our bucket key ranges to fill or split them
-                # random_ids_in_range = self._routingTable.getRefreshList()
-                # while random_ids_in_range:
-                #     yield self.iterativeFindNode(random_ids_in_range.pop())
+                # query random hashes in our bucket key ranges to fill or split them
+                random_ids_in_range = self._routingTable.getRefreshList()
+                while random_ids_in_range:
+                    yield self.iterativeFindNode(random_ids_in_range.pop())
                 defer.returnValue(None)
 
         @defer.inlineCallbacks

--- a/lbrynet/dht/routingtable.py
+++ b/lbrynet/dht/routingtable.py
@@ -7,7 +7,6 @@
 
 import random
 import logging
-from binascii import unhexlify
 from twisted.internet import defer
 
 from lbrynet.dht import constants, kbucket
@@ -214,7 +213,7 @@ class TreeRoutingTable:
         now = int(self._getTime())
         for bucket in self._buckets[startIndex:]:
             if force or now - bucket.lastAccessed >= constants.refreshTimeout:
-                searchID = self._randomIDInBucketRange(bucketIndex)
+                searchID = self.midpoint_id_in_bucket_range(bucketIndex)
                 refreshIDs.append(searchID)
             bucketIndex += 1
         return refreshIDs
@@ -262,22 +261,25 @@ class TreeRoutingTable:
                 i += 1
         return i
 
-    def _randomIDInBucketRange(self, bucketIndex):
+    def random_id_in_bucket_range(self, bucketIndex):
         """ Returns a random ID in the specified k-bucket's range
 
         @param bucketIndex: The index of the k-bucket to use
         @type bucketIndex: int
         """
-        idValue = random.randrange(
-            self._buckets[bucketIndex].rangeMin, self._buckets[bucketIndex].rangeMax)
-        randomID = hex(idValue)[2:]
-        if randomID[-1] == 'L':
-            randomID = randomID[:-1]
-        if len(randomID) % 2 != 0:
-            randomID = '0' + randomID
-        randomID = unhexlify(randomID)
-        randomID = ((constants.key_bits // 8) - len(randomID)) * b'\x00' + randomID
-        return randomID
+
+        random_id = int(random.randrange(self._buckets[bucketIndex].rangeMin, self._buckets[bucketIndex].rangeMax))
+        return random_id.to_bytes(constants.key_bits // 8, 'big')
+
+    def midpoint_id_in_bucket_range(self, bucketIndex):
+        """ Returns the middle ID in the specified k-bucket's range
+
+        @param bucketIndex: The index of the k-bucket to use
+        @type bucketIndex: int
+        """
+
+        half = int((self._buckets[bucketIndex].rangeMax - self._buckets[bucketIndex].rangeMin) // 2)
+        return int(self._buckets[bucketIndex].rangeMin + half).to_bytes(constants.key_bits // 8, 'big')
 
     def _splitBucket(self, oldBucketIndex):
         """ Splits the specified k-bucket into two new buckets which together

--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -3114,6 +3114,7 @@ class Daemon(AuthJSONRPCServer):
         result['buckets'] = {}
 
         for i in range(len(self.dht_node._routingTable._buckets)):
+            result['buckets'][i] = []
             for contact in self.dht_node._routingTable._buckets[i]._contacts:
                 blobs = list(hosts.pop(contact)) if contact in hosts else []
                 blob_hashes.update(blobs)
@@ -3123,7 +3124,7 @@ class Daemon(AuthJSONRPCServer):
                     "node_id": hexlify(contact.id).decode(),
                     "blobs": blobs,
                 }
-                result['buckets'].setdefault(i, []).append(host)
+                result['buckets'][i].append(host)
                 contact_set.add(hexlify(contact.id).decode())
 
         result['contacts'] = list(contact_set)


### PR DESCRIPTION
### Fixes #

- routing table only populating one or two buckets on startup. This caused poorer connectivity before blob and peer searches fill out the buckets.
 - `routing_table_get` not including empty buckets
 - query ids in the middle of the bucket range instead of random ids in the range when populating buckets.