### PR TITLE
Adds comment function to component manager

### DIFF
--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -505,7 +505,12 @@ class Daemon(metaclass=JSONRPCServerType):
         result = fn(self, *_args, **_kwargs)
         if asyncio.iscoroutine(result):
             result = await result
-
+        
+        # await all the coroutine objects within the result before processing as json
+        for key, value in result.items():
+            if repr(type(value)) == "<class 'coroutine'>":
+                result[key] = await value
+                
         return web.Response(
             text=jsonrpc_dumps_pretty(result, ledger=self.ledger),
             content_type='application/json'


### PR DESCRIPTION
Fixes issues with `lbrynet.extras.daemon.Daemon.Daemon.handle_old_jsonrpc` method which contains `coroutine` objects within the `result` dict that cause the `json` encoder to break. 
This solution just `await`s all the coroutines before passing them to `web.Response` 