### PR TITLE
Removes third-party mock dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     ],
     extras_require={
         'test': (
-            'mock>=2.0,<3.0',
             'faker==0.8.17',
             'pytest',
             'pytest-asyncio',

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,6 +1,6 @@
 import base64
 import io
-import mock
+from unittest import mock
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import time
 import os
 import tempfile
 import shutil
-import mock
+from unittest import mock
 from binascii import hexlify
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ def random_lbry_hash():
     return hexlify(os.urandom(48)).decode()
 
 
-def resetTime(test_case, timestamp=DEFAULT_TIMESTAMP):
+def reset_time(test_case, timestamp=DEFAULT_TIMESTAMP):
     iso_time = time.mktime(timestamp.timetuple())
     patcher = mock.patch('time.time')
     patcher.start().return_value = iso_time

--- a/tests/unit/core/server/test_BlobRequestHandler.py
+++ b/tests/unit/core/server/test_BlobRequestHandler.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from unittest import mock
 
 import mock
 from twisted.internet import defer

--- a/tests/unit/core/server/test_BlobRequestHandler.py
+++ b/tests/unit/core/server/test_BlobRequestHandler.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 from unittest import mock
 
-import mock
 from twisted.internet import defer
 from twisted.test import proto_helpers
 from twisted.trial import unittest

--- a/tests/unit/core/test_HTTPBlobDownloader.py
+++ b/tests/unit/core/test_HTTPBlobDownloader.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from twisted.trial import unittest
 from twisted.internet import defer

--- a/tests/unit/core/test_Strategy.py
+++ b/tests/unit/core/test_Strategy.py
@@ -3,8 +3,7 @@ import random
 from unittest import mock
 
 from twisted.trial import unittest
-import random
-import mock
+
 from lbrynet.p2p.PaymentRateManager import NegotiatedPaymentRateManager, BasePaymentRateManager
 from lbrynet.p2p.Strategy import BasicAvailabilityWeightedStrategy
 from lbrynet.p2p.Offer import Offer

--- a/tests/unit/core/test_Strategy.py
+++ b/tests/unit/core/test_Strategy.py
@@ -1,4 +1,7 @@
 import itertools
+import random
+from unittest import mock
+
 from twisted.trial import unittest
 import random
 import mock

--- a/tests/unit/lbrynet_daemon/auth/test_server.py
+++ b/tests/unit/lbrynet_daemon/auth/test_server.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 from twisted.internet import reactor
 from twisted.trial import unittest
 from lbrynet import conf

--- a/tests/unit/lbrynet_daemon/auth/test_server.py
+++ b/tests/unit/lbrynet_daemon/auth/test_server.py
@@ -2,9 +2,9 @@ from unittest import mock
 
 from twisted.internet import reactor
 from twisted.trial import unittest
+
 from lbrynet import conf
 from lbrynet.extras.daemon.auth import server
-
 from tests.mocks import mock_conf_settings
 
 

--- a/tests/unit/lbrynet_daemon/test_Daemon.py
+++ b/tests/unit/lbrynet_daemon/test_Daemon.py
@@ -83,7 +83,7 @@ class TestCostEst(unittest.TestCase):
 
     def setUp(self):
         mock_conf_settings(self)
-        test_utils.resetTime(self)
+        test_utils.reset_time(self)
 
     @defer.inlineCallbacks
     def test_fee_and_generous_data(self):
@@ -128,7 +128,7 @@ class TestJsonRpc(unittest.TestCase):
             return None
 
         mock_conf_settings(self)
-        test_utils.resetTime(self)
+        test_utils.reset_time(self)
         self.test_daemon = get_test_daemon()
         self.test_daemon.wallet_manager.is_first_run = False
         self.test_daemon.wallet_manager.get_best_blockhash = noop
@@ -150,7 +150,7 @@ class TestFileListSorting(unittest.TestCase):
 
     def setUp(self):
         mock_conf_settings(self)
-        test_utils.resetTime(self)
+        test_utils.reset_time(self)
         self.faker = Faker('en_US')
         self.faker.seed(129)  # contains 3 same points paid (5.9)
         self.test_daemon = get_test_daemon()

--- a/tests/unit/lbrynet_daemon/test_Daemon.py
+++ b/tests/unit/lbrynet_daemon/test_Daemon.py
@@ -13,7 +13,8 @@ from lbrynet.extras.daemon.storage import SQLiteStorage
 from lbrynet.extras.daemon.ComponentManager import ComponentManager
 from lbrynet.extras.daemon.Components import DATABASE_COMPONENT, DHT_COMPONENT, WALLET_COMPONENT
 from lbrynet.extras.daemon.Components import f2d
-from lbrynet.extras.daemon.Components import HASH_ANNOUNCER_COMPONENT, REFLECTOR_COMPONENT, UPNP_COMPONENT, BLOB_COMPONENT
+from lbrynet.extras.daemon.Components import HASH_ANNOUNCER_COMPONENT, REFLECTOR_COMPONENT
+from lbrynet.extras.daemon.Components import UPNP_COMPONENT, BLOB_COMPONENT
 from lbrynet.extras.daemon.Components import PEER_PROTOCOL_SERVER_COMPONENT, EXCHANGE_RATE_MANAGER_COMPONENT
 from lbrynet.extras.daemon.Components import RATE_LIMITER_COMPONENT, HEADERS_COMPONENT, FILE_MANAGER_COMPONENT
 from lbrynet.extras.daemon.Daemon import Daemon as LBRYDaemon

--- a/tests/unit/lbrynet_daemon/test_Daemon.py
+++ b/tests/unit/lbrynet_daemon/test_Daemon.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import json
 import random
 from os import path

--- a/tests/unit/lbrynet_daemon/test_Downloader.py
+++ b/tests/unit/lbrynet_daemon/test_Downloader.py
@@ -1,5 +1,5 @@
 import types
-import mock
+from unittest import mock
 from twisted.trial import unittest
 from twisted.internet import defer, task
 

--- a/tests/unit/lbrynet_daemon/test_ExchangeRateManager.py
+++ b/tests/unit/lbrynet_daemon/test_ExchangeRateManager.py
@@ -32,7 +32,7 @@ class FeeFormatTest(unittest.TestCase):
 
 class ExchangeRateTest(unittest.TestCase):
     def setUp(self):
-        test_utils.resetTime(self)
+        test_utils.reset_time(self)
 
     def test_invalid_rates(self):
         with self.assertRaises(ValueError):
@@ -43,7 +43,7 @@ class ExchangeRateTest(unittest.TestCase):
 
 class FeeTest(unittest.TestCase):
     def setUp(self):
-        test_utils.resetTime(self)
+        test_utils.reset_time(self)
 
     def test_fee_converts_to_lbc(self):
         fee = Fee({

--- a/tests/unit/test_customLogger.py
+++ b/tests/unit/test_customLogger.py
@@ -2,8 +2,10 @@ from io import StringIO
 import logging
 from unittest import mock
 from unittest import skipIf
+
 from twisted.internet import defer
 from twisted.trial import unittest
+
 from lbrynet import custom_logger
 from tests.test_utils import is_android
 
@@ -34,7 +36,7 @@ class TestLogger(unittest.TestCase):
             return self.stream.getvalue().split('\n')
 
         # the line number could change if this file gets refactored
-        expected_first_line = 'test_customLogger.py:18 - My message: terrible things happened'
+        expected_first_line = 'test_customLogger.py:20 - My message: terrible things happened'
 
         # testing the entirety of the message is futile as the
         # traceback will depend on the system the test is being run on

--- a/tests/unit/test_customLogger.py
+++ b/tests/unit/test_customLogger.py
@@ -1,6 +1,6 @@
 from io import StringIO
 import logging
-import mock
+from unittest import mock
 from unittest import skipIf
 from twisted.internet import defer
 from twisted.trial import unittest


### PR DESCRIPTION
<!-- 
Thank your for making LBRY better!

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->
### Description

Not much to it other than what's asked in #1657; the module `mock` is refactored and replaced with `unittest.mock`; the builtin version. Additionally, `mock` is removed from `setup.py` since Python 3.7 already contains it. Some simple refactoring is done for compliance with `pylint` and some import stubs were whitespace delimited in order to separate the import sections into builtin, third-party and in-project modules. As a bonus, the function `resetTime` is renamed to `reset_time`.

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
If this pull request applies to an issue, add in the issue number here
e.g.
Fixes #1
-->
### Fixes #1657 