### PR TITLE
refactored --max-key-fee to be more ergonomic

### DIFF
--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -159,10 +159,11 @@ class Path(String):
 class MaxKeyFee(Setting[dict]):
 
     def validate(self, value):
-        assert isinstance(value, dict) and set(value) == {'currency', 'amount'}, \
-            f"Setting '{self.name}' must be a dict like \"{{'amount': 50.0, 'currency': 'USD'}}\"."
-        if value["currency"] not in CURRENCIES:
-            raise InvalidCurrencyError(value["currency"])
+        if value is not None:
+            assert isinstance(value, dict) and set(value) == {'currency', 'amount'}, \
+                f"Setting '{self.name}' must be a dict like \"{{'amount': 50.0, 'currency': 'USD'}}\"."
+            if value["currency"] not in CURRENCIES:
+                raise InvalidCurrencyError(value["currency"])
 
     @staticmethod
     def _parse_list(l):

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -4,7 +4,6 @@ import sys
 import typing
 import logging
 import yaml
-import decimal
 from argparse import ArgumentParser
 from contextlib import contextmanager
 from appdirs import user_data_dir, user_config_dir
@@ -117,11 +116,17 @@ class Integer(Setting[int]):
         assert isinstance(val, int), \
             f"Setting '{self.name}' must be an integer."
 
+    def deserialize(self, value):
+        return int(value)
+
 
 class Float(Setting[float]):
     def validate(self, val):
         assert isinstance(val, float), \
             f"Setting '{self.name}' must be a decimal."
+
+    def deserialize(self, value):
+        return float(value)
 
 
 class Toggle(Setting[bool]):
@@ -169,8 +174,8 @@ class MaxKeyFee(Setting[dict]):
     def _parse_list(l):
         assert len(l) == 2, 'Max key fee is made up of two values: "AMOUNT CURRENCY".'
         try:
-            amount = decimal.Decimal(l[0])
-        except decimal.InvalidOperation:
+            amount = float(l[0])
+        except ValueError:
             raise AssertionError('First value in max key fee is a decimal: "AMOUNT CURRENCY"')
         currency = str(l[1]).upper()
         if currency not in CURRENCIES:
@@ -183,7 +188,7 @@ class MaxKeyFee(Setting[dict]):
         if isinstance(value, dict):
             return {
                 'currency': value['currency'],
-                'amount': decimal.Decimal(value['amount']),
+                'amount': float(value['amount']),
             }
         if isinstance(value, str):
             value = value.split()

--- a/lbrynet/extras/cli.py
+++ b/lbrynet/extras/cli.py
@@ -176,7 +176,7 @@ def get_argument_parser():
         help='Show lbrynet CLI version and exit.'
     )
     main.set_defaults(group=None, command=None)
-    CLIConfig.contribute_args(main)
+    CLIConfig.contribute_to_argparse(main)
     sub = main.add_subparsers(metavar='COMMAND')
     start = sub.add_parser(
         'start',
@@ -193,7 +193,7 @@ def get_argument_parser():
               'should selectively be applied.')
     )
     start.set_defaults(command='start', start_parser=start)
-    Config.contribute_args(start)
+    Config.contribute_to_argparse(start)
 
     api = Daemon.get_api_definitions()
     groups = {}

--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -780,7 +780,7 @@ class Daemon(metaclass=JSONRPCServerType):
             --data_rate=<data_rate>                    : (float) 0.0001
             --download_timeout=<download_timeout>      : (int) 180
             --peer_port=<peer_port>                    : (int) 3333
-            --max_key_fee=<max_key_fee>                : (dict) maximum key fee for downloads,
+            --max_key_fee=<max_key_fee>                : (str) maximum key fee for downloads,
                                                           in the format: '<amount> <currency>'
                                                           Supported currency symbols: LBC, USD, BTC
             --no_max_key_fee                 : (bool) Disable max key fee.
