### PR TITLE
WIP: Claim signatures

### DIFF
--- a/lbrynet/extras/wallet/manager.py
+++ b/lbrynet/extras/wallet/manager.py
@@ -413,7 +413,7 @@ class LbryWalletManager(BaseWalletManager):
             claim_address = await account.receiving.get_or_create_usable_address()
         if certificate:
             claim = claim.sign(
-                certificate.private_key, claim_address, certificate.claim_id, curve=SECP256k1
+                certificate.private_key, claim_address, certificate.claim_id, curve=SECP256k1, name=name
             )
         existing_claims = await account.get_claims(
             claim_name_type__any={'is_claim': 1, 'is_update': 1},  # exclude is_supports

--- a/lbrynet/extras/wallet/resolve.py
+++ b/lbrynet/extras/wallet/resolve.py
@@ -186,7 +186,7 @@ class Resolver:
                 claim_result['has_signature'] = True
                 claim_result['signature_is_valid'] = False
                 validated, channel_name = validate_claim_signature_and_get_channel_name(
-                    decoded, certificate, claim_result['address'])
+                    decoded, certificate, claim_result['address'], claim_result['name'])
                 claim_result['channel_name'] = channel_name
                 if validated:
                     claim_result['signature_is_valid'] = True
@@ -197,7 +197,7 @@ class Resolver:
         if 'amount' in claim_result:
             claim_result = format_amount_value(claim_result)
 
-        claim_result['permanent_url'] = _get_permanent_url(claim_result)
+        claim_result['permanent_url'] = _get_permanent_url(claim_result, decoded.certificate_id)
 
         return claim_result
 
@@ -307,11 +307,11 @@ def format_amount_value(obj):
     return obj
 
 
-def _get_permanent_url(claim_result):
+def _get_permanent_url(claim_result, certificate_id):
     if claim_result.get('has_signature') and claim_result.get('channel_name'):
         return "{}#{}/{}".format(
             claim_result['channel_name'],
-            claim_result['value']['publisherSignature']['certificateId'],
+            certificate_id,
             claim_result['name']
         )
     else:
@@ -386,7 +386,7 @@ def _verify_proof(name, claim_trie_root, result, height, depth, transaction_clas
 
 
 def validate_claim_signature_and_get_channel_name(claim, certificate_claim,
-                                                  claim_address, decoded_certificate=None):
+                                                  claim_address, name, decoded_certificate=None):
     if not certificate_claim:
         return False, None
     if 'value' not in certificate_claim:
