### PR TITLE
Fixes cli start --api argument to use main --api parameter if missing.

### DIFF
--- a/lbrynet/extras/cli.py
+++ b/lbrynet/extras/cli.py
@@ -14,7 +14,7 @@ from aiohttp.web import GracefulExit
 
 from lbrynet import __name__ as lbrynet_name, __version__ as lbrynet_version
 from lbrynet.extras.daemon.loggly_handler import get_loggly_handler
-from lbrynet.conf import Config, CLIConfig
+from lbrynet.conf import Config, CLIConfig, NOT_SET
 from lbrynet.extras.daemon.Daemon import Daemon
 
 log = logging.getLogger(lbrynet_name)
@@ -235,6 +235,14 @@ def main(argv=None):
         return 0
 
     elif args.command == 'start':
+        ## If the --api argument was not provided to the start command,
+        ## check to see if it was given on the main parser and use that instead:
+        if args.api is NOT_SET:
+            try:
+                if argv.index('--api') < argv.index('start'):
+                    conf.api = args.api = argv[argv.index('--api') + 1]
+            except (ValueError, IndexError):
+                pass
 
         if args.help:
             args.start_parser.print_help()


### PR DESCRIPTION
## PR Checklist
Please check all that apply to this PR using "x":

- [ x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ x ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?

Fixes #2073 

When starting the lbrynet daemon, the `api` parameter can be provided before or after the `start` command.

Why is this change necessary?

<!-- Please check all that apply to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2073 


## What is the current behavior?

`lbrynet --api 127.0.0.1:5279 start` does not set the binding ip for the daemon.

## What is the new behavior?

Both of these commands set the binding ip correctly:

`lbrynet --api 127.0.0.1:5279 start`

`lbrynet start --api 127.0.0.1:5279`

## Other information

I understand the first `--api` paramter (before the start subcommand) is usually used for the client, not for the daemon. But when starting the daemon with the `start` command, it is clear that user meant to provide the daemon binding ip with the `--api` parameter and not the client (which cannot be invoked with start.)

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
