### PR TITLE
Fixes issue causing packages incompatible with torba getting installed [attrs==18.2.0]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'console_scripts': 'lbrynet=lbrynet.extras.cli:main'
     },
     install_requires=[
+        'torba',
         'aiohttp==3.5.4',
         'aioupnp',
         'appdirs==1.4.3',
@@ -35,7 +36,6 @@ setup(
         'protobuf==3.6.1',
         'msgpack==0.6.1',
         'ecdsa==0.13',
-        'torba',
         'pyyaml==4.2b1',
         'docopt==0.6.2',
         'hachoir',


### PR DESCRIPTION
I've frequently had this problem with multiple packages, but the current one causing issues is the `attrs` module, which gets automatically installed by `aiohttp`. However, `aiohttp` has a loose requirement of `attrs>=17.3.0`, whereas `torba` has a strict requirement of `attrs==18.2.0`. 

This fixes that issue by simply moving `torba` to the top in `setup.py`. 