### PR TITLE
Test and fix edge cases for adding peers to routing

### DIFF
--- a/lbrynet/dht/constants.py
+++ b/lbrynet/dht/constants.py
@@ -16,6 +16,7 @@ refresh_interval = 3600  # 1 hour
 replicate_interval = refresh_interval
 data_expiration = 86400  # 24 hours
 token_secret_refresh_interval = 300  # 5 minutes
+maybe_ping_delay = 300  # 5 minutes
 check_refresh_interval = refresh_interval / 5
 max_datagram_size = 8192  # 8 KB
 rpc_id_length = 20

--- a/lbrynet/dht/protocol/protocol.py
+++ b/lbrynet/dht/protocol/protocol.py
@@ -313,9 +313,13 @@ class KademliaProtocol(DatagramProtocol):
         return args, {}
 
     async def _add_peer(self, peer: 'KademliaPeer'):
+        for p in self.routing_table.get_peers():
+            if (p.address, p.udp_port) == (peer.address, peer.udp_port) and p.node_id != peer.node_id:
+                self.routing_table.remove_peer(p)
         bucket_index = self.routing_table.kbucket_index(peer.node_id)
         if self.routing_table.buckets[bucket_index].add_peer(peer):
             return True
+
         # The bucket is full; see if it can be split (by checking if its range includes the host node's node_id)
         if self.routing_table.should_split(bucket_index, peer.node_id):
             self.routing_table.split_bucket(bucket_index)

--- a/lbrynet/dht/protocol/protocol.py
+++ b/lbrynet/dht/protocol/protocol.py
@@ -187,56 +187,46 @@ class PingQueue:
     def __init__(self, loop: asyncio.BaseEventLoop, protocol: 'KademliaProtocol'):
         self._loop = loop
         self._protocol = protocol
-        self._enqueued_contacts: typing.List['KademliaPeer'] = []
         self._pending_contacts: typing.Dict['KademliaPeer', float] = {}
         self._process_task: asyncio.Task = None
-        self._next_task: asyncio.Future = None
-        self._next_timer: asyncio.TimerHandle = None
         self._running = False
+        self._running_pings: typing.List[asyncio.Task] = []
 
     @property
     def running(self):
         return self._running
 
-    def enqueue_maybe_ping(self, *peers: 'KademliaPeer', delay: typing.Optional[float] = None):
-        delay = constants.check_refresh_interval if delay is None else delay
+    def enqueue_maybe_ping(self, *peers: 'KademliaPeer', delay: float = constants.maybe_ping_delay):
+        now = self._loop.time()
         for peer in peers:
-            if delay and peer not in self._enqueued_contacts:
-                self._pending_contacts[peer] = self._loop.time() + delay
-            elif peer not in self._enqueued_contacts:
-                self._enqueued_contacts.append(peer)
-                if peer in self._pending_contacts:
-                    del self._pending_contacts[peer]
+            if peer not in self._pending_contacts or now + delay < self._pending_contacts[peer]:
+                self._pending_contacts[peer] = delay + now
 
-    async def _process(self):
-        async def _ping(p: 'KademliaPeer'):
+    def maybe_ping(self, peer: 'KademliaPeer'):
+        async def ping_task():
             try:
-                if self._protocol.peer_manager.peer_is_good(p):
-                    await self._protocol.add_peer(p)
+                if self._protocol.peer_manager.peer_is_good(peer):
+                    if peer not in self._protocol.routing_table.get_peers():
+                        await self._protocol.add_peer(peer)
                     return
-                await self._protocol.get_rpc_peer(p).ping()
+                await self._protocol.get_rpc_peer(peer).ping()
             except asyncio.TimeoutError:
                 pass
 
+        task = self._loop.create_task(ping_task())
+        task.add_done_callback(lambda _: None if task not in self._running_pings else self._running_pings.remove(task))
+        self._running_pings.append(task)
+
+    async def _process(self):  # send up to 1 ping per second
         while True:
-            tasks = []
-
-            if self._enqueued_contacts or self._pending_contacts:
-                now = self._loop.time()
-                scheduled = [k for k, d in self._pending_contacts.items() if now >= d]
-                for k in scheduled:
-                    del self._pending_contacts[k]
-                    if k not in self._enqueued_contacts:
-                        self._enqueued_contacts.append(k)
-                while self._enqueued_contacts:
-                    peer = self._enqueued_contacts.pop()
-                    tasks.append(self._loop.create_task(_ping(peer)))
-            if tasks:
-                await asyncio.wait(tasks, loop=self._loop)
-
-            f = self._loop.create_future()
-            self._loop.call_later(1.0, lambda: None if f.done() else f.set_result(None))
-            await f
+            enqueued = list(self._pending_contacts.keys())
+            now = self._loop.time()
+            for peer in enqueued:
+                if self._pending_contacts[peer] <= now:
+                    del self._pending_contacts[peer]
+                    self.maybe_ping(peer)
+                    break
+            await asyncio.sleep(1, loop=self._loop)
 
     def start(self):
         assert not self._running
@@ -250,12 +240,8 @@ class PingQueue:
         if self._process_task:
             self._process_task.cancel()
             self._process_task = None
