### PR TITLE
Update settings

### DIFF
--- a/lbrynet/blob_exchange/downloader.py
+++ b/lbrynet/blob_exchange/downloader.py
@@ -31,9 +31,9 @@ class BlobDownloader:  # TODO: refactor to be the base class used by StreamDownl
         self.blob: 'BlobFile' = None
         self.blob_queue = asyncio.Queue(loop=self.loop)
 
-        self.blob_download_timeout = config.get('blob_download_timeout')
-        self.peer_connect_timeout = config.get('peer_connect_timeout')
-        self.max_connections = config.get('max_connections_per_stream')
+        self.blob_download_timeout = config.blob_download_timeout
+        self.peer_connect_timeout = config.peer_connect_timeout
+        self.max_connections = config.max_connections_per_download
 
     async def _request_blob(self, peer: 'KademliaPeer'):
         if self.blob.get_is_verified():

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -16,29 +16,11 @@ log = logging.getLogger(__name__)
 NOT_SET = type(str('NOT_SET'), (object,), {})
 T = typing.TypeVar('T')
 
-KB = 2 ** 10
-MB = 2 ** 20
-
-ANALYTICS_ENDPOINT = 'https://api.segment.io/v1'
-ANALYTICS_TOKEN = 'Ax5LZzR1o3q3Z3WjATASDwR5rKyHH0qOIRIbLmMXn2H='
-API_ADDRESS = 'lbryapi'
-APP_NAME = 'LBRY'
-BLOBFILES_DIR = 'blobfiles'
-CRYPTSD_FILE_EXTENSION = '.cryptsd'
 CURRENCIES = {
     'BTC': {'type': 'crypto'},
     'LBC': {'type': 'crypto'},
     'USD': {'type': 'fiat'},
 }
