### PR TITLE
Removes `six` From Project

### DIFF
--- a/lbrynet/extras/daemon/auth/server.py
+++ b/lbrynet/extras/daemon/auth/server.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from six.moves.urllib import parse as urlparse
+from urllib import parse as urlparse
 import json
 import inspect
 import signal

--- a/lbrynet/extras/wallet/claim_proofs.py
+++ b/lbrynet/extras/wallet/claim_proofs.py
@@ -1,4 +1,3 @@
-import six
 import struct
 import binascii
 from torba.client.hash import double_sha256
@@ -32,7 +31,7 @@ def verify_proof(proof, rootHash, name):
                 if previous_child_character >= child['character']:
                     raise InvalidProofError("children not in increasing order")
             previous_child_character = child['character']
-            to_hash += six.int2byte(child['character'])
+            to_hash += bytes((child['character'], ))
             if 'nodeHash' in child:
                 if len(child['nodeHash']) != 64:
                     raise InvalidProofError("invalid child nodeHash")

--- a/lbrynet/schema/address.py
+++ b/lbrynet/schema/address.py
@@ -1,4 +1,3 @@
-import six
 import lbrynet.schema
 from lbrynet.schema.base import b58encode, b58decode, validate_b58_checksum
 from lbrynet.schema.hashing import double_sha256, hash160
@@ -12,10 +11,7 @@ def validate_address_length(addr_bytes):
 
 
 def validate_address_prefix(addr_bytes):
-    if six.PY3:
-        prefix = addr_bytes[0]
-    else:
-        prefix = ord(addr_bytes[0])
+    prefix = addr_bytes[0]
     if prefix not in ADDRESS_PREFIXES[lbrynet.schema.BLOCKCHAIN_NAME].values():
         raise InvalidAddress("Invalid address prefix: %.2X" % prefix)
 

--- a/lbrynet/schema/base.py
+++ b/lbrynet/schema/base.py
@@ -1,4 +1,3 @@
-import six
 from lbrynet.schema.schema import ADDRESS_CHECKSUM_LENGTH
 from lbrynet.schema.hashing import double_sha256
 from lbrynet.schema.error import InvalidAddress
@@ -7,18 +6,11 @@ from lbrynet.schema.error import InvalidAddress
 alphabet = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 
-if six.PY2:
-    iseq, bseq, buffer = (
-        lambda s: map(ord, s),
-        lambda s: ''.join(map(chr, s)),
-        lambda s: s,
-    )
-elif six.PY3:
-    iseq, bseq, buffer = (
-        lambda s: s,
-        bytes,
-        lambda s: s.buffer,
-    )
+iseq, bseq, buffer = (
+    lambda s: s,
+    bytes,
+    lambda s: s.buffer,
+)
 
 
 def scrub_input(v):

--- a/lbrynet/schema/base.py
+++ b/lbrynet/schema/base.py
@@ -76,7 +76,7 @@ def b58decode(v):
         acc, mod = divmod(acc, 256)
         result.append(mod)
 
-    return (b'\0' * (origlen - newlen) + bseq(reversed(result)))
+    return b'\0' * (origlen - newlen) + bseq(reversed(result))
 
 
 def validate_b58_checksum(addr_bytes):

--- a/lbrynet/schema/decode.py
+++ b/lbrynet/schema/decode.py
@@ -1,7 +1,6 @@
 import json
 import binascii
 from google.protobuf import json_format  # pylint: disable=no-name-in-module
-import six
 
 from lbrynet.schema.error import DecodeError, InvalidAddress
 from lbrynet.schema.legacy.migrate import migrate as schema_migrator
@@ -48,14 +47,14 @@ def smart_decode(claim_value):
 
     if claim_value[0] in ['{', ord('{')]:
         try:
-            if six.PY3 and isinstance(claim_value, six.binary_type):
+            if isinstance(claim_value, bytes):
                 claim_value = claim_value.decode()
             decoded_json = json.loads(claim_value)
             return migrate_json_claim_value(decoded_json)
         except (ValueError, TypeError):
             pass
     try:
-        if six.PY3 and isinstance(claim_value, six.text_type):
+        if isinstance(claim_value, str):
             claim_value = claim_value.encode()
         return ClaimDict.deserialize(claim_value)
     except (DecodeError, InvalidAddress, KeyError, TypeError):

--- a/lbrynet/schema/decode.py
+++ b/lbrynet/schema/decode.py
@@ -58,4 +58,4 @@ def smart_decode(claim_value):
             claim_value = claim_value.encode()
         return ClaimDict.deserialize(claim_value)
     except (DecodeError, InvalidAddress, KeyError, TypeError):
-            raise DecodeError(claim_value)
+        raise DecodeError(claim_value)

--- a/lbrynet/schema/hashing.py
+++ b/lbrynet/schema/hashing.py
@@ -1,9 +1,8 @@
-import six
 import hashlib
 
 
 def sha256(x):
-    if isinstance(x, six.text_type):
+    if isinstance(x, str):
         x = x.encode('utf-8')
     return hashlib.sha256(x).digest()
 
@@ -13,7 +12,7 @@ def double_sha256(x):
 
 
 def ripemd160(x):
-    if isinstance(x, six.text_type):
+    if isinstance(x, str):
         x = x.encode('utf-8')
     md = hashlib.new('ripemd160')
     md.update(x)

--- a/lbrynet/schema/validator.py
+++ b/lbrynet/schema/validator.py
@@ -25,7 +25,7 @@ def validate_claim_id(claim_id):
         raise Exception("Claim id is not hex encoded")
 
 
-class Validator(object):
+class Validator:
     CURVE_NAME = None
     HASHFUNC = hashlib.sha256
 

--- a/lbrynet/schema/validator.py
+++ b/lbrynet/schema/validator.py
@@ -1,5 +1,4 @@
 from string import hexdigits
-import six
 import ecdsa
 import hashlib
 import binascii
@@ -20,7 +19,7 @@ from lbrynet.schema.schema import NIST256p, NIST384p, SECP256k1, ECDSA_CURVES, C
 def validate_claim_id(claim_id):
     if not len(claim_id) == 40:
         raise Exception("Incorrect claimid length: %i" % len(claim_id))
-    if isinstance(claim_id, six.binary_type):
+    if isinstance(claim_id, bytes):
         claim_id = claim_id.decode('utf-8')
     if set(claim_id).difference(hexdigits):
         raise Exception("Claim id is not hex encoded")

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'treq',
         'docopt',
         'colorama==0.3.7',
-        'six'
     ],
     extras_require={
         'wallet-server': SERVER_REQUIRES,

--- a/tests/unit/cryptstream/test_cryptblob.py
+++ b/tests/unit/cryptstream/test_cryptblob.py
@@ -8,7 +8,7 @@ from tests.mocks import mock_conf_settings
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 import random
 import string
-from six import BytesIO
+from io import BytesIO
 import os
 
 AES_BLOCK_SIZE_BYTES = int(AES.block_size / 8)


### PR DESCRIPTION
<!-- 
Thank your for making LBRY better!

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->
### Description

Refactors code and removes compatibility library `six` from project. Effectively renders code only usable with `python3`  now. 

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
If this pull request applies to an issue, add in the issue number here
e.g.
Fixes #1
-->
### Fixes #1656 