### PR TITLE
Fix deleting incomplete downloads when they are stopped

### DIFF
--- a/lbrynet/stream/assembler.py
+++ b/lbrynet/stream/assembler.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 def _get_next_available_file_name(download_directory: str, file_name: str) -> str:
-    base_name, ext = os.path.splitext(file_name)
+    base_name, ext = os.path.splitext(os.path.basename(file_name))
     i = 0
     while os.path.isfile(os.path.join(download_directory, file_name)):
         i += 1

--- a/lbrynet/stream/managed_stream.py
+++ b/lbrynet/stream/managed_stream.py
@@ -170,6 +170,10 @@ class ManagedStream:
     def stop_download(self):
         if self.downloader:
             self.downloader.stop()
+            if not self.downloader.stream_finished_event.is_set() and self.downloader.wrote_bytes_event.is_set():
+                path = os.path.join(self.download_directory, self.file_name)
+                if os.path.isfile(path):
+                    os.remove(path)
         if not self.finished:
             self.update_status(self.STATUS_STOPPED)
 

--- a/lbrynet/stream/stream_manager.py
+++ b/lbrynet/stream/stream_manager.py
@@ -194,10 +194,6 @@ class StreamManager:
         return stream
 
     async def delete_stream(self, stream: ManagedStream, delete_file: typing.Optional[bool] = False):
-        stream_finished = False if not stream.finished and stream.downloader\
-            else (stream.downloader and stream.downloader.stream_finished_event.is_set())
-        if not stream_finished:
-            delete_file = True
         stream.stop_download()
         self.streams.remove(stream)
         await self.storage.delete_stream(stream.descriptor)


### PR DESCRIPTION
also fixes deleting previous streams (but not assembled/published files) for a claim being updated

