### PR TITLE
added additional fields to uri parser to return consistent results

### DIFF
--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -2133,7 +2133,7 @@ class Daemon(metaclass=JSONRPCServerType):
         timeout = timeout if timeout is not None else conf.settings['download_timeout']
 
         parsed_uri = parse_lbry_uri(uri)
-        if parsed_uri.is_channel and not parsed_uri.path:
+        if parsed_uri.is_channel:
             raise Exception("cannot download a channel claim, specify a /path")
 
         resolved = (await self.wallet_manager.resolve(uri)).get(uri, {})
@@ -2310,7 +2310,7 @@ class Daemon(metaclass=JSONRPCServerType):
         """
         try:
             parsed = parse_lbry_uri(channel_name)
-            if not parsed.is_channel:
+            if not parsed.contains_channel:
                 raise Exception("Cannot make a new channel for a non channel name")
             if parsed.path:
                 raise Exception("Invalid channel uri")
@@ -2898,7 +2898,7 @@ class Daemon(metaclass=JSONRPCServerType):
         for chan_uri in uris:
             try:
                 parsed = parse_lbry_uri(chan_uri)
-                if not parsed.is_channel:
+                if not parsed.contains_channel:
                     results[chan_uri] = {"error": "%s is not a channel uri" % parsed.name}
                 elif parsed.path:
                     results[chan_uri] = {"error": "%s is a claim in a channel" % parsed.path}

--- a/lbrynet/extras/wallet/server/session.py
+++ b/lbrynet/extras/wallet/server/session.py
@@ -307,7 +307,7 @@ class LBRYElectrumX(ElectrumX):
             return {'error': err.message}
         result = {}
 
-        if parsed_uri.is_channel:
+        if parsed_uri.contains_channel:
             certificate = None
 
             # TODO: this is also done on the else, refactor

--- a/lbrynet/schema/uri.py
+++ b/lbrynet/schema/uri.py
@@ -28,7 +28,7 @@ class URI(object):
         self.claim_id = claim_id
         self.path = path
 
-        if self.path is not None and not self.is_channel:
+        if self.path is not None and not self.contains_channel:
             raise ValueError("Content claims cannot have paths")
 
     def __str__(self):
@@ -39,10 +39,21 @@ class URI(object):
             if not hasattr(other, prop) or getattr(self, prop) != getattr(other, prop):
                 return False
         return self.__class__ == other.__class__
+    @property
+    def channel_name(self):
+        return self.name if self.contains_channel else None
+
+    @property
+    def claim_name(self):
+        return self.name if not self.contains_channel else self.path
+
+    @property
+    def contains_channel(self):
+        return self.name.startswith(CHANNEL_CHAR)
 
     @property
     def is_channel(self):
-        return self.name.startswith(CHANNEL_CHAR)
+        return self.contains_channel and not self.path
 
     def to_uri_string(self):
         uri_string = PROTOCOL + "%s" % self.name

--- a/tests/unit/schema/test_lbryschema.py
+++ b/tests/unit/schema/test_lbryschema.py
@@ -25,24 +25,25 @@ from lbrynet.schema.address import decode_address, encode_address
 
 
 parsed_uri_matches = [
-    ("test", URI("test"), False),
-    ("test#%s" % claim_id_1, URI("test", claim_id=claim_id_1), False),
-    ("test:1", URI("test", claim_sequence=1), False),
-    ("test$1", URI("test", bid_position=1), False),
-    ("lbry://test", URI("test"), False),
-    ("lbry://test#%s" % claim_id_1, URI("test", claim_id=claim_id_1), False),
-    ("lbry://test:1", URI("test", claim_sequence=1), False),
-    ("lbry://test$1", URI("test", bid_position=1), False),
-    ("@test", URI("@test"), True),
-    ("@test#%s" % claim_id_1, URI("@test", claim_id=claim_id_1), True),
-    ("@test:1", URI("@test", claim_sequence=1), True),
-    ("@test$1", URI("@test", bid_position=1), True),
-    ("lbry://@test1:1/fakepath", URI("@test1", claim_sequence=1, path="fakepath"), True),
-    ("lbry://@test1$1/fakepath", URI("@test1", bid_position=1, path="fakepath"), True),
-    ("lbry://@test1#abcdef/fakepath", URI("@test1", claim_id="abcdef", path="fakepath"), True),
-    ("@z", URI("@z"), True),
-    ("@yx", URI("@yx"), True),
-    ("@abc", URI("@abc"), True)
+    ("test", URI("test"), False, False, "test", None),
+    ("test#%s" % claim_id_1, URI("test", claim_id=claim_id_1), False, False, "test", None),
+    ("test:1", URI("test", claim_sequence=1), False, False, "test", None),
+    ("test$1", URI("test", bid_position=1), False, False, "test", None),
+    ("lbry://test", URI("test"), False, False, "test", None),
+    ("lbry://test#%s" % claim_id_1, URI("test", claim_id=claim_id_1), False, False, "test", None),
+    ("lbry://test:1", URI("test", claim_sequence=1), False, False, "test", None),
+    ("lbry://test$1", URI("test", bid_position=1), False, False, "test", None),
+    ("@test", URI("@test"), True, True, None, "@test"),
+    ("@test#%s" % claim_id_1, URI("@test", claim_id=claim_id_1), True, True, None, "@test"),
+    ("@test:1", URI("@test", claim_sequence=1), True, True, None, "@test"),
+    ("@test$1", URI("@test", bid_position=1), True, True, None, "@test"),
+    ("lbry://@test1:1/fakepath", URI("@test1", claim_sequence=1, path="fakepath"), True, False, "fakepath", "@test1"),
+    ("lbry://@test1$1/fakepath", URI("@test1", bid_position=1, path="fakepath"), True, False, "fakepath", "@test1"),
+    ("lbry://@test1#abcdef/fakepath", URI("@test1", claim_id="abcdef", path="fakepath"), True, False, "fakepath",
+     "@test1"),
+    ("@z", URI("@z"), True, True, None, "@z"),
+    ("@yx", URI("@yx"), True, True, None, "@yx"),
+    ("@abc", URI("@abc"), True, True, None, "@abc")
 ]
 
 parsed_uri_raises = [
@@ -89,15 +90,24 @@ class TestURIParser(UnitTest):
         self.longMessage = True
 
     def test_uri_parse(self):
-        for test_string, expected_uri_obj, is_channel in parsed_uri_matches:
+        for test_string, expected_uri_obj, contains_channel, is_channel, claim_name, channel_name in parsed_uri_matches:
             try:
                 # string -> URI
                 self.assertEqual(URI.from_uri_string(test_string), expected_uri_obj, test_string)
                 # URI -> dict -> URI
                 self.assertEqual(URI.from_dict(expected_uri_obj.to_dict()), expected_uri_obj,
                                   test_string)
+                # contains_channel
+                self.assertEqual(URI.from_uri_string(test_string).contains_channel, contains_channel,
+                                  test_string)
                 # is_channel
                 self.assertEqual(URI.from_uri_string(test_string).is_channel, is_channel,
+                                  test_string)
+                # claim_name
+                self.assertEqual(URI.from_uri_string(test_string).claim_name, claim_name,
+                                  test_string)
+                # channel_name
+                self.assertEqual(URI.from_uri_string(test_string).channel_name, channel_name,
                                   test_string)
 
                 # convert-to-string test only works if protocol is present in test_string


### PR DESCRIPTION
added `claim_name`, `channel_name`, `contains_channel`
renamed `is_channel` to `contains_channel`
now `is_channel` returns true iff the uri contains just the channel and not a path
