### PR TITLE
add saved_file and content_fee columns to file table

### DIFF
--- a/lbrynet/extras/daemon/Components.py
+++ b/lbrynet/extras/daemon/Components.py
@@ -63,7 +63,7 @@ class DatabaseComponent(Component):
 
     @staticmethod
     def get_current_db_revision():
-        return 10
+        return 11
 
     @property
     def revision_filename(self):

--- a/lbrynet/extras/daemon/migrator/dbmigrator.py
+++ b/lbrynet/extras/daemon/migrator/dbmigrator.py
@@ -24,6 +24,8 @@ def migrate_db(conf, start, end):
             from .migrate8to9 import do_migration
         elif current == 9:
             from .migrate9to10 import do_migration
+        elif current == 10:
+            from .migrate10to11 import do_migration
         else:
             raise Exception("DB migration of version {} to {} is not available".format(current,
                                                                                        current+1))

--- a/lbrynet/extras/daemon/migrator/migrate10to11.py
+++ b/lbrynet/extras/daemon/migrator/migrate10to11.py
@@ -1,0 +1,46 @@
+import sqlite3
+import os
+import binascii
+
+
+def do_migration(conf):
+    db_path = os.path.join(conf.data_dir, "lbrynet.sqlite")
+    connection = sqlite3.connect(db_path)
+    cursor = connection.cursor()
+
+    cursor.execute(
+        "pragma foreign_keys=off;"
+    )
+
+    cursor.execute("""
+        create table if not exists new_file (
+            stream_hash text primary key not null references stream,
+            file_name text,
+            download_directory text,
+            blob_data_rate real not null,
+            status text not null,
+            saved_file integer not null,
+            content_fee text
+        );
+    """)
+    for (stream_hash, file_name, download_dir, data_rate, status) in cursor.execute("select * from file").fetchall():
+        saved_file = 0
+        if download_dir != '{stream}' and file_name != '{stream}':
+            try:
+                if os.path.isfile(os.path.join(binascii.unhexlify(download_dir).decode(),
+                                  binascii.unhexlify(file_name).decode())):
+                    saved_file = 1
+                else:
+                    download_dir, file_name = None, None
+            except (OSError, ValueError):
+                download_dir, file_name = None, None
+        else:
+            download_dir, file_name = None, None
+        cursor.execute(
+            "insert into new_file values (?, ?, ?, ?, ?, ?, NULL)",
+            (stream_hash, file_name, download_dir, data_rate, status, saved_file)
+        )
+    cursor.execute("drop table file")
+    cursor.execute("alter table new_file rename to file")
+    connection.commit()
+    connection.close()

--- a/lbrynet/extras/daemon/migrator/migrate10to11.py
+++ b/lbrynet/extras/daemon/migrator/migrate10to11.py
@@ -8,6 +8,14 @@ def do_migration(conf):
     connection = sqlite3.connect(db_path)
     cursor = connection.cursor()
 
+    current_columns = []
+    for col_info in cursor.execute("pragma table_info('file');").fetchall():
+        current_columns.append(col_info[1])
+    if 'content_fee' in current_columns or 'saved_file' in current_columns:
+        connection.close()
+        print("already migrated")
+        return
+
     cursor.execute(
         "pragma foreign_keys=off;"
     )
@@ -32,7 +40,7 @@ def do_migration(conf):
                     saved_file = 1
                 else:
                     download_dir, file_name = None, None
-            except (OSError, ValueError):
+            except Exception:
                 download_dir, file_name = None, None
         else:
             download_dir, file_name = None, None

--- a/lbrynet/schema/claim.py
+++ b/lbrynet/schema/claim.py
@@ -215,8 +215,6 @@ class Stream(BaseClaim):
 
         if 'sd_hash' in kwargs:
             self.source.sd_hash = kwargs.pop('sd_hash')
-        if 'file_size' in kwargs:
-            self.source.size = kwargs.pop('file_size')
         if 'file_name' in kwargs:
             self.source.name = kwargs.pop('file_name')
         if 'file_hash' in kwargs:
@@ -229,6 +227,9 @@ class Stream(BaseClaim):
             self.source.media_type, stream_type = guess_media_type(self.source.name)
         elif self.source.media_type:
             stream_type = guess_stream_type(self.source.media_type)
+
+        if 'file_size' in kwargs:
+            self.source.size = kwargs.pop('file_size')
 
         if stream_type in ('image', 'video', 'audio'):
             media = getattr(self, stream_type)

--- a/lbrynet/stream/managed_stream.py
+++ b/lbrynet/stream/managed_stream.py
@@ -351,6 +351,7 @@ class ManagedStream:
             self.finished_writing.set()
             log.info("finished saving file for lbry://%s#%s (sd hash %s...) -> %s", self.claim_name, self.claim_id,
                      self.sd_hash[:6], self.full_path)
+            await self.blob_manager.storage.set_saved_file(self.stream_hash)
         except Exception as err:
             if os.path.isfile(output_path):
                 log.warning("removing incomplete download %s for %s", output_path, self.sd_hash)

--- a/lbrynet/stream/managed_stream.py
+++ b/lbrynet/stream/managed_stream.py
@@ -462,8 +462,18 @@ class ManagedStream:
             get_range = get_range.split('=')[1]
         start, end = get_range.split('-')
         size = 0