@@ -395,18 +395,18 @@ def validate_claim_signature_and_get_channel_name(claim, certificate_claim,
     certificate = decoded_certificate or smart_decode(certificate_claim['value'])
     if not isinstance(certificate, ClaimDict):
         raise TypeError("Certificate is not a ClaimDict: %s" % str(type(certificate)))
-    if _validate_signed_claim(claim, claim_address, certificate):
+    if _validate_signed_claim(claim, claim_address, name, certificate):
         return True, certificate_claim['name']
     return False, None
 
 
-def _validate_signed_claim(claim, claim_address, certificate):
+def _validate_signed_claim(claim, claim_address, name, certificate):
     if not claim.has_signature:
         raise Exception("Claim is not signed")
     if not is_address(claim_address):
         raise Exception("Not given a valid claim address")
     try:
-        if claim.validate_signature(claim_address, certificate.protobuf):
+        if claim.validate_signature(claim_address, certificate.protobuf, name):
             return True
     except BadSignatureError:
         # print_msg("Signature for %s is invalid" % claim_id)

--- a/lbrynet/extras/wallet/server/block_processor.py
+++ b/lbrynet/extras/wallet/server/block_processor.py
@@ -1,11 +1,11 @@
 import hashlib
 import struct
+from binascii import unhexlify
 
 import msgpack
 from torba.server.hash import hash_to_hex_str
 
 from torba.server.block_processor import BlockProcessor
-from lbrynet.schema.proto.claim_pb2 import Claim
 from lbrynet.schema.uri import parse_lbry_uri
 from lbrynet.schema.decode import smart_decode
 
@@ -153,14 +153,14 @@ class LBRYBlockProcessor(BlockProcessor):
     def _checksig(self, name, value, address):
         try:
             parse_lbry_uri(name.decode())  # skip invalid names
-            cert_id = Claim.FromString(value).publisherSignature.certificateId[::-1] or None
+            claim_dict = smart_decode(value)
+            cert_id = unhexlify(claim_dict.certificate_id)[::-1]
             if not self.should_validate_signatures:
                 return cert_id
             if cert_id:
                 cert_claim = self.db.get_claim_info(cert_id)
                 if cert_claim:
                     certificate = smart_decode(cert_claim.value)
-                    claim_dict = smart_decode(value)
                     claim_dict.validate_signature(address, certificate)
                     return cert_id
         except Exception as e:

--- a/lbrynet/schema/claim.py
+++ b/lbrynet/schema/claim.py
@@ -160,11 +160,11 @@ class ClaimDict(OrderedDict):
         return cls.load_protobuf(temp_claim, detached_signature=detached_signature)
 
     @classmethod
-    def generate_certificate(cls, private_key, curve=NIST256p):
+    def generate_certificate(cls, private_key, curve=SECP256k1):
         signer = get_signer(curve).load_pem(private_key)
         return cls.load_protobuf(signer.certificate)
 
-    def sign(self, private_key, claim_address, cert_claim_id, curve=NIST256p, name=None):
+    def sign(self, private_key, claim_address, cert_claim_id, curve=SECP256k1, name=None):
         signer = get_signer(curve).load_pem(private_key)
         signed, signature = signer.sign_stream_claim(self, claim_address, cert_claim_id, name)
         return ClaimDict.load_protobuf(signed, signature)

--- a/lbrynet/schema/claim.py
+++ b/lbrynet/schema/claim.py
@@ -55,7 +55,7 @@ class ClaimDict(OrderedDict):
         claim = self.protobuf
         if claim.HasField("publisherSignature"):
             return True
-        return False
+        return self.detached_signature and self.detached_signature.certificate_id
 
     @property
     def is_certificate(self):

--- a/lbrynet/schema/signature.py
+++ b/lbrynet/schema/signature.py
@@ -1,0 +1,24 @@
+# Flags
+LEGACY = 0x80  # Everything is contained in the protobuf.
+NAMED_SECP256K1 = 0x01  # ECDSA SECP256k1 64 bytes. Claim name is also signed.
+
+
+class Signature:
+
+    def __init__(self, raw_signature: bytes, certificate_id: bytes, flag: int=NAMED_SECP256K1):
+        self.flag = flag
+        assert len(raw_signature) == 64, f"signature must be 64 bytes, not: {len(raw_signature)}"
+        self.raw_signature = raw_signature
+        assert len(certificate_id) == 20, f"certificate_id must be 20 bytes, not: {len(certificate_id)}"
+        self.certificate_id = certificate_id
+
+    @classmethod
+    def flagged_parse(cls, binary: bytes):
+        if binary[0] == NAMED_SECP256K1:
+            return binary[85:], cls(binary[1:65], binary[65:85], NAMED_SECP256K1)
+        else:
+            return binary, None
+
+    @property
+    def serialized(self):
+        return (bytes([self.flag]) + self.raw_signature + self.certificate_id) if self.flag != LEGACY else b''

--- a/lbrynet/schema/signer.py
+++ b/lbrynet/schema/signer.py
@@ -64,7 +64,7 @@ class NIST_ECDSASigner(object):
 
         digest = self.HASHFUNC(to_sign).digest()
         if self.DETACHED:
-            return claim.protobuf_dict, Signature(
+            return Claim.load(decode_b64_fields(claim.protobuf_dict)), Signature(
                 self.private_key.sign_digest_deterministic(digest, hashfunc=self.HASHFUNC), raw_cert_id
             )
 

--- a/lbrynet/schema/validator.py
+++ b/lbrynet/schema/validator.py
@@ -76,6 +76,25 @@ class Validator:
             from ecdsa import BadSignatureError
             raise BadSignatureError
 
+    def validate_detached_claim_signature(self, claim, claim_address, name):
+        decoded_address = decode_address(claim_address)
+
+        # extract and serialize the stream from the claim, then check the signature
+        signature = claim.detached_signature.raw_signature
+
+        if signature is None:
+            raise Exception("No signature to validate")
+
+        name = name.lower().encode()
+
+        to_sign = bytearray()
+        to_sign.extend(name)
+        to_sign.extend(decoded_address)
+        to_sign.extend(claim.serialized_no_signature)
+        to_sign.extend(binascii.unhexlify(self.certificate_claim_id))
+
+        return self.validate_signature(self.HASHFUNC(to_sign).digest(), signature)
+
     def validate_claim_signature(self, claim, claim_address):
         decoded_address = decode_address(claim_address)
 

--- a/tests/integration/wallet/test_transactions.py
+++ b/tests/integration/wallet/test_transactions.py
@@ -1,6 +1,7 @@
 import logging
 import asyncio
 
+from lbrynet.schema.schema import SECP256k1
 from torba.testcase import IntegrationTestCase
 from lbrynet.schema.claim import ClaimDict
 from lbrynet.extras.wallet.transaction import Transaction
@@ -95,3 +96,31 @@ class BasicTransactionTest(IntegrationTestCase):
         response = await self.ledger.resolve(0, 10, 'lbry://404', 'lbry://@404')
         self.assertEqual('URI lbry://404 cannot be resolved', response['lbry://404']['error'])
         self.assertEqual('URI lbry://@404 cannot be resolved', response['lbry://@404']['error'])
+
+    async def test_new_signature_model(self):
+        address1, address2 = await self.account.receiving.get_addresses(limit=2, only_usable=True)
+        sendtxid1 = await self.blockchain.send_to_address(address1, 5)
+        sendtxid2 = await self.blockchain.send_to_address(address2, 5)
+        await self.blockchain.generate(1)
+        await asyncio.wait([
+            self.on_transaction_id(sendtxid1),
+            self.on_transaction_id(sendtxid2)
+        ])
+
+        self.assertEqual(d2l(await self.account.get_balance()), '10.0')
+
+        cert, key = generate_certificate()
+        cert_tx = await Transaction.claim('@bar', cert, l2d('1.0'), address1, [self.account], self.account)
+        claim = ClaimDict.load_dict(example_claim_dict)
+        claim = claim.sign(key, address1, cert_tx.outputs[0].claim_id, name='foo', curve=SECP256k1)
+        claim_tx = await Transaction.claim('foo', claim, l2d('1.0'), address1, [self.account], self.account)
+
+        await self.broadcast(cert_tx)
+        await self.broadcast(claim_tx)
+        await self.ledger.wait(claim_tx)
+        await self.blockchain.generate(1)
+        await self.ledger.wait(claim_tx)
+
+        response = await self.ledger.resolve(0, 10, 'lbry://@bar/foo')
+        self.assertIn('lbry://@bar/foo', response)
+        self.assertIn('claim', response['lbry://@bar/foo'])

--- a/tests/integration/wallet/test_transactions.py
+++ b/tests/integration/wallet/test_transactions.py
@@ -61,7 +61,7 @@ class BasicTransactionTest(IntegrationTestCase):
         cert, key = generate_certificate()
         cert_tx = await Transaction.claim('@bar', cert, l2d('1.0'), address1, [self.account], self.account)
         claim = ClaimDict.load_dict(example_claim_dict)
-        claim = claim.sign(key, address1, cert_tx.outputs[0].claim_id)
+        claim = claim.sign(key, address1, cert_tx.outputs[0].claim_id, name='foo')
         claim_tx = await Transaction.claim('foo', claim, l2d('1.0'), address1, [self.account], self.account)
 
         await self.broadcast(cert_tx)

--- a/tests/unit/schema/test_lbryschema.py
+++ b/tests/unit/schema/test_lbryschema.py
@@ -319,6 +319,65 @@ class TestSECP256k1Signatures(UnitTest):
                           claim_address_1, cert)
 
 
+class TestDetachedNamedSECP256k1Signatures(UnitTest):
+    def test_validate_detached_named_ecdsa_signature(self):
+        cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
+        self.assertDictEqual(cert.claim_dict, secp256k1_cert)
+        signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_2,
+                                                       claim_id_1, curve=SECP256k1, name='example')
+        #self.assertDictEqual(signed.claim_dict, claim_010_signed_secp256k1)
+        signed_copy = ClaimDict.deserialize(signed.serialized)
+        self.assertEqual(signed_copy.validate_signature(claim_address_2, cert, name='example'), True)
+
+    def test_fail_to_sign_with_no_claim_address(self):
+        cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
+        self.assertDictEqual(cert.claim_dict, secp256k1_cert)
+        self.assertRaises(Exception, ClaimDict.load_dict(example_010).sign, secp256k1_private_key,
+                          None, claim_id_1, curve=SECP256k1, name='example')
+
+    def test_fail_to_validate_with_no_claim_address(self):
+        cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
+        self.assertDictEqual(cert.claim_dict, secp256k1_cert)
+        signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_2,
+                                                       claim_id_1, curve=SECP256k1, name='example')
+        #self.assertDictEqual(signed.claim_dict, claim_010_signed_secp256k1)
+        signed_copy = ClaimDict.load_protobuf(signed.protobuf)
+        self.assertRaises(Exception, signed_copy.validate_signature, None, cert, name='example')
+
+    def test_fail_to_validate_with_no_name(self):
+        cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
+        self.assertDictEqual(cert.claim_dict, secp256k1_cert)
+        signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_2,
+                                                       claim_id_1, curve=SECP256k1, name='example')
+        #self.assertDictEqual(signed.claim_dict, claim_010_signed_secp256k1)
+        signed_copy = ClaimDict.load_protobuf(signed.protobuf)
+        self.assertRaises(Exception, signed_copy.validate_signature, None, cert, name=None)
+
+    def test_remove_signature_equals_unsigned(self):
+        unsigned = ClaimDict.load_dict(example_010)
+        signed = unsigned.sign(secp256k1_private_key, claim_address_1, claim_id_1, curve=SECP256k1, name='example')
+        self.assertEqual(unsigned.serialized, signed.serialized_no_signature)
+
+    def test_fail_to_validate_fake_ecdsa_signature(self):
+        signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_1,
+                                                       claim_id_1, curve=SECP256k1, name='example')
+        signed_copy = ClaimDict.deserialize(signed.serialized)
+        fake_key = get_signer(SECP256k1).generate().private_key.to_pem()
+        fake_cert = ClaimDict.generate_certificate(fake_key, curve=SECP256k1)
+        self.assertRaises(ecdsa.keys.BadSignatureError, signed_copy.validate_signature,
+                          claim_address_2, fake_cert, 'example')
+
+    def test_fail_to_validate_ecdsa_sig_for_altered_claim(self):
+        cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
+        altered = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_1,
+                                                        claim_id_1, curve=SECP256k1, name='example')
+        sd_hash = altered['stream']['source']['source']
+        altered['stream']['source']['source'] = sd_hash[::-1]
+        altered_copy = ClaimDict.deserialize(altered.serialized)
+        self.assertRaises(ecdsa.keys.BadSignatureError, altered_copy.validate_signature,
+                          claim_address_1, cert, 'example')
+
+
 class TestMetadata(UnitTest):
     def test_fail_with_fake_sd_hash(self):
         claim = deepcopy(example_010)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv =
   TORBA_LEDGER=lbrynet.extras.wallet
 commands =
   orchstr8 download
-  coverage run -p --source={envsitepackagesdir}/lbrynet -m unittest integration.wallet.test_transactions.BasicTransactionTest
+  coverage run -p --source={envsitepackagesdir}/lbrynet -m unittest integration.wallet.test_transactions.BasicTransactionTest.test_creating_updating_and_abandoning_claim_with_channel
+  coverage run -p --source={envsitepackagesdir}/lbrynet -m unittest integration.wallet.test_transactions.BasicTransactionTest.test_new_signature_model
   coverage run -p --source={envsitepackagesdir}/lbrynet -m twisted.trial --reactor=asyncio integration.cli
   coverage run -p --source={envsitepackagesdir}/lbrynet -m twisted.trial --reactor=asyncio integration.wallet.test_commands


### PR DESCRIPTION
still missing:
- Add a flag for unsigned (see spec). (2)
- Add tests where a protobuf with extra unparsed data can still be verified (1)
- ^Store the payload immutably, change all serialization calls on sign/verify code. Serialization should happen only to create the object. (2)
- Review how everything is stored on dbs (should be fine, but has to be checked). (1)