### PR TITLE
paginated deterministically shuffled find_value

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,7 @@ persistent=yes
 load-plugins=
 
 # Use multiple processes to speed up Pylint.
-jobs=1
+jobs=4
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
@@ -77,8 +77,6 @@ disable=
   dangerous-default-value,
   duplicate-code,
   fixme,
-  global-statement,
-  inherit-non-class,
   invalid-name,
   len-as-condition,
   locally-disabled,
@@ -111,13 +109,11 @@ disable=
   unnecessary-lambda,
   unused-argument,
   unused-variable,
-  wildcard-import,
   wrong-import-order,
   wrong-import-position,
   deprecated-lambda,
   simplifiable-if-statement,
   unidiomatic-typecheck,
-  global-at-module-level,
   inconsistent-return-statements,
   keyword-arg-before-vararg,
   assignment-from-no-return,

--- a/lbrynet/dht/constants.py
+++ b/lbrynet/dht/constants.py
@@ -18,11 +18,10 @@ data_expiration = 86400  # 24 hours
 token_secret_refresh_interval = 300  # 5 minutes
 maybe_ping_delay = 300  # 5 minutes
 check_refresh_interval = refresh_interval / 5
-max_datagram_size = 8192  # 8 KB
 rpc_id_length = 20
 protocol_version = 1
 bottom_out_limit = 3
-msg_size_limit = max_datagram_size - 26
+msg_size_limit = 1400
 
 
 def digest(data: bytes) -> bytes:

--- a/lbrynet/dht/serialization/bencoding.py
+++ b/lbrynet/dht/serialization/bencoding.py
@@ -63,7 +63,7 @@ def bencode(data: typing.Dict) -> bytes:
 
 
 def bdecode(data: bytes, allow_non_dict_return: typing.Optional[bool] = False) -> typing.Dict:
-    assert type(data) == bytes, DecodeError(f"invalid data type: {str(type(data))}")
+    assert isinstance(data, bytes), DecodeError(f"invalid data type: {str(type(data))}")
 
     if len(data) == 0:
         raise DecodeError('Cannot decode empty string')

--- a/lbrynet/dht/serialization/datagram.py
+++ b/lbrynet/dht/serialization/datagram.py
@@ -7,6 +7,9 @@ REQUEST_TYPE = 0
 RESPONSE_TYPE = 1
 ERROR_TYPE = 2
 
+# bencode representation of argument keys
+PAGE_KEY = b'p'
+
 
 class KademliaDatagramBase:
     """
@@ -91,11 +94,13 @@ class RequestDatagram(KademliaDatagramBase):
 
     @classmethod
     def make_find_value(cls, from_node_id: bytes, key: bytes,
-                        rpc_id: typing.Optional[bytes] = None) -> 'RequestDatagram':
+                        rpc_id: typing.Optional[bytes] = None, page: int = 0) -> 'RequestDatagram':
         rpc_id = rpc_id or constants.generate_id()[:constants.rpc_id_length]
         if len(key) != constants.hash_bits // 8:
             raise ValueError(f"invalid key length: {len(key)}")
-        return cls(REQUEST_TYPE, rpc_id, from_node_id, b'findValue', [key])
+        if page < 0:
+            raise ValueError(f"cannot request a negative page ({page})")
+        return cls(REQUEST_TYPE, rpc_id, from_node_id, b'findValue', [key, {PAGE_KEY: page}])
 
 
 class ResponseDatagram(KademliaDatagramBase):

--- a/tests/unit/dht/protocol/test_protocol.py
+++ b/tests/unit/dht/protocol/test_protocol.py
@@ -83,11 +83,14 @@ class TestProtocol(AsyncioTestCase):
             find_value_response = peer1.node_rpc.find_value(peer3, b'2' * 48)
             self.assertEqual(len(find_value_response[b'contacts']), 0)
             self.assertSetEqual(
-                {b'2' * 48, b'token', b'protocolVersion', b'contacts'}, set(find_value_response.keys())
+                {b'2' * 48, b'token', b'protocolVersion', b'contacts', b'p'}, set(find_value_response.keys())
             )
             self.assertEqual(2, len(find_value_response[b'2' * 48]))
             self.assertEqual(find_value_response[b'2' * 48][0], peer2_from_peer1.compact_address_tcp())
             self.assertDictEqual(bdecode(bencode(find_value_response)), find_value_response)
+
+            find_value_page_above_pages_response = peer1.node_rpc.find_value(peer3, b'2' * 48, page=10)
+            self.assertNotIn(b'2' * 48, find_value_page_above_pages_response)
 
             peer1.stop()
             peer2.stop()


### PR DESCRIPTION
- fixes #2244
- reduce the max DHT datagram size to 1400 bytes
- truncate `contacts` field of find_value response datagrams to the k closest (8)
- truncate peers in find_node response datagrams to the 2k closest (16)
- remove `contacts` field from find_value responses beyond `page` 0 (the first/default)
- deterministically shuffle the peers for a blob in a find_value response
- add optional `page` argument to `find_value` and `p` field to find_value responses containing the number of pages of k peers for the blob
- test one blob being announced by 150 different peers to one peer
- speed up pylint and remove some disabled checks