@@ -801,7 +801,7 @@ class Daemon(metaclass=JSONRPCServerType):
             (dict) Updated dictionary of daemon settings
         """
         with self.conf.update_config() as c:
-            for key, value in kwargs:
+            for key, value in kwargs.items():
                 attr: Setting = getattr(type(c), key)
                 setattr(c, key, attr.deserialize(value))
         return self.jsonrpc_settings_get()

--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -781,12 +781,7 @@ class Daemon(metaclass=JSONRPCServerType):
             --download_timeout=<download_timeout>      : (int) 180
             --peer_port=<peer_port>                    : (int) 3333
             --max_key_fee=<max_key_fee>                : (dict) maximum key fee for downloads,
-                                                          in the format:
-                                                          {
-                                                            'currency': <currency_symbol>,
-                                                            'amount': <amount>
-                                                          }.
-                                                          In the CLI, it must be: '<amount> <currency>'
+                                                          in the format: '<amount> <currency>'
                                                           Supported currency symbols: LBC, USD, BTC
             --no_max_key_fee                 : (bool) Disable max key fee.
             --use_upnp=<use_upnp>            : (bool) True

--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -766,7 +766,6 @@ class Daemon(metaclass=JSONRPCServerType):
                          [--download_timeout=<download_timeout>]
                          [--peer_port=<peer_port>]
                          [--max_key_fee=<max_key_fee>]
-                         [--disable_max_key_fee=<disable_max_key_fee>]
                          [--use_upnp=<use_upnp>]
                          [--run_reflector_server=<run_reflector_server>]
                          [--cache_time=<cache_time>]
@@ -787,9 +786,9 @@ class Daemon(metaclass=JSONRPCServerType):
                                                             'currency': <currency_symbol>,
                                                             'amount': <amount>
                                                           }.
-                                                          In the CLI, it must be an escaped JSON string
+                                                          In the CLI, it must be: '<amount> <currency>'
                                                           Supported currency symbols: LBC, USD, BTC
-            --disable_max_key_fee=<disable_max_key_fee> : (bool) False
+            --no_max_key_fee                 : (bool) Disable max key fee.
             --use_upnp=<use_upnp>            : (bool) True
             --run_reflector_server=<run_reflector_server>  : (bool) False
             --cache_time=<cache_time>  : (int) 150

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -46,7 +46,7 @@ class ConfigurationTests(unittest.TestCase):
 
     def test_arguments(self):
         parser = argparse.ArgumentParser()
-        TestConfig.contribute_args(parser)
+        TestConfig.contribute_to_argparse(parser)
 
         args = parser.parse_args([])
         c = TestConfig.create_from_arguments(args)
@@ -180,7 +180,7 @@ class ConfigurationTests(unittest.TestCase):
             )
             self.assertEqual(c.servers, [('localhost', 5566)])
 
-    def test_max_key_fee(self):
+    def test_max_key_fee_from_yaml(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             config = os.path.join(temp_dir, 'settings.yml')
             with open(config, 'w') as fd:
@@ -196,3 +196,22 @@ class ConfigurationTests(unittest.TestCase):
                 c.max_key_fee = {'currency': 'BTC', 'amount': 1}
             with open(config, 'r') as fd:
                 self.assertEqual(fd.read(), 'max_key_fee:\n  amount: 1\n  currency: BTC\n')
+
+    def test_max_key_fee_from_args(self):
+        parser = argparse.ArgumentParser()
+        Config.contribute_to_argparse(parser)
+
+        # default
+        args = parser.parse_args([])
+        c = Config.create_from_arguments(args)
+        self.assertEqual(c.max_key_fee, {'amount': 50.0, 'currency': 'USD'})
+
+        # disabled
+        args = parser.parse_args(['--no-max-key-fee'])
+        c = Config.create_from_arguments(args)
+        self.assertEqual(c.max_key_fee, None)
+
+        # set
+        args = parser.parse_args(['--max-key-fee', '1.0', 'BTC'])
+        c = Config.create_from_arguments(args)
+        self.assertEqual(c.max_key_fee, {'amount': 1.0, 'currency': 'BTC'})

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -196,6 +196,10 @@ class ConfigurationTests(unittest.TestCase):
                 c.max_key_fee = {'currency': 'BTC', 'amount': 1}
             with open(config, 'r') as fd:
                 self.assertEqual(fd.read(), 'max_key_fee:\n  amount: 1\n  currency: BTC\n')
+            with c.update_config():
+                c.max_key_fee = None
+            with open(config, 'r') as fd:
+                self.assertEqual(fd.read(), 'max_key_fee: null\n')
 
     def test_max_key_fee_from_args(self):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
backwards-incompatible: setting max key fee via command line now uses the following format (via yaml config is unchanged): `--max-key-fee 40.0 USD`
backwards-incompatible: `--disable-max-key-fee` is now replaced by `--no-max-key-fee` on command line and in yaml file just `max_key_fee: null`