### PR TITLE
`account_list` defaults to 0 confirmations for balance

### DIFF
--- a/lbrynet/extras/daemon/Daemon.py
+++ b/lbrynet/extras/daemon/Daemon.py
@@ -979,7 +979,7 @@ class Daemon(metaclass=JSONRPCServerType):
     """
 
     @requires("wallet")
-    def jsonrpc_account_list(self, account_id=None, confirmations=6,
+    def jsonrpc_account_list(self, account_id=None, confirmations=0,
                              include_claims=False, show_seed=False):
         """
         List details of all of the accounts or a specific account.


### PR DESCRIPTION
fixes #2077 