-        if self._next_task:
-            self._next_task.cancel()
-            self._next_task = None
-        if self._next_timer:
-            self._next_timer.cancel()
-            self._next_timer = None
+        while self._running_pings:
+            self._running_pings[0].cancel()
 
 
 class KademliaProtocol(DatagramProtocol):

--- a/lbrynet/dht/protocol/routing_table.py
+++ b/lbrynet/dht/protocol/routing_table.py
@@ -49,7 +49,14 @@ class KBucket:
             self.peers.remove(peer)
             self.peers.append(peer)
             return True
-        elif len(self.peers) < constants.k:
+        else:
+            for i in range(len(self.peers)):
+                p = self.peers[i]
+                if p.node_id == peer.node_id:
+                    self.peers.remove(p)
+                    self.peers.append(peer)
+                    return True
+        if len(self.peers) < constants.k:
             self.peers.append(peer)
             return True
         else:

--- a/tests/unit/dht/protocol/test_protocol.py
+++ b/tests/unit/dht/protocol/test_protocol.py
@@ -93,3 +93,65 @@ class TestProtocol(AsyncioTestCase):
             peer2.stop()
             peer1.disconnect()
             peer2.disconnect()
+
+    async def _make_protocol(self, other_peer, node_id, address, udp_port, tcp_port):
+        proto = KademliaProtocol(
+            self.loop, PeerManager(self.loop), node_id, address, udp_port, tcp_port
+        )
+        await self.loop.create_datagram_endpoint(lambda: proto, (address, 4444))
+        return proto, other_peer.peer_manager.get_kademlia_peer(node_id, address, udp_port=udp_port)
+
+    async def test_add_peer_after_handle_request(self):
+        with dht_mocks.mock_network_loop(self.loop):
+            node_id1 = constants.generate_id()
+            node_id2 = constants.generate_id()
+            node_id3 = constants.generate_id()
+            node_id4 = constants.generate_id()
+
+            peer1 = KademliaProtocol(
+                self.loop, PeerManager(self.loop), node_id1, '1.2.3.4', 4444, 3333
+            )
+            await self.loop.create_datagram_endpoint(lambda: peer1, ('1.2.3.4', 4444))
+
+            peer2, peer_2_from_peer_1 = await self._make_protocol(peer1, node_id2, '1.2.3.5', 4444, 3333)
+            peer3, peer_3_from_peer_1 = await self._make_protocol(peer1, node_id3, '1.2.3.6', 4444, 3333)
+            peer4, peer_4_from_peer_1 = await self._make_protocol(peer1, node_id4, '1.2.3.7', 4444, 3333)
+
+            # peers who reply should be added
+            await peer1.get_rpc_peer(peer_2_from_peer_1).ping()
+            self.assertListEqual([peer_2_from_peer_1], peer1.routing_table.get_peers())
+            peer1.routing_table.remove_peer(peer_2_from_peer_1)
+
+            # peers not known by be good/bad should be enqueued to maybe-ping
+            peer1_from_peer3 = peer3.get_rpc_peer(peer3.peer_manager.get_kademlia_peer(node_id1, '1.2.3.4', 4444))
+            self.assertEqual(0, len(peer1.ping_queue._pending_contacts))
+            pong = await peer1_from_peer3.ping()
+            self.assertEqual(b'pong', pong)
+            self.assertEqual(1, len(peer1.ping_queue._pending_contacts))
+            peer1.ping_queue._pending_contacts.clear()
+
+            # peers who are already good should be added
+            peer1_from_peer4 = peer4.get_rpc_peer(peer4.peer_manager.get_kademlia_peer(node_id1, '1.2.3.4', 4444))
+            peer1.peer_manager.update_contact_triple(node_id4,'1.2.3.7', 4444)
+            peer1.peer_manager.report_last_replied('1.2.3.7', 4444)
+            self.assertEqual(0, len(peer1.ping_queue._pending_contacts))
+            pong = await peer1_from_peer4.ping()
+            self.assertEqual(b'pong', pong)
+            self.assertEqual(1, len(peer1.routing_table.get_peers()))
+            self.assertEqual(0, len(peer1.ping_queue._pending_contacts))
+            peer1.routing_table.buckets[0].peers.clear()
+
+            # peers who are known to be bad recently should not be added or maybe-pinged
+            peer1_from_peer4 = peer4.get_rpc_peer(peer4.peer_manager.get_kademlia_peer(node_id1, '1.2.3.4', 4444))
+            peer1.peer_manager.update_contact_triple(node_id4,'1.2.3.7', 4444)
+            peer1.peer_manager.report_failure('1.2.3.7', 4444)
+            peer1.peer_manager.report_failure('1.2.3.7', 4444)
+            self.assertEqual(0, len(peer1.ping_queue._pending_contacts))
+            pong = await peer1_from_peer4.ping()
+            self.assertEqual(b'pong', pong)
+            self.assertEqual(0, len(peer1.routing_table.get_peers()))
+            self.assertEqual(0, len(peer1.ping_queue._pending_contacts))
+
+            for p in [peer1, peer2, peer3, peer4]:
+                p.stop()
+                p.disconnect()


### PR DESCRIPTION
-prevent duplicate ids in the same bucket
-prevent the same address/port from appearing under multiple ids in the routing table
-fix updating the contact triple in the peer manager and on the peer object