### PR TITLE
Refactor peer scoring and maintain connections to fix stuck downloads, remove locking from ping queue

### DIFF
--- a/lbrynet/blob_exchange/client.py
+++ b/lbrynet/blob_exchange/client.py
@@ -137,7 +137,7 @@ class BlobExchangeClientProtocol(asyncio.Protocol):
         self.transport = None
 
     async def download_blob(self, blob: 'BlobFile') -> typing.Tuple[int, typing.Optional[asyncio.Transport]]:
-        if blob.get_is_verified() or blob.file_exists:
+        if blob.get_is_verified() or blob.file_exists or blob.blob_write_lock.locked():
             return 0, self.transport
         try:
             self.blob, self.writer, self._blob_bytes_received = blob, blob.open_for_writing(), 0

--- a/lbrynet/blob_exchange/downloader.py
+++ b/lbrynet/blob_exchange/downloader.py
@@ -31,9 +31,10 @@ class BlobDownloader:
             return False
         # if a peer won 3 or more blob races and is active as a downloader, stop the race so bandwidth improves
         # the safe net side is that any failure will reset the peer score, triggering the race back
-        for peer, task in self.active_connections.items():
-            if self.scores.get(peer, 0) >= 0 and self.rounds_won.get(peer, 0) >= 3 and not task.done():
-                return False
+        # TODO: this is a good idea for low bandwidth, but doesnt play nice on high bandwidth
+        # for peer, task in self.active_connections.items():
+        #   if self.scores.get(peer, 0) >= 0 and self.rounds_won.get(peer, 0) >= 3 and not task.done():
+        #       return False
         return True
 
     async def request_blob_from_peer(self, blob: 'BlobFile', peer: 'KademliaPeer'):

--- a/lbrynet/conf.py
+++ b/lbrynet/conf.py
@@ -475,8 +475,8 @@ class Config(CLIConfig):
 
     # protocol timeouts
     download_timeout = Float("Cumulative timeout for a stream to begin downloading before giving up", 30.0)
-    blob_download_timeout = Float("Timeout to download a blob from a peer", 20.0)
-    peer_connect_timeout = Float("Timeout to establish a TCP connection to a peer", 3.0)
+    blob_download_timeout = Float("Timeout to download a blob from a peer", 30.0)
+    peer_connect_timeout = Float("Timeout to establish a TCP connection to a peer", 2.0)
     node_rpc_timeout = Float("Timeout when making a DHT request", constants.rpc_timeout)
 
     # blob announcement and download

--- a/lbrynet/dht/node.py
+++ b/lbrynet/dht/node.py
@@ -64,7 +64,7 @@ class Node:
             # ping the set of peers; upon success/failure the routing able and last replied/failed time will be updated
             to_ping = [peer for peer in set(total_peers) if self.protocol.peer_manager.peer_is_good(peer) is not True]
             if to_ping:
-                await self.protocol.ping_queue.enqueue_maybe_ping(*to_ping, delay=0)
+                self.protocol.ping_queue.enqueue_maybe_ping(*to_ping, delay=0)
 
             fut = asyncio.Future(loop=self.loop)
             self.loop.call_later(constants.refresh_interval, fut.set_result, None)

--- a/lbrynet/stream/downloader.py
+++ b/lbrynet/stream/downloader.py
@@ -51,6 +51,7 @@ class StreamDownloader(StreamAssembler):
     async def after_finished(self):
         log.info("downloaded stream %s -> %s", self.sd_hash, self.output_path)
         await self.blob_manager.storage.change_file_status(self.descriptor.stream_hash, 'finished')
+        self.blob_downloader.close()
 
     def stop(self):
         if self.accumulate_task:

--- a/tests/unit/blob_exchange/test_transfer_blob.py
+++ b/tests/unit/blob_exchange/test_transfer_blob.py
@@ -70,6 +70,7 @@ class TestBlobExchange(BlobExchangeTestBase):
         # download the blob
         downloaded = await request_blob(self.loop, client_blob, self.server_from_client.address,
                                         self.server_from_client.tcp_port, 2, 3)
+        await client_blob.finished_writing.wait()
         self.assertEqual(client_blob.get_is_verified(), True)
         self.assertTrue(downloaded)
 
@@ -111,6 +112,7 @@ class TestBlobExchange(BlobExchangeTestBase):
             ),
             self._test_transfer_blob(blob_hash)
         )
+        await second_client_blob.finished_writing.wait()
         self.assertEqual(second_client_blob.get_is_verified(), True)
 
     async def test_host_different_blobs_to_multiple_peers_at_once(self):
@@ -140,7 +142,8 @@ class TestBlobExchange(BlobExchangeTestBase):
                 self.loop, second_client_blob, server_from_second_client.address,
                 server_from_second_client.tcp_port, 2, 3
             ),
-            self._test_transfer_blob(sd_hash)
+            self._test_transfer_blob(sd_hash),
+            second_client_blob.finished_writing.wait()
         )
         self.assertEqual(second_client_blob.get_is_verified(), True)
 


### PR DESCRIPTION
- bypass response parser during blob downloads
- peer score now accounts for rough speed (bytes transferred over time since the connection attempt)
- reuse connections on downloads when possible, skipping the time it takes to connect
- penalize peers who gets cancelled due not connecting fast enough to compete for the download
- check free connection slots during downloads, instead of just new peers, so peer slots are replaced as soon as possible, solving situations where the download used to get stuck waiting on new peers while having enough to work
- remove ping queue lock
- fix race condition where an open blob about to be written would be opened again, raising errors
- tune default configuration for slow connections: raised `blob_download_timeout` to match  `download_timeout` while lowering `peer_connect_timeout`, so we fail earlier if its totally bad but let it work for longer if it managed to connect
- removed some places that used to catch CancelledError so we get less orphaned tasks and bugs when stopping