-ICON_PATH = 'icons' if 'win' in sys.platform else 'app.icns'
-LOG_FILE_NAME = 'lbrynet.log'
-LOG_POST_URL = 'https://lbry.io/log-upload'
-MAX_BLOB_REQUEST_SIZE = 64 * KB
-MAX_HANDSHAKE_SIZE = 64 * KB
-MAX_REQUEST_SIZE = 64 * KB
-MAX_RESPONSE_INFO_SIZE = 64 * KB
-MAX_BLOB_INFOS_TO_REQUEST = 20
-PROTOCOL_PREFIX = 'lbry'
 SLACK_WEBHOOK = (
     'nUE0pUZ6Yl9bo29epl5moTSwnl5wo20ip2IlqzywMKZiIQSFZR5'
     'AHx4mY0VmF0WQZ1ESEP9kMHZlp1WzJwWOoKN3ImR1M2yUAaMyqGZ='
@@ -471,7 +453,6 @@ class CLIConfig(BaseConfig):
 
 
 class Config(CLIConfig):
-
     data_dir = Path("Directory path to store blobs.", metavar='DIR')
     download_dir = Path(
         "Directory path to place assembled files downloaded from LBRY.",
@@ -486,20 +467,12 @@ class Config(CLIConfig):
         "Whether to share usage stats and diagnostic info with LBRY.", True,
         previous_names=['upload_log', 'upload_log', 'share_debug_info']
     )
-
-    # claims set to expire within this many blocks will be
-    # automatically renewed after startup (if set to 0, renews
-    # will not be made automatically)
-    auto_renew_claim_height_delta = Integer("", 0)
     cache_time = Integer("", 150)
-    data_rate = Float("points/megabyte", .0001)
-    delete_blobs_on_remove = Toggle("", True)
     dht_node_port = Integer("", 4444)
     download_timeout = Float("", 30.0)
     blob_download_timeout = Float("", 20.0)
     peer_connect_timeout = Float("", 3.0)
     node_rpc_timeout = Float("", constants.rpc_timeout)
-    is_generous_host = Toggle("", True)
     announce_head_blobs_only = Toggle("", True)
     concurrent_announcers = Integer("", 10)
     known_dht_nodes = Servers("", [
@@ -509,26 +482,15 @@ class Config(CLIConfig):
         ('lbrynet4.lbry.io', 4444)  # ASIA
     ])
     max_connections_per_stream = Integer("", 5)
-    seek_head_blob_first = Toggle("", True)
     max_key_fee = MaxKeyFee("", {'currency': 'USD', 'amount': 50.0})
-    min_info_rate = Float("points/1000 infos", .02)
-    min_valuable_hash_rate = Float("points/1000 infos", .05)
-    min_valuable_info_rate = Float("points/1000 infos", .05)
     peer_port = Integer("", 3333)
-    pointtrader_server = String("", 'http://127.0.0.1:2424')
-    reflector_port = Integer("", 5566)
     # if reflect_uploads is True, send files to reflector after publishing (as well as a periodic check in the
     # event the initial upload failed or was disconnected part way through, provided the auto_re_reflect_interval > 0)
     reflect_uploads = Toggle("", True)
-    auto_re_reflect_interval = Integer("set to 0 to disable", 86400)
     reflector_servers = Servers("", [
         ('reflector.lbry.io', 5566)
     ])
-    run_reflector_server = Toggle("adds reflector to components_to_skip unless True", False)
-    sd_download_timeout = Integer("", 3)
-    peer_search_timeout = Integer("", 60)
     use_upnp = Toggle("", True)
-    use_keyring = Toggle("", False)
     blockchain_name = String("", 'lbrycrd_main')
     lbryum_servers = Servers("", [
         ('lbryumx1.lbry.io', 50001),

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -485,7 +485,8 @@ class Config(CLIConfig):
         previous_names=['announce_head_blobs_only']
     )
     concurrent_blob_announcers = Integer(
-        "Number of blobs to iteratively announce at once", 10, previous_names=['concurrent_announcers']
+        "Number of blobs to iteratively announce at once, set to 0 to disable", 10,
+        previous_names=['concurrent_announcers']
     )
     max_connections_per_download = Integer(
         "Maximum number of peers to connect to while downloading a blob", 5,

--- a/lbrynet/dht/blob_announcer.py
+++ b/lbrynet/dht/blob_announcer.py
@@ -19,6 +19,8 @@ class BlobAnnouncer:
         self.announce_queue: typing.List[str] = []
 
     async def _announce(self, batch_size: typing.Optional[int] = 10):
+        if not batch_size:
+            return
         if not self.node.joined.is_set():
             await self.node.joined.wait()
         blob_hashes = await self.storage.get_blobs_to_announce()

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -20,10 +20,10 @@ log = logging.getLogger(__name__)
 
 class Node:
     def __init__(self, loop: asyncio.BaseEventLoop, peer_manager: 'PeerManager', node_id: bytes, udp_port: int,
-                 internal_udp_port: int, peer_port: int, external_ip: str):
+                 internal_udp_port: int, peer_port: int, external_ip: str, rpc_timeout: typing.Optional[float] = 5.0):
         self.loop = loop
         self.internal_udp_port = internal_udp_port
-        self.protocol = KademliaProtocol(loop, peer_manager, node_id, external_ip, udp_port, peer_port)
+        self.protocol = KademliaProtocol(loop, peer_manager, node_id, external_ip, udp_port, peer_port, rpc_timeout)
         self.listening_port: asyncio.DatagramTransport = None
         self.joined = asyncio.Event(loop=self.loop)
         self._join_task: asyncio.Task = None
@@ -123,7 +123,10 @@ class Node:
         self.protocol.ping_queue.start()
         self._refresh_task = self.loop.create_task(self.refresh_node())
 
+        # resolve the known node urls
         known_node_addresses = known_node_addresses or []
+        url_to_addr = {}
+
         if known_node_urls:
             for host, port in known_node_urls:
                 info = await self.loop.getaddrinfo(
@@ -132,23 +135,35 @@ class Node:
                 )
                 if (info[0][4][0], port) not in known_node_addresses:
                     known_node_addresses.append((info[0][4][0], port))
-        futs = []
-        for address, port in known_node_addresses:
-            peer = self.protocol.get_rpc_peer(KademliaPeer(self.loop, address, udp_port=port))
-            futs.append(peer.ping())
-        if futs:
-            await asyncio.wait(futs, loop=self.loop)
+                    url_to_addr[info[0][4][0]] = host
 
-        async with self.peer_search_junction(self.protocol.node_id, max_results=16) as junction:
-            async for peers in junction:
-                for peer in peers:
+        if known_node_addresses:
+            while not self.protocol.routing_table.get_peers():
+                success = False
+                # ping the seed nodes, this will set their node ids (since we don't know them ahead of time)
+                for address, port in known_node_addresses:
+                    peer = self.protocol.get_rpc_peer(KademliaPeer(self.loop, address, udp_port=port))
                     try:
-                        await self.protocol.get_rpc_peer(peer).ping()
-                    except (asyncio.TimeoutError, RemoteException):
-                        pass
-        self.joined.set()
+                        await peer.ping()
+                        success = True
+                    except asyncio.TimeoutError:
+                        log.warning("seed node (%s:%i) timed out in %s", url_to_addr.get(address, address), port,
+                                    round(self.protocol.rpc_timeout, 2))
+                if success:
+                    break
+            # now that we have the seed nodes in routing, to an iterative lookup of our own id to populate the buckets
+            # in the routing table with good peers who are near us
+            async with self.peer_search_junction(self.protocol.node_id, max_results=16) as junction:
+                async for peers in junction:
+                    for peer in peers:
+                        try:
+                            await self.protocol.get_rpc_peer(peer).ping()
+                        except (asyncio.TimeoutError, RemoteException):
+                            pass
+
         log.info("Joined DHT, %i peers known in %i buckets", len(self.protocol.routing_table.get_peers()),
                  self.protocol.routing_table.buckets_with_contacts())
+        self.joined.set()
 
     def start(self, interface: str, known_node_urls: typing.List[typing.Tuple[str, int]]):
         self._join_task = self.loop.create_task(

--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -1551,8 +1551,6 @@ class Daemon(metaclass=JSONRPCServerType):
             }
         """
 
-        timeout = timeout if timeout is not None else self.conf.download_timeout
-
         parsed_uri = parse_lbry_uri(uri)
         if parsed_uri.is_channel:
             raise Exception("cannot download a channel claim, specify a /path")
@@ -1584,7 +1582,7 @@ class Daemon(metaclass=JSONRPCServerType):
             stream = existing[0]
         else:
             stream = await self.stream_manager.download_stream_from_claim(
-                self.dht_node, self.conf.download_dir, resolved, file_name, timeout, fee_amount, fee_address
+                self.dht_node, self.conf, resolved, file_name, timeout, fee_amount, fee_address
             )
         if stream:
             return stream.as_dict()

--- a/lbrynet/extras/daemon/analytics.py
+++ b/lbrynet/extras/daemon/analytics.py
@@ -5,8 +5,11 @@ import logging
 import aiohttp
 
 from lbrynet import utils
-from lbrynet.conf import Config, ANALYTICS_ENDPOINT, ANALYTICS_TOKEN
+from lbrynet.conf import Config
 from lbrynet.extras import system_info
+
+ANALYTICS_ENDPOINT = 'https://api.segment.io/v1'
+ANALYTICS_TOKEN = 'Ax5LZzR1o3q3Z3WjATASDwR5rKyHH0qOIRIbLmMXn2H='
 
 # Things We Track
 SERVER_STARTUP = 'Server Startup'

--- a/lbrynet/extras/daemon/storage.py
+++ b/lbrynet/extras/daemon/storage.py
@@ -275,7 +275,7 @@ class SQLiteStorage(SQLiteMixin):
     def get_blobs_to_announce(self):
         def get_and_update(transaction):
             timestamp = self.loop.time()
-            if self.conf.announce_head_blobs_only:
+            if self.conf.announce_head_and_sd_only:
                 r = transaction.execute(
                     "select blob_hash from blob "
                     "where blob_hash is not null and "
@@ -694,5 +694,5 @@ class SQLiteStorage(SQLiteMixin):
             "select s.sd_hash from stream s "
             "left outer join reflected_stream r on s.sd_hash=r.sd_hash "
             "where r.timestamp is null or r.timestamp < ?",
-            self.loop.time() - self.conf.auto_re_reflect_interval
+            self.loop.time() - 86400
         )

--- a/lbrynet/stream/downloader.py
+++ b/lbrynet/stream/downloader.py
@@ -83,7 +83,7 @@ class StreamDownloader(StreamAssembler):  # TODO: reduce duplication, refactor t
         else:
             log.info("downloader idle...")
         for peer in to_add:
-            if len(self.running_download_requests) >= 8:
+            if len(self.running_download_requests) >= self.max_connections_per_stream:
                 break
             task = self.loop.create_task(self._request_blob(peer))
             self.requested_from[self.current_blob.blob_hash][peer] = task

--- a/lbrynet/stream/reflector/client.py
+++ b/lbrynet/stream/reflector/client.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class StreamReflectorClient(asyncio.Protocol):
     def __init__(self, blob_manager: 'BlobFileManager', descriptor: 'StreamDescriptor'):
+        self.loop = asyncio.get_event_loop()
         self.transport: asyncio.StreamWriter = None
         self.blob_manager = blob_manager
         self.descriptor = descriptor
@@ -45,7 +46,7 @@ class StreamReflectorClient(asyncio.Protocol):
         msg = json.dumps(request_dict)
         self.transport.write(msg.encode())
         try:
-            self.pending_request = asyncio.get_event_loop().create_task(self.response_queue.get())
+            self.pending_request = self.loop.create_task(self.response_queue.get())
             return await self.pending_request
         finally:
             self.pending_request = None

--- a/tests/integration/wallet/test_commands.py
+++ b/tests/integration/wallet/test_commands.py
@@ -41,7 +41,7 @@ class CommandTestCase(IntegrationTestCase):
         conf.download_dir = self.wallet_node.data_path
         conf.share_usage_data = False
         conf.use_upnp = False
-        conf.reflect_uploads = False
+        conf.reflect_streams = False
         conf.blockchain_name = 'lbrycrd_regtest'
         conf.lbryum_servers = [('localhost', 50001)]
         conf.known_dht_nodes = []

--- a/tests/unit/lbrynet_daemon/test_Daemon.py
+++ b/tests/unit/lbrynet_daemon/test_Daemon.py
@@ -84,29 +84,12 @@ class TestCostEst(unittest.TestCase):
         result = yield f2d(daemon.get_est_cost("test", size))
         self.assertEqual(result, correct_result)
 
-    def test_fee_and_ungenerous_data(self):
-        conf = Config(is_generous_host=False)
-        size = 10000000
-        fake_fee_amount = 4.5
-        correct_result = size / 10 ** 6 * conf.data_rate + fake_fee_amount
-        daemon = get_test_daemon(conf, with_fee=True)
-        result = yield f2d(daemon.get_est_cost("test", size))
-        self.assertEqual(result, round(correct_result, 1))
-
     def test_generous_data_and_no_fee(self):
         size = 10000000
         correct_result = 0.0
         daemon = get_test_daemon(Config(is_generous_host=True))
         result = yield f2d(daemon.get_est_cost("test", size))
         self.assertEqual(result, correct_result)
-
-    def test_ungenerous_data_and_no_fee(self):
-        conf = Config(is_generous_host=False)
-        size = 10000000
-        correct_result = size / 10 ** 6 * conf.data_rate
-        daemon = get_test_daemon(conf)
-        result = yield f2d(daemon.get_est_cost("test", size))
-        self.assertEqual(result, round(correct_result, 1))
 
 
 @unittest.SkipTest


### PR DESCRIPTION
- Added new `network_inferface` (default `0.0.0.0`) setting to configure what interface to listen on for the dht/blob exchange.

- Remove the following unused settings:
```
use_keyring
peer_search_timeout
sd_download_timeout
run_reflector_server
auto_re_reflect_interval
reflector_port
pointtrader_server
min_valuable_info_rate
min_valuable_hash_rate
min_info_rate
seek_head_blob_first
is_generous_host
delete_blobs_on_remove
data_rate
auto_renew_claim_height_delta
```

- Renamed the following settings to better describe what they do (backwards compatible):

```
dht_node_port -> udp_port
peer_port -> tcp_port
announce_head_blobs_only -> announce_head_and_sd_only
concurrent_announcers -> concurrent_blob_announcers
max_connections_per_stream -> max_connections_per_download
reflect_uploads -> reflect_streams
```
