### PR TITLE
removed `block_show` command from API

### DIFF
--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -310,7 +310,7 @@ class Daemon(metaclass=JSONRPCServerType):
     @classmethod
     def get_api_definitions(cls):
         prefix = 'jsonrpc_'
-        not_grouped = ['block_show', 'report_bug', 'routing_table_get']
+        not_grouped = ['routing_table_get']
         api = {
             'groups': {
                 group_name[:-len('_DOC')].lower(): getattr(cls, group_name).strip()
@@ -2901,23 +2901,6 @@ class Daemon(metaclass=JSONRPCServerType):
             None
         """
         return self.get_account_or_default(account_id).release_all_outputs()
-
-    @requires(WALLET_COMPONENT)
-    def jsonrpc_block_show(self, blockhash=None, height=None):
-        """
-        Get contents of a block
-
-        Usage:
-            block_show (<blockhash> | --blockhash=<blockhash>) | (<height> | --height=<height>)
-
-        Options:
-            --blockhash=<blockhash>  : (str) hash of the block to look up
-            --height=<height>        : (int) height of the block to look up
-
-        Returns:
-            (dict) Requested block
-        """
-        return self.wallet_manager.get_block(blockhash, height)
 
     BLOB_DOC = """
     Blob management.

--- a/lbrynet/wallet/manager.py
+++ b/lbrynet/wallet/manager.py
@@ -308,13 +308,6 @@ class LbryWalletManager(BaseWalletManager):
         for wallet in self.wallets:
             wallet.save()
 
-    def get_block(self, block_hash=None, height=None):
-        if height is None:
-            height = self.ledger.headers.height
-        if block_hash is None:
-            block_hash = self.ledger.headers.hash(height).decode()
-        return self.ledger.network.get_block(block_hash)
-
     def get_claim_by_claim_id(self, claim_id):
         return self.ledger.get_claim_by_claim_id(claim_id)
 

--- a/lbrynet/wallet/network.py
+++ b/lbrynet/wallet/network.py
@@ -3,9 +3,6 @@ from torba.client.basenetwork import BaseNetwork
 
 class Network(BaseNetwork):
 
-    def get_block(self, block_hash):
-        return self.rpc('blockchain.block.get_block', block_hash)
-
     def get_server_height(self):
         return self.rpc('blockchain.block.get_server_height')
 

--- a/lbrynet/wallet/server/session.py
+++ b/lbrynet/wallet/server/session.py
@@ -41,7 +41,6 @@ class LBRYElectrumX(ElectrumX):
             'blockchain.claimtrie.getvaluesforuris': self.claimtrie_getvalueforuris,
             'blockchain.claimtrie.getclaimssignedbyid': self.claimtrie_getclaimssignedbyid,
             'blockchain.block.get_server_height': self.get_server_height,
-            'blockchain.block.get_block': self.get_block,
         }
         # fixme: methods we use but shouldnt be using anymore. To be removed when torba goes out
         handlers.update({
@@ -103,9 +102,6 @@ class LBRYElectrumX(ElectrumX):
         if verbose not in (True, False):
             verbose = False
         return await self.daemon_request('getrawtransaction', tx_hash, verbose)
-
-    async def get_block(self, block_hash):
-        return await self.daemon.deserialised_block(block_hash)
 
     async def get_server_height(self):
         return self.bp.height

--- a/scripts/generate_json_api.py
+++ b/scripts/generate_json_api.py
@@ -82,10 +82,6 @@ class Examples(CommandTestCase):
             'Get settings',
             'settings', 'get'
         )
-        await r(
-            'Show contents of the first block.',
-            'block_show', '--height=1'
-        )
 
         # accounts
 

--- a/tests/integration/test_claim_commands.py
+++ b/tests/integration/test_claim_commands.py
@@ -783,8 +783,7 @@ class StreamCommands(CommandTestCase):
         self.assertNotEqual(r1c, r2c)
 
         await self.generate(50)
-        head = await self.daemon.jsonrpc_block_show()
-        self.assertTrue(head['height'] > 250)
+        self.assertTrue(self.ledger.headers.height > 250)
 
         r3 = await self.daemon.jsonrpc_resolve(urls='lbry://ΣίσυφοςﬁÆ')
         r4 = await self.daemon.jsonrpc_resolve(urls='lbry://ΣΊΣΥΦΟσFIæ')


### PR DESCRIPTION
backwards-incompatible: `block_show` command is no longer available in the API, users should run a full node if they need access to blocks