### PR TITLE
include file extension in media-type metadata for unknown media types

### DIFF
--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -23,7 +23,7 @@ from lbrynet.extras.daemon.Components import EXCHANGE_RATE_MANAGER_COMPONENT, PA
 from lbrynet.extras.daemon.ComponentManager import RequiredCondition
 from lbrynet.extras.daemon.Downloader import GetStream
 from lbrynet.extras.daemon.Publisher import Publisher
-from lbrynet.extras.daemon.mime_types import guess_mime_type
+from lbrynet.extras.daemon.mime_types import guess_media_type
 from lbrynet.extras.wallet import LbryWalletManager
 from lbrynet.extras.wallet.account import Account as LBCAccount
 from lbrynet.extras.wallet.dewies import dewies_to_lbc, lbc_to_dewies
@@ -817,7 +817,7 @@ class Daemon(metaclass=JSONRPCServerType):
     async def _get_lbry_file_dict(self, lbry_file):
         key = hexlify(lbry_file.key) if lbry_file.key else None
         full_path = os.path.join(lbry_file.download_directory, lbry_file.file_name)
-        mime_type = guess_mime_type(lbry_file.file_name)
+        mime_type = guess_media_type(lbry_file.file_name)
         if os.path.isfile(full_path):
             with open(full_path) as written_file:
                 written_file.seek(0, os.SEEK_END)

--- a/lbrynet/extras/daemon/Publisher.py
+++ b/lbrynet/extras/daemon/Publisher.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from lbrynet.blob.EncryptedFileCreator import create_lbry_file
-from lbrynet.extras.daemon.mime_types import guess_mime_type
+from lbrynet.extras.daemon.mime_types import guess_media_type
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class Publisher:
             claim_dict['stream']['source'] = {}
         claim_dict['stream']['source']['source'] = self.lbry_file.sd_hash
         claim_dict['stream']['source']['sourceType'] = 'lbry_sd_hash'
-        claim_dict['stream']['source']['contentType'] = guess_mime_type(file_path)
+        claim_dict['stream']['source']['contentType'] = guess_media_type(file_path)
         claim_dict['stream']['source']['version'] = "_0_0_1"  # need current version here
         tx = await self.wallet.claim_name(
             self.account, name, bid, claim_dict, self.certificate, holding_address

--- a/lbrynet/extras/daemon/mime_types.py
+++ b/lbrynet/extras/daemon/mime_types.py
@@ -151,9 +151,6 @@ types_map = {
 }
 
 
-fallback_mime_type = 'application/octet-stream'
-
-
-def guess_mime_type(path):
+def guess_media_type(path):
     _, ext = os.path.splitext(path)
-    return types_map.get(ext, fallback_mime_type)
+    return types_map.get(ext, f'application/x-ext-{ext}')


### PR DESCRIPTION
… extension

## PR Checklist
Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?
when publishing a file whose media type is not known, use a generic media type that includes the filename extension

Why is this change necessary?
there's no way to know what kind of file is in a stream without downloading the manifest blob. 

<!-- Please check all that apply to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: N/A


## What is the current behavior?


## What is the new behavior?


## Other information


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