+
         for blob in self.descriptor.blobs[:-1]:
             size += blob.length - 1
+        if self.stream_claim_info and self.stream_claim_info.claim.stream.source.size:
+            size_from_claim = int(self.stream_claim_info.claim.stream.source.size)
+            if not size_from_claim <= size <= size_from_claim + 16:
+                raise ValueError("claim contains implausible stream size")
+            log.debug("using stream size from claim")
+            size = size_from_claim
+        elif self.stream_claim_info:
+            log.debug("estimating stream size")
+
         start = int(start)
         end = int(end) if end else size - 1
         skip_blobs = start // 2097150

--- a/tests/integration/test_file_commands.py
+++ b/tests/integration/test_file_commands.py
@@ -239,6 +239,7 @@ class FileCommands(CommandTestCase):
         await self.daemon.jsonrpc_file_delete(claim_name='icanpay')
         await self.assertBalance(self.account, '9.925679')
         response = await self.daemon.jsonrpc_get('lbry://icanpay')
+        raw_content_fee = response.content_fee.raw
         await self.ledger.wait(response.content_fee)
         await self.assertBalance(self.account, '8.925555')
         self.assertEqual(len(self.daemon.jsonrpc_file_list()), 1)
@@ -252,3 +253,10 @@ class FileCommands(CommandTestCase):
         self.assertEqual(
             await self.blockchain.get_balance(), starting_balance + block_reward_and_claim_fee
         )
+
+        # restart the daemon and make sure the fee is still there
+
+        self.daemon.stream_manager.stop()
+        await self.daemon.stream_manager.start()
+        self.assertEqual(len(self.daemon.jsonrpc_file_list()), 1)
+        self.assertEqual(self.daemon.jsonrpc_file_list()[0].content_fee.raw, raw_content_fee)

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -97,7 +97,7 @@ class RangeRequests(CommandTestCase):
     async def test_range_requests_no_padding_size_from_claim(self):
         size = ((MAX_BLOB_SIZE - 1) * 4) - 14
         await self.test_range_requests_0_padded_bytes(size, padding=b'', file_size=size,
-                                                      expected_range=f"bytes 0-{size}/{size+1}")
+                                                      expected_range=f"bytes 0-{size-1}/{size}")
 
     async def test_range_requests_15_padded_bytes(self):
         await self.test_range_requests_0_padded_bytes(

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -24,11 +24,11 @@ class RangeRequests(CommandTestCase):
         await self.daemon.stream_manager.start()
         return
 
-    async def _setup_stream(self, data: bytes, save_blobs: bool = True, save_files: bool = False):
+    async def _setup_stream(self, data: bytes, save_blobs: bool = True, save_files: bool = False, file_size=0):
         self.daemon.conf.save_blobs = save_blobs
         self.daemon.conf.save_files = save_files
         self.data = data
-        await self.stream_create('foo', '0.01', data=self.data)
+        await self.stream_create('foo', '0.01', data=self.data, file_size=file_size)
         if save_blobs:
             self.assertTrue(len(os.listdir(self.daemon.blob_manager.blob_dir)) > 1)
         await self.daemon.jsonrpc_file_list()[0].fully_reflected.wait()
@@ -70,9 +70,10 @@ class RangeRequests(CommandTestCase):
         self.assertEqual('bytes 0-14/15', content_range)
 
     async def test_range_requests_0_padded_bytes(self, size: int = (MAX_BLOB_SIZE - 1) * 4,
-                                                 expected_range: str = 'bytes 0-8388603/8388604', padding=b''):
+                                                 expected_range: str = 'bytes 0-8388603/8388604', padding=b'',
+                                                 file_size=0):
         self.data = get_random_bytes(size)
-        await self._setup_stream(self.data)
+        await self._setup_stream(self.data, file_size=file_size)
         streamed, content_range, content_length = await self._test_range_requests()
         self.assertEqual(len(self.data + padding), content_length)
         self.assertEqual(streamed, self.data + padding)
@@ -92,6 +93,11 @@ class RangeRequests(CommandTestCase):
         await self.test_range_requests_0_padded_bytes(
             ((MAX_BLOB_SIZE - 1) * 4) - 14, padding=b'\x00' * 14
         )
+
+    async def test_range_requests_no_padding_size_from_claim(self):
+        size = ((MAX_BLOB_SIZE - 1) * 4) - 14
+        await self.test_range_requests_0_padded_bytes(size, padding=b'', file_size=size,
+                                                      expected_range=f"bytes 0-{size}/{size+1}")
 
     async def test_range_requests_15_padded_bytes(self):
         await self.test_range_requests_0_padded_bytes(


### PR DESCRIPTION
Database changes:
- add `saved_file` and `content_fee` columns to `file` table
- drop not null constraints for `file_name` and `download_directory` in the `file` table

Fixes:
-  ``` BLOCKER - see a download path / written bytes even though I deleted the file. This used to update right away. This is important for the app since it would try to stream from the file which doesn't exist```

-  ```BLOCKER? incomplete files continue to retry (this is different from old behavior and probably should be handled in the connection manager). Had trouble shutting down the sdk. On restart, it would try to start/stop the file. Not sure if it actually tried to complete it, but it didn't look like it. Need to make sure that the file will retry on restart at least (old behavior)```