### PR TITLE
Improve startup time

### DIFF
--- a/lbrynet/blob/blob_file.py
+++ b/lbrynet/blob/blob_file.py
@@ -1,4 +1,5 @@
 import os
+import re
 import asyncio
 import binascii
 import logging
@@ -21,6 +22,9 @@ def is_valid_hashcharacter(char: str) -> bool:
     return char in "0123456789abcdef"
 
 
+_hexmatch = re.compile("^[a-f,0-9]+$")
+
+
 def is_valid_blobhash(blobhash: str) -> bool:
     """Checks whether the blobhash is the correct length and contains only
     valid characters (0-9, a-f)
@@ -29,8 +33,7 @@ def is_valid_blobhash(blobhash: str) -> bool:
 
     @return: True/False
     """
-    return len(blobhash) == blobhash_length and all(is_valid_hashcharacter(l) for l in blobhash)
-
+    return len(blobhash) == blobhash_length and _hexmatch.match(blobhash)
 
 def encrypt_blob_bytes(key: bytes, iv: bytes, unencrypted: bytes) -> typing.Tuple[bytes, str]:
     cipher = Cipher(AES(key), modes.CBC(iv), backend=backend)

--- a/lbrynet/blob/blob_file.py
+++ b/lbrynet/blob/blob_file.py
@@ -18,11 +18,11 @@ from lbrynet.blob.writer import HashBlobWriter
 log = logging.getLogger(__name__)
 
 
-def is_valid_hashcharacter(char: str) -> bool:
-    return char in "0123456789abcdef"
-
-
 _hexmatch = re.compile("^[a-f,0-9]+$")
+
+
+def is_valid_hashcharacter(char: str) -> bool:
+    return len(char) == 1 and _hexmatch.match(char)
 
 
 def is_valid_blobhash(blobhash: str) -> bool:
@@ -34,6 +34,7 @@ def is_valid_blobhash(blobhash: str) -> bool:
     @return: True/False
     """
     return len(blobhash) == blobhash_length and _hexmatch.match(blobhash)
+
 
 def encrypt_blob_bytes(key: bytes, iv: bytes, unencrypted: bytes) -> typing.Tuple[bytes, str]:
     cipher = Cipher(AES(key), modes.CBC(iv), backend=backend)

--- a/lbrynet/blob_exchange/client.py
+++ b/lbrynet/blob_exchange/client.py
@@ -51,7 +51,7 @@ class BlobExchangeClientProtocol(asyncio.Protocol):
             # fire the Future with the response to our request
             self._response_fut.set_result(response)
         if response.blob_data and self.writer and not self.writer.closed():
-            log.debug("got %i blob bytes from %s:%i", len(response.blob_data), self.peer_address, self.peer_port)
+            # log.debug("got %i blob bytes from %s:%i", len(response.blob_data), self.peer_address, self.peer_port)
             # write blob bytes if we're writing a blob and have blob bytes to write
             self._write(response.blob_data)
 

--- a/lbrynet/extras/cli.py
+++ b/lbrynet/extras/cli.py
@@ -259,8 +259,11 @@ def main(argv=None):
         logging.getLogger('aioupnp').setLevel(logging.WARNING)
         logging.getLogger('aiohttp').setLevel(logging.CRITICAL)
 
+        loop = asyncio.get_event_loop()
+
         if args.verbose:
             log.setLevel(logging.DEBUG)
+            loop.set_debug(True)
         else:
             log.setLevel(logging.INFO)
         if conf.share_usage_data:
@@ -269,7 +272,6 @@ def main(argv=None):
             log.addHandler(loggly_handler)
 
         daemon = Daemon(conf)
-        loop = asyncio.get_event_loop()
         try:
             loop.run_until_complete(daemon.start())
             loop.run_forever()

--- a/lbrynet/extras/daemon/storage.py
+++ b/lbrynet/extras/daemon/storage.py
@@ -308,16 +308,18 @@ class SQLiteStorage(SQLiteMixin):
                 r = transaction.execute(
                     "select blob_hash from blob "
                     "where blob_hash is not null and "
-                    "(should_announce=1 or single_announce=1) and next_announce_time<? and status='finished'",
-                    (timestamp,)
+                    "(should_announce=1 or single_announce=1) and next_announce_time<? and status='finished' "
+                    "order by next_announce_time asc limit ?",
+                    (timestamp, int(self.conf.concurrent_blob_announcers * 10))
                 )
             else:
                 r = transaction.execute(
                     "select blob_hash from blob where blob_hash is not null "
-                    "and next_announce_time<? and status='finished'", (timestamp,)
+                    "and next_announce_time<? and status='finished' "
+                    "order by next_announce_time asc limit ?",
+                    (timestamp, int(self.conf.concurrent_blob_announcers * 10))
                 )
-            blobs = [b[0] for b in r.fetchall()]
-            return blobs
+            return [b[0] for b in r.fetchall()]
         return self.db.run(get_and_update)
 
     def delete_blobs_from_db(self, blob_hashes):

--- a/lbrynet/extras/daemon/storage.py
+++ b/lbrynet/extras/daemon/storage.py
@@ -145,9 +145,6 @@ def get_all_lbry_files(transaction: sqlite3.Connection) -> typing.List[typing.Di
     ]
 
 
-
-
-
 class SQLiteStorage(SQLiteMixin):
     CREATE_TABLES_QUERY = """
             pragma foreign_keys=on;

