### PR TITLE
dropped help, commands and resolve_name commands

### DIFF
--- a/lbrynet/extras/cli.py
+++ b/lbrynet/extras/cli.py
@@ -201,7 +201,7 @@ def get_argument_parser():
         group_parser = sub.add_parser(group_name, group_name=group_name, help=api['groups'][group_name])
         groups[group_name] = group_parser.add_subparsers(metavar='COMMAND')
 
-    nicer_order = ['stop', 'get', 'publish', 'resolve', 'resolve_name']
+    nicer_order = ['stop', 'get', 'publish', 'resolve']
     for command_name in sorted(api['commands']):
         if command_name not in nicer_order:
             nicer_order.append(command_name)

--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import json
 import inspect
-import textwrap
 import typing
 import aiohttp
 import base58
@@ -20,7 +19,7 @@ from lbrynet import __version__, utils
 from lbrynet.conf import Config, Setting, SLACK_WEBHOOK
 from lbrynet.blob.blob_file import is_valid_blobhash
 from lbrynet.blob_exchange.downloader import BlobDownloader
-from lbrynet.error import InsufficientFundsError, UnknownNameError, DownloadSDTimeout, ComponentsNotStarted
+from lbrynet.error import InsufficientFundsError, DownloadSDTimeout, ComponentsNotStarted
 from lbrynet.error import NullFundsError, NegativeFundsError, ResolveError, ComponentStartConditionNotMet
 from lbrynet.extras import system_info
 from lbrynet.extras.daemon import analytics


### PR DESCRIPTION
backwards-incompatible: `help` jsonrpc command has been dropped, use `lbrynet --help` instead.
backwards-incompatible: `resolve_name` command has been dropped, use `resolve` instead.
backwards-incompatible: `commands` jsonrpc command has been dropped, a better version could be added in the future, feedback and use cases greatly appreciated.