### PR TITLE
Adding armhf-docker-compiler

### DIFF
--- a/docker/armhf-compiler/Dockerfile
+++ b/docker/armhf-compiler/Dockerfile
@@ -1,0 +1,54 @@
+FROM multiarch/ubuntu-core:armhf-bionic
+
+RUN	apt update && \
+	apt install -y \
+		python3-pip \
+		python3.7 \
+		python3.7-dev \
+		build-essential \
+		libssl-dev \
+		libacl1-dev \
+		liblz4-dev \
+		libfuse-dev \
+		fuse \
+		pkg-config \
+		fakeroot \
+		git \
+		zlib1g-dev \
+		libbz2-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		liblzma-dev \
+		libsqlite3-dev \
+		zip \
+		libffi-dev
+
+RUN	update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1 && \
+	update-alternatives --install /usr/bin/python python /usr/bin/python3.7 10 && \
+	update-alternatives --config python && \
+	python --version && \
+	pip3 --version
+
+
+RUN	python3.7 -m pip install -U pyinstaller cryptography aiohttp coincurve pbkdf2 cryptography attrs pylru 
+
+RUN	git clone https://github.com/lbryio/lbry.git --depth 1 /lbry && \
+	cd /lbry && \
+	git clone https://github.com/lbryio/torba.git --depth 1 /lbry/torba
+
+RUN	sed -i -e "s/'plyvel',//" /lbry/torba/setup.py && \
+	cd /lbry/torba && python3.7 -m pip install -e . && cd /lbry/ && \
+	python3.7 scripts/set_build.py && \
+	python3.7 -m pip install -e . && \
+	pyinstaller -F -n lbrynet lbrynet/extras/cli.py
+
+RUN	echo "checking contents of /lbry/dist/" && ls -lAh /lbry/dist/ && \
+	echo "checking contents of /" && ls -lAh / && \
+	echo "redundantly setting executable bit for good measure" && chmod +x /lbry/dist/lbrynet && \
+	echo "compressing lbrynet armhf binary" && zip -j /lbry/dist/lbrynet-armhf.zip /lbry/dist/lbrynet && \
+	echo "creating /target/" && mkdir /target
+COPY	./start.sh /usr/local/bin/start
+
+RUN	/lbry/dist/lbrynet --version
+
+CMD	start

--- a/docker/armhf-compiler/README.md
+++ b/docker/armhf-compiler/README.md
@@ -1,0 +1,28 @@
+# armhf-compiler
+
+This container's goal is to make CI/CD easier for everyone, Travis CI, GitlabCI, Jenkins... Your desktop's docker equipped development environment.
+
+## Example Usage
+
+#### binfmt_misc register
+This step sets up your docker daemon to support more container architectures.
+
+Register `quemu-*-static` for all supported processors except the current one.
+* `docker run --rm --privileged multiarch/qemu-user-static:register`
+
+#### build the armhf bin
+<!-- TODO: Process could be greatly sped up but keeping it simple for first release. -->
+* `docker build --tag lbryio/lbrynet:armhf-compiler .`
+
+#### export compiled bin to local /target
+This containers sole purpose is to build and spit out the bin.
+<!-- TODO: Fork this container base to begin work on LbryTV compiler to reduce build time on rpi -->
+* `docker run --rm -ti -v $(pwd)/target:/target lbryio/lbrynet:armhf-compiler`
+
+
+## Cleanup
+If you're doing this on a machine you care to have restored to defaults this is the only host change we imposed so to revert the change you must execute the following docker command.
+
+Same as above, but remove all registered `binfmt_misc` before
+* `docker run --rm --privileged multiarch/qemu-user-static:register --reset`
+

--- a/docker/armhf-compiler/start.sh
+++ b/docker/armhf-compiler/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 2
+cp /lbry/dist/lbrynet-armhf.zip /target/


### PR DESCRIPTION
This commit contains a functional Dockerfile which will produce a zip file containing the latest armhf build of the lbrynet daemon.

## PR Checklist
Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?

It equips the LBRY team with the ability to compile an armhf binary via Docker if they wish they can use Travis CI to do this as they use it for other builds as well.  

Why is this change necessary?
Currently, @kodxana is building this binary at home on their Raspberry PI and it takes ages.  This reduces build times from hours to under an hour.  The other benefit is this means that automation can take over.

<!-- Please check all that apply to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [X] Refactoring (no functional changes)
- [X] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: N/A


## What is the current behavior?
Currently, @kodxana is building the binary on their volunteer hardware. 

## What is the new behavior?
You can now follow the new `/lbry/docker/armhf-compiler/README.md` to build the `armhf` container on any `x86_64` host.

## Other information
Someone will need to implement this in the travis-ci.yml if not me it'll need to be done by someone who manages this on the team.  

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