--- a/lbrynet/extras/daemon/storage.py
+++ b/lbrynet/extras/daemon/storage.py
@@ -105,44 +105,53 @@ def get_content_claim_from_outpoint(transaction: sqlite3.Connection,
         return StoredStreamClaim(*claim_fields)
 
 
-def _batched_select(transaction, query, parameters):
-    for start_index in range(0, len(parameters), 900):
-        current_batch = parameters[start_index:start_index+900]
+def _batched_select(transaction, query, parameters, batch_size=900):
+    for start_index in range(0, len(parameters), batch_size):
+        current_batch = parameters[start_index:start_index+batch_size]
         bind = "({})".format(','.join(['?'] * len(current_batch)))
         for result in transaction.execute(query.format(bind), current_batch):
             yield result
 
 
 def get_all_lbry_files(transaction: sqlite3.Connection) -> typing.List[typing.Dict]:
-    return [
-        {
-            "row_id": rowid,
-            "stream_hash": stream_hash,
-            "file_name": file_name,                      # hex
-            "download_directory": download_dir,          # hex
-            "blob_data_rate": data_rate,
-            "status": status,
-            "sd_hash": sd_hash,
-            "key": stream_key,
-            "stream_name": stream_name,                  # hex
-            "suggested_file_name": suggested_file_name,  # hex
-            "claim": StoredStreamClaim(stream_hash, *claim_args)
-        } for (rowid, stream_hash, file_name, download_dir, data_rate, status, _, sd_hash, stream_key,
-               stream_name, suggested_file_name, *claim_args) in _batched_select(
-            transaction, "select file.rowid, file.*, stream.*, c.*, case when c.channel_claim_id is not null "
-                         "  then (select claim_name from claim where claim_id==c.channel_claim_id) "
-                         "  else null end as channel_name "
+    files = []
+    signed_claims = {}
+    for (rowid, stream_hash, file_name, download_dir, data_rate, status, _, sd_hash, stream_key,
+         stream_name, suggested_file_name, *claim_args) in _batched_select(
+            transaction, "select file.rowid, file.*, stream.*, c.* "
                          "from file inner join stream on file.stream_hash=stream.stream_hash "
                          "inner join content_claim cc on file.stream_hash=cc.stream_hash "
                          "inner join claim c on cc.claim_outpoint=c.claim_outpoint "
                          "where file.stream_hash in {} "
-                         "order by c.rowid desc",
-            [
-                stream_hash
-                for (stream_hash,) in transaction.execute("select stream_hash from file")
-            ]
+                         "order by c.rowid desc", [
+            stream_hash for (stream_hash,) in transaction.execute("select stream_hash from file")]):
+
+        claim = StoredStreamClaim(stream_hash, *claim_args)
+        if claim.channel_claim_id:
+            if claim.channel_claim_id not in signed_claims:
+                signed_claims[claim.channel_claim_id] = []
+            signed_claims[claim.channel_claim_id].append(claim)
+        files.append(
+            {
+                "row_id": rowid,
+                "stream_hash": stream_hash,
+                "file_name": file_name,                      # hex
+                "download_directory": download_dir,          # hex
+                "blob_data_rate": data_rate,
+                "status": status,
+                "sd_hash": sd_hash,
+                "key": stream_key,
+                "stream_name": stream_name,                  # hex
+                "suggested_file_name": suggested_file_name,  # hex
+                "claim": claim
+            }
         )
-    ]
+    for claim_id in signed_claims.keys():
+        channel_name = transaction.execute("select claim_name from claim where claim_id=?", (claim_id, )).fetchone()
+        if channel_name:
+            for claim in signed_claims[claim_id]:
+                claim.channel_name = channel_name[0]
+    return files
 
 
 class SQLiteStorage(SQLiteMixin):
@@ -441,7 +450,7 @@ class SQLiteStorage(SQLiteMixin):
              binascii.hexlify(download_directory.encode()).decode(), data_payment_rate, status)
         )
 
