### PR TITLE
listen on internal port instead of upnp redirect

### DIFF
--- a/lbrynet/extras/daemon/Components.py
+++ b/lbrynet/extras/daemon/Components.py
@@ -477,7 +477,7 @@ class PeerProtocolServerComponent(Component):
         upnp = self.component_manager.get_component(UPNP_COMPONENT)
         blob_manager: BlobFileManager = self.component_manager.get_component(BLOB_COMPONENT)
         wallet: LbryWalletManager = self.component_manager.get_component(WALLET_COMPONENT)
-        peer_port = upnp.upnp_redirects.get("TCP", self.conf.tcp_port)
+        peer_port = self.conf.tcp_port
         address = await wallet.get_unused_address()
         self.blob_server = BlobServer(asyncio.get_event_loop(), blob_manager, address)
         self.blob_server.start_server(peer_port, interface=self.conf.network_interface)


### PR DESCRIPTION
## PR Checklist
Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [x] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?

Why is this change necessary?

<!-- Please check all that apply to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: N/A


## What is the current behavior?
binds peer port to the external port - the redirects are set to the internal. 

## What is the new behavior?


## Other information


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