-    def get_all_lbry_files(self) -> typing.List[typing.Dict]:
+    def get_all_lbry_files(self) -> typing.Awaitable[typing.List[typing.Dict]]:
         return self.db.run(get_all_lbry_files)
 
     def change_file_status(self, stream_hash: str, new_status: str):

--- a/lbrynet/stream/stream_manager.py
+++ b/lbrynet/stream/stream_manager.py
@@ -168,7 +168,7 @@ class StreamManager:
 
     async def reflect_streams(self):
         while True:
-            if self.config.reflector_servers:
+            if self.config.reflect_streams and self.config.reflector_servers:
                 sd_hashes = await self.storage.get_streams_to_re_reflect()
                 streams = list(filter(lambda s: s.sd_hash in sd_hashes, self.streams))
                 batch = []
@@ -205,7 +205,7 @@ class StreamManager:
         stream = await ManagedStream.create(self.loop, self.blob_manager, file_path, key, iv_generator)
         self.streams.add(stream)
         self.storage.content_claim_callbacks[stream.stream_hash] = lambda: self._update_content_claim(stream)
-        if self.config.reflector_servers:
+        if self.config.reflect_streams and self.config.reflector_servers:
             host, port = random.choice(self.config.reflector_servers)
             self.loop.create_task(stream.upload_to_reflector(host, port))
         return stream

--- a/lbrynet/stream/stream_manager.py
+++ b/lbrynet/stream/stream_manager.py
@@ -143,7 +143,9 @@ class StreamManager:
             self.storage.content_claim_callbacks[stream.stream_hash] = lambda: self._update_content_claim(stream)
 
     async def load_streams_from_database(self):
+        log.info("Initializing stream manager from %s", self.storage._db_path)
         file_infos = await self.storage.get_all_lbry_files()
+        log.info("Initializing %i files", len(file_infos))
         await asyncio.gather(*[
             self.add_stream(
                 file_info['sd_hash'], binascii.unhexlify(file_info['file_name']).decode(),


### PR DESCRIPTION
* populate the stream manager from a single batched db query, then get the channel names as separate queries (substantially faster)
* speed up blob manager startup
* speed up blob hash character validation
* fix `reflect_streams` setting not being followed
* turn on debugging with the event loop when in running verbose
* limit the number of blobs queried for announcement